### PR TITLE
codecs.JSON now delegates to safejson instead of reimplementing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,12 +24,13 @@
   version = "v0.1.3"
 
 [[projects]]
-  digest = "1:d8167ec52758fcda939c23e932b87d769975362f7f0cf4114309da54c8ac79ff"
+  digest = "1:b2063e94ed2d41c96dae2c01d68236cf0d96a0f5809631d834b0f6146b4161a4"
   name = "github.com/palantir/pkg"
   packages = [
     "bytesbuffers",
     "metrics",
     "retry",
+    "safejson",
     "tlsconfig",
     "uuid",
     "uuid/internal/uuid",
@@ -155,6 +156,7 @@
     "github.com/palantir/pkg/bytesbuffers",
     "github.com/palantir/pkg/metrics",
     "github.com/palantir/pkg/retry",
+    "github.com/palantir/pkg/safejson",
     "github.com/palantir/pkg/tlsconfig",
     "github.com/palantir/pkg/uuid",
     "github.com/palantir/witchcraft-go-error",

--- a/vendor/github.com/palantir/pkg/safejson/decoder.go
+++ b/vendor/github.com/palantir/pkg/safejson/decoder.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safejson
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// Decoder returns a new *json.Decoder with UseNumber enabled.
+func Decoder(r io.Reader) *json.Decoder {
+	decoder := json.NewDecoder(r)
+	decoder.UseNumber()
+	return decoder
+}

--- a/vendor/github.com/palantir/pkg/safejson/doc.go
+++ b/vendor/github.com/palantir/pkg/safejson/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package safejson provides functions that allows JSON to be marshaled
+// and unmarshaled in a safe and consistent manner. This package exists
+// to standardize and normalize some of the default behavior of the json
+// package that is unintuitive.
+//
+// Marshal:
+//
+// The default encoder returned by json.NewEncoder has "SetEscapeHTML" set
+// to "true", which makes sense for HTML environments, but results in output
+// that is hard to read in non-HTML environments. The default behavior of
+// json.Marshal also appends a newline to the end of the generated JSON which,
+// although this is technically legal from a JSON perspective, is often unexpected.
+//
+// Unmarshal:
+//
+// The default decoder returned by json.NewDecoder does not have the "UseNumber"
+// behavior enabled. This means that all numeric values are unmarshaled as a float64.
+// This behavior is generally less flexible, so safejson sets "UseNumber" to "true",
+// which ensures that all numbers are unmarshaled as a json.Number.
+package safejson

--- a/vendor/github.com/palantir/pkg/safejson/encoder16.go
+++ b/vendor/github.com/palantir/pkg/safejson/encoder16.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package safejson
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+func Encoder(w io.Writer) *json.Encoder {
+	return json.NewEncoder(unescapedHTMLWriter{w})
+}
+
+type unescapedHTMLWriter struct {
+	w io.Writer
+}
+
+// Write unescapes the HTML contents of p and writes it to the underlying writer.
+func (u unescapedHTMLWriter) Write(p []byte) (n int, err error) {
+	return u.w.Write(htmlUnescape(p))
+}
+
+// htmlUnescape returns a copy of the slice s with unescaped special HTML
+// characters like <, >, and &.
+//
+// Warning: this allocates 3 additional copies of the slice s.
+func htmlUnescape(s []byte) []byte {
+	s = bytes.Replace(s, []byte("\\u003c"), []byte("<"), -1)
+	s = bytes.Replace(s, []byte("\\u003e"), []byte(">"), -1)
+	return bytes.Replace(s, []byte("\\u0026"), []byte("&"), -1)
+}

--- a/vendor/github.com/palantir/pkg/safejson/encoder17.go
+++ b/vendor/github.com/palantir/pkg/safejson/encoder17.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package safejson
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// Encoder returns a new *json.Encoder with SetEscapeHTML(false).
+func Encoder(w io.Writer) *json.Encoder {
+	e := json.NewEncoder(w)
+	e.SetEscapeHTML(false)
+	return e
+}

--- a/vendor/github.com/palantir/pkg/safejson/gocd_imports.json
+++ b/vendor/github.com/palantir/pkg/safejson/gocd_imports.json
@@ -1,0 +1,30 @@
+{
+    "imports": [],
+    "mainOnlyImports": [],
+    "testOnlyImports": [
+        {
+            "path": "github.com/palantir/pkg/vendor/github.com/stretchr/testify/assert",
+            "numGoFiles": 10,
+            "numImportedGoFiles": 19,
+            "importedFrom": [
+                "github.com/palantir/pkg/safejson_test"
+            ]
+        },
+        {
+            "path": "github.com/palantir/pkg/vendor/github.com/stretchr/testify/require",
+            "numGoFiles": 7,
+            "numImportedGoFiles": 29,
+            "importedFrom": [
+                "github.com/palantir/pkg/safejson_test"
+            ]
+        },
+        {
+            "path": "github.com/palantir/pkg/vendor/gopkg.in/yaml.v2",
+            "numGoFiles": 16,
+            "numImportedGoFiles": 0,
+            "importedFrom": [
+                "github.com/palantir/pkg/safejson_test"
+            ]
+        }
+    ]
+}

--- a/vendor/github.com/palantir/pkg/safejson/marshal.go
+++ b/vendor/github.com/palantir/pkg/safejson/marshal.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safejson
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Marshal returns the JSON encoding of v encoded using the "safe" encoder.
+// Unlike json.Marshal, the returned JSON bytes will not have a trailing newline.
+func Marshal(v interface{}) ([]byte, error) {
+	// go through Encoder to control SetEscapeHTML
+	var buf bytes.Buffer
+	if err := Encoder(&buf).Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
+}
+
+// MarshalIndent is like Marshal but applies Indent to format the output.
+func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	b, err := Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = json.Indent(&buf, b, prefix, indent)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/vendor/github.com/palantir/pkg/safejson/unmarshal.go
+++ b/vendor/github.com/palantir/pkg/safejson/unmarshal.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safejson
+
+import (
+	"bytes"
+)
+
+// Unmarshal unmarshals the provided bytes (which should be valid JSON)
+// into "v" using safejson.Decoder.
+func Unmarshal(data []byte, v interface{}) error {
+	return Decoder(bytes.NewReader(data)).Decode(v)
+}

--- a/vendor/github.com/palantir/pkg/safejson/yaml.go
+++ b/vendor/github.com/palantir/pkg/safejson/yaml.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safejson
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// FromYAMLValue returns a version of the provided input where all nested map[interface{}]interface{} values are
+// converted to map[string]interface{}. The input should be the representation of an object in
+// map[interface{}]interface{} form (as opposed to a string or []byte of the YAML itself). Returns an error if the
+// conversion fails because any of the object keys are not strings.
+//
+// Assumes that the input consists of only maps, slices, arrays, primitives and pointers to these types. Structs are
+// assumed to have been converted into a map representation -- if a struct value is encountered, it will be treated as a
+// primitive and left as-is (in particular, any maps in the struct will not be converted).
+//
+// Many YAML libraries unmarshal YAML content as map[interface{}]interface{}, but the Go JSON library requires JSON maps
+// to be represented as map[string]interface{}, so this function is helpful in converting the former to the latter.
+func FromYAMLValue(y interface{}) (interface{}, error) {
+	return fromYAMLValue(reflect.ValueOf(y), "")
+}
+
+func fromYAMLValue(v reflect.Value, path string) (interface{}, error) {
+	switch v.Kind() {
+	case reflect.Map:
+		return fromYAMLMap(v, path)
+	case reflect.Slice, reflect.Array:
+		return fromYAMLArray(v, path)
+	case reflect.Interface, reflect.Ptr:
+		return fromYAMLValue(v.Elem(), path)
+	case reflect.Invalid:
+		return nil, nil
+	default:
+		return v.Interface(), nil
+	}
+}
+
+func fromYAMLMap(v reflect.Value, path string) (interface{}, error) {
+	m := make(map[string]interface{}, v.Len())
+	for _, entry := range v.MapKeys() {
+		k, err := fromYAMLKey(entry, path)
+		if err != nil {
+			return nil, err
+		}
+		v, err := fromYAMLValue(v.MapIndex(entry), fmt.Sprintf("%s.%s", path, k))
+		if err != nil {
+			return nil, err
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+func fromYAMLArray(v reflect.Value, path string) (interface{}, error) {
+	a := make([]interface{}, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		v, err := fromYAMLValue(v.Index(i), fmt.Sprintf("%s[%d]", path, i))
+		if err != nil {
+			return nil, err
+		}
+		a[i] = v
+	}
+	return a, nil
+}
+
+func fromYAMLKey(k reflect.Value, path string) (string, error) {
+	switch k.Kind() {
+	case reflect.String:
+		return k.String(), nil
+	case reflect.Interface, reflect.Ptr:
+		return fromYAMLKey(k.Elem(), path)
+	default:
+		return "", expectedString(k, path)
+	}
+}
+
+func expectedString(k reflect.Value, path string) error {
+	var valStr string
+	if k.IsValid() {
+		valStr = fmt.Sprintf("%v: %v", k.Type(), k.Interface())
+	} else {
+		valStr = "null"
+	}
+	if path == "" {
+		return fmt.Errorf("Expected map key to be a string but was %s", valStr)
+	}
+	path = strings.TrimPrefix(path, ".") // no leading dot
+	return fmt.Errorf("Expected map key inside %s to be a string but was %s", path, valStr)
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/6)
<!-- Reviewable:end -->
