### PR TITLE
Lower default connect timeout.

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -109,7 +109,7 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 	return &httpClientBuilder{
 		TLSClientConfig:     defaultTLSConfig,
 		Timeout:             1 * time.Minute,
-		DialTimeout:         30 * time.Second,
+		DialTimeout:         5 * time.Second,
 		KeepAlive:           30 * time.Second,
 		MaxIdleConns:        32,
 		MaxIdleConnsPerHost: 32,

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -109,7 +109,7 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 	return &httpClientBuilder{
 		TLSClientConfig:     defaultTLSConfig,
 		Timeout:             1 * time.Minute,
-		DialTimeout:         5 * time.Second,
+		DialTimeout:         10 * time.Second,
 		KeepAlive:           30 * time.Second,
 		MaxIdleConns:        32,
 		MaxIdleConnsPerHost: 32,


### PR DESCRIPTION
5s is the default for conjure-java-runtime, I can't think of a good reason why it should be 30s.

cc @mahmoudm @ryanmcnamara

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/13)
<!-- Reviewable:end -->
