### PR TITLE
fix httpclient round robin behavior

### DIFF
--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -128,7 +128,7 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
 	_, performBackoff := failedURIs[lastURI]
 	failedURIs[lastURI] = struct{}{}
-	nextURIOffset = (offset+1)%len(uris)
+	nextURIOffset = (offset + 1) % len(uris)
 	nextURI = uris[nextURIOffset]
 	// If the URI has failed before, perform a backoff
 	if performBackoff {

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -160,7 +160,7 @@ func TestSleep(t *testing.T) {
 func TestRoundRobin(t *testing.T) {
 	requestsPerSever := make([]int, 3)
 	getHandler := func(i int) http.Handler {
-		return http.HandlerFunc(func(rw http.ResponseWriter, r * http.Request) {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			requestsPerSever[i]++
 			rw.WriteHeader(http.StatusServiceUnavailable)
 		})
@@ -170,7 +170,7 @@ func TestRoundRobin(t *testing.T) {
 	s2 := httptest.NewServer(getHandler(2))
 	cli, err := NewClient(WithBaseURLs([]string{s0.URL, s1.URL, s2.URL}))
 	require.NoError(t, err)
-	_, err  = cli.Do(context.Background(), WithRequestMethod("GET"))
+	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
 	assert.Error(t, err)
-	assert.Equal(t, []int{2,2,2}, requestsPerSever)
+	assert.Equal(t, []int{2, 2, 2}, requestsPerSever)
 }

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -156,3 +156,21 @@ func TestSleep(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, n)
 }
+
+func TestRoundRobin(t *testing.T) {
+	requestsPerSever := make([]int, 3)
+	getHandler := func(i int) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r * http.Request) {
+			requestsPerSever[i]++
+			rw.WriteHeader(http.StatusServiceUnavailable)
+		})
+	}
+	s0 := httptest.NewServer(getHandler(0))
+	s1 := httptest.NewServer(getHandler(1))
+	s2 := httptest.NewServer(getHandler(2))
+	cli, err := NewClient(WithBaseURLs([]string{s0.URL, s1.URL, s2.URL}))
+	require.NoError(t, err)
+	_, err  = cli.Do(context.Background(), WithRequestMethod("GET"))
+	assert.Error(t, err)
+	assert.Equal(t, []int{2,2,2}, requestsPerSever)
+}


### PR DESCRIPTION
previously the offset was never incremented, so if three URLs were provided that were all failing, rather than starting with a random URL then proceeding through each of them in a round robin fashion, it would try the first one once, then try the next URI five times because retrieving the "next" URI continue to use the original offset, making the request per server [1,5,0]. Now the offset is properly updated when the nextURI is updated as well and test that in this scenario each server is tried an equal number of times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/16)
<!-- Reviewable:end -->
