### PR TITLE
Fix: Drain body after invoking error decoder.

### DIFF
--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -172,6 +172,8 @@ func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...Reque
 	if err != nil {
 		return nil, werror.Wrap(err, "failed to build new HTTP request")
 	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	req = req.WithContext(ctx)
 	req.Header = b.headers
 	if q := b.query.Encode(); q != "" {
@@ -257,5 +259,3 @@ func (c *clientImpl) initializeRequestHeaders(ctx context.Context) http.Header {
 	}
 	return headers
 }
-
-func (c *clientImpl) setDrainMiddleware()

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -185,16 +185,7 @@ func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...Reque
 	clientCopy := c.client
 	transport := clientCopy.Transport // start with the concrete http.Transport from the client
 
-	var drain func()
-
 	middlewares := []Middleware{
-		MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-			resp, err := next.RoundTrip(req)
-			drain = func() {
-				internal.DrainBody(resp)
-			}
-			return resp, err
-		}),
 		// must precede the error decoders because they return a nil response and the metrics need the status code of
 		// the raw response.
 		c.metricsMiddleware,
@@ -217,8 +208,8 @@ func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...Reque
 
 	// unless this is exactly the scenario where the caller has opted into being responsible for draining and closing
 	// the response body, be sure to do so here.
-	if !b.bodyMiddleware.rawOutput {
-		drain()
+	if !(respErr == nil && b.bodyMiddleware.rawOutput) {
+		internal.DrainBody(resp)
 	}
 
 	return resp, unwrapURLError(respErr)

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -55,12 +55,37 @@ func TestClose(t *testing.T) {
 	assert.NotContains(t, s, "net/http.setRequestCancel")
 }
 
-func TestCloseOnError(t *testing.T) {
+func TestCloseOnErrorWithNonEmptyBody(t *testing.T) {
 
 	// create test server and client with an HTTP Timeout of 5s
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusBadRequest)
 		_, _ = fmt.Fprintln(rw, "test")
+	}))
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithHTTPTimeout(5*time.Second),
+	)
+	require.NoError(t, err)
+
+	// execute a simple request
+	ctx := context.Background()
+	_, err = client.Get(ctx, httpclient.WithPath("/"))
+	require.Error(t, err)
+
+	// check for bad goroutine before timeout is over
+	time.Sleep(100 * time.Millisecond) // leave some time for the goroutine to reasonably exit
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, pprof.Lookup("goroutine").WriteTo(buf, 1))
+	s := buf.String()
+	assert.NotContains(t, s, "net/http.(*persistConn).readLoop")
+}
+
+func TestCloseOnErrorWithEmptyBody(t *testing.T) {
+
+	// create test server and client with an HTTP Timeout of 5s
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusBadRequest)
 	}))
 	client, err := httpclient.NewClient(
 		httpclient.WithBaseURLs([]string{ts.URL}),

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -18,8 +18,6 @@ import (
 	"net/http"
 
 	"github.com/palantir/witchcraft-go-error"
-
-	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/internal"
 )
 
 // ErrorDecoder implementations declare whether or not they should be used to handle certain http responses, and return
@@ -43,7 +41,6 @@ func errorDecoderMiddleware(errorDecoder ErrorDecoder) Middleware {
 			return nil, err
 		}
 		if errorDecoder.Handles(resp) {
-			defer internal.DrainBody(resp)
 			return nil, errorDecoder.DecodeError(resp)
 		}
 		return resp, nil

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/palantir/witchcraft-go-error"
+
+	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/internal"
 )
 
 // ErrorDecoder implementations declare whether or not they should be used to handle certain http responses, and return
@@ -41,6 +43,7 @@ func errorDecoderMiddleware(errorDecoder ErrorDecoder) Middleware {
 			return nil, err
 		}
 		if errorDecoder.Handles(resp) {
+			defer internal.DrainBody(resp)
 			return nil, errorDecoder.DecodeError(resp)
 		}
 		return resp, nil


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We leaked goroutines when the client received a response that error decoders were invoked to handle.
## After this PR
We make sure to drain the body in error decoders to avoid these goroutine leaks, so there is now less memory/goroutine usage when a client is routinely hitting an unhealthy service (i.e. the service is consistently returning 4XX or 5XX's).

## Possible downsides?
The same goroutine leak issue could be hit if the following is true:
1. the client being used has no error decoder set, and neither does each request
2. the request does not specify the WithRawResponseBody request parameter.

@jdhenke I'd like your opinion on this change as it deals with changes you made recently to response body draining and I don't want to miss out on relevant context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/51)
<!-- Reviewable:end -->
