### PR TITLE
[fix] Fix goroutine leak when using error decoder

### DIFF
--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"runtime/pprof"
 	"testing"
 	"time"
@@ -53,4 +55,97 @@ func TestClose(t *testing.T) {
 	require.NoError(t, pprof.Lookup("goroutine").WriteTo(buf, 1))
 	s := buf.String()
 	assert.NotContains(t, s, "net/http.setRequestCancel")
+}
+
+func TestCloseOnError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(400)
+		_, _ = fmt.Fprintln(rw, "test")
+	}))
+	defer ts.Close()
+	before := runtime.NumGoroutine()
+	// create test server and client with an HTTP Timeout of 5s
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithHTTPTimeout(5*time.Second),
+	)
+	require.NoError(t, err)
+
+	// execute a simple request
+	ctx := context.Background()
+	_, err = client.Get(
+		ctx,
+		httpclient.WithPath("/"),
+		httpclient.WithHeader("Connection", "close "),
+	)
+	require.Error(t, err)
+
+	// check for bad goroutine before timeout is over
+	time.Sleep(100 * time.Millisecond) // leave some time for the goroutine to reasonably exit
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, pprof.Lookup("goroutine").WriteTo(buf, 1))
+	s := buf.String()
+	after := runtime.NumGoroutine()
+	assert.Equal(t, before, after, s)
+}
+
+func TestCloseOnEmptyResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(400)
+	}))
+	defer ts.Close()
+	before := runtime.NumGoroutine()
+	// create test server and client with an HTTP Timeout of 5s
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithHTTPTimeout(5*time.Second),
+	)
+	require.NoError(t, err)
+
+	// execute a simple request
+	ctx := context.Background()
+	_, err = client.Get(
+		ctx,
+		httpclient.WithPath("/"),
+		httpclient.WithHeader("Connection", "close "),
+	)
+	require.Error(t, err)
+
+	// check for bad goroutine before timeout is over
+	time.Sleep(1000 * time.Millisecond) // leave some time for the goroutine to reasonably exit
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, pprof.Lookup("goroutine").WriteTo(buf, 1))
+	s := buf.String()
+	after := runtime.NumGoroutine()
+	assert.Equal(t, before, after, s)
+}
+
+func TestStreamingResponse(t *testing.T) {
+	const (
+		firstLine  = "alpha"
+		secondLine = "bravo"
+	)
+	finishResponseChan := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		f, ok := rw.(http.Flusher)
+		require.True(t, ok)
+		_, err := fmt.Fprintln(rw, firstLine)
+		f.Flush()
+		require.NoError(t, err)
+		<-finishResponseChan
+		_, err = fmt.Fprintln(rw, secondLine)
+		f.Flush()
+	}))
+	defer ts.Close()
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{ts.URL}),
+	)
+	require.NoError(t, err)
+	ctx := context.Background()
+	resp, err := client.Get(ctx, httpclient.WithPath("/"), httpclient.WithRawResponseBody())
+	require.NoError(t, err)
+	close(finishResponseChan)
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, firstLine+"\n"+secondLine+"\n", string(b))
 }

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -134,6 +134,7 @@ func TestStreamingResponse(t *testing.T) {
 		require.NoError(t, err)
 		<-finishResponseChan
 		_, err = fmt.Fprintln(rw, secondLine)
+		require.NoError(t, err)
 		f.Flush()
 	}))
 	defer ts.Close()

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/palantir/witchcraft-go-error"
+
+	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/internal"
 )
 
 // ErrorDecoder implementations declare whether or not they should be used to handle certain http responses, and return
@@ -41,6 +43,7 @@ func errorDecoderMiddleware(errorDecoder ErrorDecoder) Middleware {
 			return nil, err
 		}
 		if errorDecoder.Handles(resp) {
+			defer internal.DrainBody(resp)
 			return nil, errorDecoder.DecodeError(resp)
 		}
 		return resp, nil


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
A goroutine is leaked any time an error decoder is used that doesn't close the response body.

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==
The response body is always closed if an error decoder should handle a response.

## Possible downsides?
Unlikely, but if an error decoder expects to be able to use the response body in a separate goroutine after it returns, this would break that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/52)
<!-- Reviewable:end -->
