### PR TITLE
[fix] Apply metrics middleware to HTTPClient

### DIFF
--- a/changelog/@unreleased/pr-56.v2.yml
+++ b/changelog/@unreleased/pr-56.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Apply metrics middleware (if configured) to HTTPClient
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/56

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -145,6 +145,9 @@ func NewHTTPClient(params ...HTTPClientParam) (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	if b.metricsMiddleware != nil {
+		client.Transport = wrapTransport(client.Transport, b.metricsMiddleware)
+	}
 	for _, handler := range roundTrippers {
 		client.Transport = wrapTransport(client.Transport, handler)
 	}

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -179,14 +179,14 @@ func TestRoundTripperWithMetrics(t *testing.T) {
 }
 
 func TestMetricsMiddleware_HTTPClient(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
 	rootRegistry := metrics.NewRootMetricsRegistry()
 	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
 
 	client, err := httpclient.NewHTTPClient(httpclient.WithServiceName("test-service"), httpclient.WithMetrics())
 	require.NoError(t, err)
-
-	srv := httptest.NewServer(http.NotFoundHandler())
-	defer srv.Close()
 
 	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
`metricsMiddleware` field of `clientBuilder` is ignored by `NewHTTPClient`

## After this PR
==COMMIT_MSG==
Apply metrics middleware (if configured) to HTTPClient
==COMMIT_MSG==

Fixes #55

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/56)
<!-- Reviewable:end -->
