### PR TITLE
Update changelog type to break

### DIFF
--- a/changelog/@unreleased/pr-72.v2.yml
+++ b/changelog/@unreleased/pr-72.v2.yml
@@ -1,5 +1,5 @@
-type: feature
-feature:
+type: break
+break:
   description: Add module definition
   links:
   - https://github.com/palantir/conjure-go-runtime/pull/72


### PR DESCRIPTION
Will make next autorelease bump minor version since 1.0 release
has not yet happened.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/73)
<!-- Reviewable:end -->
