### PR TITLE
fix: correctly handle exceptions >400

### DIFF
--- a/changelog/@unreleased/pr-79.v2.yml
+++ b/changelog/@unreleased/pr-79.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: "Fixes #78 \nExtracts status code from the returned error and acts
+    on that. This limits more complex behavior, such as respecting the retry-after
+    header."
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/79

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -131,7 +131,7 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 // Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately.
 func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
 	_, performBackoff := failedURIs[lastURI]
-	nextURIOffset, nextURI = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
+	nextURI, nextURIOffset  = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
 	// If the URI has failed before, perform a backoff
 	if performBackoff {
 		retrier.Next()
@@ -141,17 +141,17 @@ func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[
 
 // Marks the current URI as failed, gets the next URI, and performs a backoff as determined by the retrier.
 func nextURIAndBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
-	nextURIOffset, nextURI = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
+	nextURI, nextURIOffset  = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
 	retrier.Next()
 	return nextURI, nextURIOffset
 
 }
 
-func markFailedAndGetNextURI(failedURIs map[string]struct{}, lastURI string, offset int, uris []string) (int, string) {
+func markFailedAndGetNextURI(failedURIs map[string]struct{}, lastURI string, offset int, uris []string) (string, int) {
 	failedURIs[lastURI] = struct{}{}
 	nextURIOffset := (offset + 1) % len(uris)
 	nextURI := uris[nextURIOffset]
-	return nextURIOffset, nextURI
+	return nextURI, nextURIOffset
 }
 
 func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...RequestParam) (*http.Response, error) {

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -97,14 +97,16 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 	failedURIs := map[string]struct{}{}
 	for i := 0; i < c.maxRetries; i++ {
 		resp, err = c.doOnce(ctx, nextURI, params...)
-		if resp == nil {
-			// If we get a nil response, we can assume there is a problem with host and can move on to the next.
-			nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
-		} else if shouldThrottle, _ := internal.IsThrottleResponse(resp); shouldThrottle {
+		errCode, ok := StatusCodeFromError(err)
+		if ok && errCode == 429 {
 			// 429: throttle
-			// Ideally we should avoid hitting this URI until it's next available. In the interest of avoiding
-			// complex state in the client that will be replaced with a service-mesh, we will simply move on to the next
-			// available URI
+			// Immediately backoff and select the next URI.
+			nextURI, offset = nextURIAndBackoff(nextURI, uris, offset, failedURIs, retrier)
+		} else if ok && errCode == 503 {
+			// 503: go to next node
+			nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
+		} else if resp == nil {
+			// If we get a nil response, we can assume there is a problem with host and can move on to the next.
 			nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
 		} else if shouldTryOther, otherURI := internal.IsRetryOtherResponse(resp); shouldTryOther {
 			// 308: go to next node, or particular node if provided.
@@ -114,9 +116,6 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 			} else {
 				nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
 			}
-		} else if internal.IsUnavailableResponse(resp) {
-			// 503: go to next node
-			nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
 		} else {
 			// The response was not a failure in any way, return the error
 			return resp, err
@@ -128,18 +127,31 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 	return resp, werror.Error("could not find live server")
 }
 
-// If lastURI was already marked failed, we perform a backoff as determined by the retrier.
-// Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately
+// If lastURI was already marked failed, we perform a backoff as determined by the retrier before returning the next URI and its offset.
+// Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately.
 func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
 	_, performBackoff := failedURIs[lastURI]
-	failedURIs[lastURI] = struct{}{}
-	nextURIOffset = (offset + 1) % len(uris)
-	nextURI = uris[nextURIOffset]
+	nextURIOffset, nextURI = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
 	// If the URI has failed before, perform a backoff
 	if performBackoff {
 		retrier.Next()
 	}
 	return nextURI, nextURIOffset
+}
+
+// Marks the current URI as failed, gets the next URI, and performs a backoff as determined by the retrier.
+func nextURIAndBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
+	nextURIOffset, nextURI = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
+	retrier.Next()
+	return nextURI, nextURIOffset
+
+}
+
+func markFailedAndGetNextURI(failedURIs map[string]struct{}, lastURI string, offset int, uris []string) (int, string) {
+	failedURIs[lastURI] = struct{}{}
+	nextURIOffset := (offset + 1) % len(uris)
+	nextURI := uris[nextURIOffset]
+	return nextURIOffset, nextURI
 }
 
 func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...RequestParam) (*http.Response, error) {

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -131,7 +131,7 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 // Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately.
 func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
 	_, performBackoff := failedURIs[lastURI]
-	nextURI, nextURIOffset  = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
+	nextURI, nextURIOffset = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
 	// If the URI has failed before, perform a backoff
 	if performBackoff {
 		retrier.Next()
@@ -141,7 +141,7 @@ func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[
 
 // Marks the current URI as failed, gets the next URI, and performs a backoff as determined by the retrier.
 func nextURIAndBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
-	nextURI, nextURIOffset  = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
+	nextURI, nextURIOffset = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
 	retrier.Next()
 	return nextURI, nextURIOffset
 

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -100,6 +100,7 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 		if retryOther, _ := internal.IsThrottleResponse(resp, err); retryOther {
 			// 429: throttle
 			// Immediately backoff and select the next URI.
+			// TODO(whickman): use the retry-after header once #81 is resolved
 			nextURI, offset = nextURIAndBackoff(nextURI, uris, offset, failedURIs, retrier)
 		} else if internal.IsUnavailableResponse(resp, err) {
 			// 503: go to next node

--- a/conjure-go-client/httpclient/error_decoder_test.go
+++ b/conjure-go-client/httpclient/error_decoder_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ func TestErrorDecoder(t *testing.T) {
 		resp, err := client.Get(context.Background())
 		assert.EqualError(t, err, errPrefix+defaultDecoderMsg)
 		assert.Nil(t, resp)
-		gotStatusCode, ok := httpclient.StatusCodeFromError(err)
+		gotStatusCode, ok := internal.StatusCodeFromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, statusCode, gotStatusCode)
 	})

--- a/conjure-go-client/httpclient/internal/errors.go
+++ b/conjure-go-client/httpclient/internal/errors.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+// StatusCodeFromError retrieves the 'statusCode' parameter from the provided werror.
+// If the error is not a werror or does not have the statusCode param, ok is false.
+//
+// The default client error decoder sets the statusCode parameter on its returned errors. Note that, if a custom error
+// decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'
+// parameter on the error.
+func StatusCodeFromError(err error) (statusCode int, ok bool) {
+	statusCodeI, ok := werror.ParamFromError(err, "statusCode")
+	if !ok {
+		return 0, false
+	}
+	statusCode, ok = statusCodeI.(int)
+	return statusCode, ok
+}

--- a/conjure-go-client/httpclient/internal/retry.go
+++ b/conjure-go-client/httpclient/internal/retry.go
@@ -73,7 +73,11 @@ func IsRetryOtherResponse(resp *http.Response) (bool, *url.URL) {
 	return true, locationURL
 }
 
-func IsThrottleResponse(resp *http.Response) (bool, time.Duration) {
+func IsThrottleResponse(resp *http.Response, err error) (bool, time.Duration) {
+	errCode, ok := StatusCodeFromError(err)
+	if ok && errCode == StatusCodeThrottle {
+		return true, 0
+	}
 	if resp == nil || resp.StatusCode != StatusCodeThrottle {
 		return false, 0
 	}
@@ -93,7 +97,11 @@ func IsThrottleResponse(resp *http.Response) (bool, time.Duration) {
 	return true, time.Until(retryAfterDate)
 }
 
-func IsUnavailableResponse(resp *http.Response) bool {
+func IsUnavailableResponse(resp *http.Response, err error) bool {
+	errCode, ok := StatusCodeFromError(err)
+	if ok && errCode == StatusCodeUnavailable {
+		return true
+	}
 	if resp == nil || resp.StatusCode != StatusCodeUnavailable {
 		return false
 	}

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -68,3 +68,8 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	// TODO(bmoylan) unmarshal conjure error
 	return werror.Error("server returned a status >= 400", werror.SafeParam("statusCode", resp.StatusCode))
 }
+
+// StatusCodeFromError wraps the internal StatusCodeFromError func. For behavior details, see its docs.
+func StatusCodeFromError(err error) (statusCode int, ok bool) {
+	return internal.StatusCodeFromError(err)
+}

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -68,18 +68,3 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	// TODO(bmoylan) unmarshal conjure error
 	return werror.Error("server returned a status >= 400", werror.SafeParam("statusCode", resp.StatusCode))
 }
-
-// StatusCodeFromError retrieves the 'statusCode' parameter from the provided werror.
-// If the error is not a werror or does not have the statusCode param, ok is false.
-//
-// The default client error decoder sets the statusCode parameter on its returned errors. Note that, if a custom error
-// decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'
-// parameter on the error.
-func StatusCodeFromError(err error) (statusCode int, ok bool) {
-	statusCodeI, ok := werror.ParamFromError(err, "statusCode")
-	if !ok {
-		return 0, false
-	}
-	statusCode, ok = statusCodeI.(int)
-	return statusCode, ok
-}

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/conjure-go-client/httpclient/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,7 +39,7 @@ func TestErrorsMiddleware(t *testing.T) {
 
 		_, err = client.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
 		require.Error(t, err)
-		status, ok := httpclient.StatusCodeFromError(err)
+		status, ok := internal.StatusCodeFromError(err)
 		require.True(t, ok)
 		require.Equal(t, http.StatusNotFound, status)
 	})


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
error handling for codes >=400 was incorrect because of the error decoding middleware
## After this PR
==COMMIT_MSG==
Fixes #78 
Extracts status code from the returned error and acts on that. This limits more complex behavior, such as respecting the retry-after header.
==COMMIT_MSG==

## Possible downsides?

The longer-term solution, which in my opinion is preferable, is to move retry logic into middleware below the error decoding middleware and out of the client directly. This will allow it to inspect the response before it gets filtered by the error decoding middleware.

Unfortunately, this is not possible given that we currently support arbitrary error decoders and retry behavior is dependent on whether an error is returned or not. Doing error decoding after retrying will therefore be a behavior break and will cause user-defined "errors" to no longer be retried.
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/79)
<!-- Reviewable:end -->
