### PR TITLE
improvement: client middleware can read request body

### DIFF
--- a/changelog/@unreleased/pr-89.v2.yml
+++ b/changelog/@unreleased/pr-89.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Client middleware is able to read the request body
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/89

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -202,9 +202,10 @@ func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...Reque
 		b.errorDecoderMiddleware,
 		// must precede the body middleware so it can read the response body
 		c.errorDecoderMiddleware,
-		b.bodyMiddleware,
 	}
+	// must precede the body middleware so it can read the request body
 	middlewares = append(middlewares, c.middlewares...)
+	middlewares = append(middlewares, b.bodyMiddleware)
 	for _, middleware := range middlewares {
 		if middleware != nil {
 			transport = wrapTransport(transport, middleware)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Client middleware could not read the request body
## After this PR
fixes: #82 
==COMMIT_MSG==
Client middleware is able to read the request body
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
see #82 for discussion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/89)
<!-- Reviewable:end -->
