### PR TITLE
improvement: explicitly set GetBody to nil for ReadCloser req input

### DIFF
--- a/changelog/@unreleased/pr-91.v2.yml
+++ b/changelog/@unreleased/pr-91.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: <!-- User-facing outcomes this PR delivers -->
+  description: Explicitly set GetBody to nil for ReadCloser req input
   links:
   - https://github.com/palantir/conjure-go-runtime/pull/91

--- a/changelog/@unreleased/pr-91.v2.yml
+++ b/changelog/@unreleased/pr-91.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: <!-- User-facing outcomes this PR delivers -->
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/91

--- a/conjure-go-client/httpclient/body_handler.go
+++ b/conjure-go-client/httpclient/body_handler.go
@@ -60,10 +60,7 @@ func (b *bodyMiddleware) setRequestBody(req *http.Request) error {
 	// use the provided input directly as the request body.
 	if bodyReadCloser, ok := b.requestInput.(io.ReadCloser); ok && b.requestEncoder == nil {
 		req.Body = bodyReadCloser
-		// Use the same heuristic as http.NewRequest to generate the "GetBody" function.
-		if newReq, err := http.NewRequest("", "", bodyReadCloser); err == nil {
-			req.GetBody = newReq.GetBody
-		}
+		req.GetBody = nil
 		return nil
 	}
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`GetBody()` was always being set to `nil` in this case so we are making it explicit.

Fixes https://github.com/palantir/conjure-go-runtime/issues/90

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/91)
<!-- Reviewable:end -->
