### PR TITLE
fix: allow GetBody() to be called multiple times

### DIFF
--- a/changelog/@unreleased/pr-92.v2.yml
+++ b/changelog/@unreleased/pr-92.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: request.GetBody() can now be called multiple times with a new copy
+    of the request body.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/92

--- a/conjure-go-client/httpclient/body_handler.go
+++ b/conjure-go-client/httpclient/body_handler.go
@@ -82,8 +82,9 @@ func (b *bodyMiddleware) setRequestBody(req *http.Request) error {
 	if buf.Len() != 0 {
 		req.Body = ioutil.NopCloser(buf)
 		req.ContentLength = int64(buf.Len())
-		roCopy := ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
-		req.GetBody = func() (io.ReadCloser, error) { return roCopy, nil }
+		req.GetBody = func() (io.ReadCloser, error) {
+			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+		}
 	} else {
 		req.Body = http.NoBody
 		req.GetBody = func() (io.ReadCloser, error) { return http.NoBody, nil }

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -94,7 +94,6 @@ func TestMiddlewareCanReadBody(t *testing.T) {
 
 	t.Run("NoByteBufferPool", func(t *testing.T) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
 			withMiddleware,
 			httpclient.WithBaseURLs([]string{server.URL}),
 		)

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -56,6 +56,11 @@ func TestMiddlewareCanReadBody(t *testing.T) {
 			body, err := req.GetBody()
 			require.NoError(t, err)
 			bodyIsCorrect(body)
+
+			bodyAgain, err := req.GetBody()
+			require.NoError(t, err)
+			bodyIsCorrect(bodyAgain)
+
 			return next.RoundTrip(req)
 		})),
 		httpclient.WithBaseURLs([]string{server.URL}),


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously, when we set the request `GetBody` function, we would not create a new copy each time `GetBody()` was called, which meant that we could only use `GetBody()` once before the request data was drained.

This is how it's done in the go net/http source code: https://github.com/golang/go/blob/master/src/net/http/request.go#L889

## After this PR
==COMMIT_MSG==
request.GetBody() can now be called multiple times with a new copy of the request body.
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/92)
<!-- Reviewable:end -->
