### PR TITLE
improvement: use BytesBufferPool in clientImpl

### DIFF
--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: NewClient uses the provided BytesBufferPool
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/93

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -108,6 +108,7 @@ func NewClient(params ...ClientParam) (Client, error) {
 		middlewares:                   middlewares,
 		metricsMiddleware:             b.metricsMiddleware,
 		errorDecoderMiddleware:        edm,
+		bufferPool:                    b.BytesBufferPool,
 	}, nil
 }
 

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -103,7 +103,7 @@ func BenchmarkAllocWithBytesBufferPool(b *testing.B) {
 	defer server.Close()
 
 	// When making 'count' requests, we expect a client with a bufferpool of size 1 to make roughly 'count'
-	// fewer allocations than a client with no bufferpool.
+	// fewer allocations than a client with no bufferpool, due to memory reuse.
 	runBench := func(b *testing.B, client httpclient.Client) {
 		ctx := context.Background()
 		reqBody := httpclient.WithRequestBody("body", codecs.Plain)


### PR DESCRIPTION
## Before this PR
I was working on https://github.com/palantir/conjure-go-runtime/pull/92 when I realized that we weren't actually using the `bufferPool` in `setRequestBody` even when we explicitly provided one in `NewClient`.

It's important we fix this so that we can avoid unnecessary allocs by using a bufferpool here.

The commit `add proving tests` shows how we fail to read the request body in the server when we are using a bufferpool, because the buf pointer is copied into `req.Body` and then immediately gets returned to the pool.

The commit `add cleanup to fix` adds a cleanup function returned by `setRequestBody` to  to allow the buf pointer to be returned to the bufferpool only after it is no longer in use.

## After this PR
==COMMIT_MSG==
NewClient uses the provided BytesBufferPool
==COMMIT_MSG==

## Possible downsides?
I don't see any possible downsides here, but happy to hear any suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/93)
<!-- Reviewable:end -->
