### PR TITLE
StatusCodeFromError should respect conjure errors

### DIFF
--- a/changelog/@unreleased/pr-119.v2.yml
+++ b/changelog/@unreleased/pr-119.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: StatusCodeFromError should respect conjure errors
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/119

--- a/conjure-go-client/httpclient/internal/errors.go
+++ b/conjure-go-client/httpclient/internal/errors.go
@@ -22,7 +22,7 @@ import (
 // StatusCodeFromError retrieves the 'statusCode' parameter from the provided werror.
 // If the statusCode can not be detected from the error, ok is false.
 // If the error is a (potentially wrapped) Conjure error, the conjure status code is returned.
-// Otherwise, if the error is a werror with the statusCode param, that parameter is returned.
+// Otherwise, if the error is a werror with the statusCode param, the value of the statusCode parameter is returned.
 //
 // The default client error decoder sets the statusCode parameter on its returned errors. Note that, if a custom error
 // decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'

--- a/conjure-go-client/httpclient/internal/errors.go
+++ b/conjure-go-client/httpclient/internal/errors.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 
@@ -25,6 +26,9 @@ import (
 // decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'
 // parameter on the error.
 func StatusCodeFromError(err error) (statusCode int, ok bool) {
+	if conjureErr, ok := werror.RootCause(err).(errors.Error); ok {
+		return conjureErr.Code().StatusCode(), true
+	}
 	statusCodeI, ok := werror.ParamFromError(err, "statusCode")
 	if !ok {
 		return 0, false

--- a/conjure-go-client/httpclient/internal/errors.go
+++ b/conjure-go-client/httpclient/internal/errors.go
@@ -20,7 +20,9 @@ import (
 )
 
 // StatusCodeFromError retrieves the 'statusCode' parameter from the provided werror.
-// If the error is not a werror or does not have the statusCode param, ok is false.
+// If the statusCode can not be detected from the error, ok is false.
+// If the error is a (potentially wrapped) Conjure error, the conjure status code is returned.
+// Otherwise, if the error is a werror with the statusCode param, that parameter is returned.
 //
 // The default client error decoder sets the statusCode parameter on its returned errors. Note that, if a custom error
 // decoder is used, this function will only return a status code for the error if the custom decoder sets a 'statusCode'

--- a/conjure-go-client/httpclient/internal/errors_test.go
+++ b/conjure-go-client/httpclient/internal/errors_test.go
@@ -1,0 +1,56 @@
+package internal_test
+
+import (
+	"fmt"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStatusCodeFromError(t *testing.T) {
+	for _, test := range []struct{
+		Name string
+		Error error
+		Expected int
+		Ok bool
+	}{
+		{
+			Name: "stdlib error",
+			Error: fmt.Errorf("an error"),
+			Expected: 0,
+			Ok: false,
+		},
+		{
+			Name: "conjure error",
+			Error: errors.NewNotFound(),
+			Expected: 404,
+			Ok: true,
+		},
+		{
+			Name: "wrapped conjure error",
+			Error: werror.Wrap(errors.NewNotFound(), "not found"),
+			Expected: 404,
+			Ok: true,
+		},
+		{
+			Name: "overridden conjure error is ignored",
+			Error: werror.Wrap(errors.NewNotFound(), "not found", werror.SafeParam("statusCode", 500)),
+			Expected: 404,
+			Ok: true,
+		},
+		{
+			Name: "werror with param",
+			Error: werror.Error( "not found", werror.SafeParam("statusCode", 500)),
+			Expected: 500,
+			Ok: true,
+		},
+	}{
+		t.Run(test.Name, func(t *testing.T) {
+			actual, ok := internal.StatusCodeFromError(test.Error)
+			assert.Equal(t, test.Expected, actual)
+			assert.Equal(t, test.Ok, ok)
+		})
+	}
+}

--- a/conjure-go-client/httpclient/internal/errors_test.go
+++ b/conjure-go-client/httpclient/internal/errors_test.go
@@ -1,52 +1,67 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestStatusCodeFromError(t *testing.T) {
-	for _, test := range []struct{
-		Name string
-		Error error
+	for _, test := range []struct {
+		Name     string
+		Error    error
 		Expected int
-		Ok bool
+		Ok       bool
 	}{
 		{
-			Name: "stdlib error",
-			Error: fmt.Errorf("an error"),
+			Name:     "stdlib error",
+			Error:    fmt.Errorf("an error"),
 			Expected: 0,
-			Ok: false,
+			Ok:       false,
 		},
 		{
-			Name: "conjure error",
-			Error: errors.NewNotFound(),
+			Name:     "conjure error",
+			Error:    errors.NewNotFound(),
 			Expected: 404,
-			Ok: true,
+			Ok:       true,
 		},
 		{
-			Name: "wrapped conjure error",
-			Error: werror.Wrap(errors.NewNotFound(), "not found"),
+			Name:     "wrapped conjure error",
+			Error:    werror.Wrap(errors.NewNotFound(), "not found"),
 			Expected: 404,
-			Ok: true,
+			Ok:       true,
 		},
 		{
-			Name: "overridden conjure error is ignored",
-			Error: werror.Wrap(errors.NewNotFound(), "not found", werror.SafeParam("statusCode", 500)),
+			Name:     "overridden conjure error is ignored",
+			Error:    werror.Wrap(errors.NewNotFound(), "not found", werror.SafeParam("statusCode", 500)),
 			Expected: 404,
-			Ok: true,
+			Ok:       true,
 		},
 		{
-			Name: "werror with param",
-			Error: werror.Error( "not found", werror.SafeParam("statusCode", 500)),
+			Name:     "werror with param",
+			Error:    werror.Error("not found", werror.SafeParam("statusCode", 500)),
 			Expected: 500,
-			Ok: true,
+			Ok:       true,
 		},
-	}{
+	} {
 		t.Run(test.Name, func(t *testing.T) {
 			actual, ok := internal.StatusCodeFromError(test.Error)
 			assert.Equal(t, test.Expected, actual)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/119)
<!-- Reviewable:end -->
