### PR TITLE
Add httpserver.NewConjureHandler with saner defaults

### DIFF
--- a/changelog/@unreleased/pr-121.v2.yml
+++ b/changelog/@unreleased/pr-121.v2.yml
@@ -1,0 +1,7 @@
+type: feature
+feature:
+  description: Add httpserver.NewConjureHandler which converts non-conjure errors
+    to conjure errors and hardcodes some of the options for logging and status code
+    handling.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/121


### PR DESCRIPTION
## Before this PR
conjure-go does not convert non-conjure errors to conjure errors before writing a result. This means that developers must explicitly handle the conversion.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add httpserver.NewConjureHandler which converts non-conjure errors to conjure errors and hardcodes some of the options for logging and status code handling.
==COMMIT_MSG==

I plan to update conjure-go to use this: https://github.com/palantir/conjure-go/pull/140

## Possible downsides?

This will affect wire format for services currently writing non-conjure errors to the response. The conjure-go release should likely be a break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/121)
<!-- Reviewable:end -->
