### PR TITLE
improvement: pull out retry logic and handle mesh URIs

### DIFF
--- a/changelog/@unreleased/pr-126.v2.yml
+++ b/changelog/@unreleased/pr-126.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'improvement: pull out retry logic and handle mesh URIs'
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/126

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -16,7 +16,6 @@ package httpclient
 
 import (
 	"context"
-	"math/rand"
 	"net/http"
 	"net/url"
 
@@ -84,74 +83,24 @@ func (c *clientImpl) Delete(ctx context.Context, params ...RequestParam) (*http.
 func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Response, error) {
 	uris := c.uris
 	if len(uris) == 0 {
-		return nil, werror.Error("no base URIs are configured")
+		return nil, werror.ErrorWithContextParams(ctx, "no base URIs are configured")
 	}
-	offset := rand.Intn(len(uris))
 
 	var err error
 	var resp *http.Response
 
-	retrier := retry.Start(ctx, c.backoffOptions...)
-
-	nextURI := uris[offset]
-	failedURIs := map[string]struct{}{}
-	for i := 0; i < c.maxRetries; i++ {
-		resp, err = c.doOnce(ctx, nextURI, params...)
-		if retryOther, _ := internal.IsThrottleResponse(resp, err); retryOther {
-			// 429: throttle
-			// Immediately backoff and select the next URI.
-			// TODO(whickman): use the retry-after header once #81 is resolved
-			nextURI, offset = nextURIAndBackoff(nextURI, uris, offset, failedURIs, retrier)
-		} else if internal.IsUnavailableResponse(resp, err) {
-			// 503: go to next node
-			nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
-		} else if resp == nil {
-			// If we get a nil response, we can assume there is a problem with host and can move on to the next.
-			nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
-		} else if shouldTryOther, otherURI := internal.IsRetryOtherResponse(resp); shouldTryOther {
-			// 308: go to next node, or particular node if provided.
-			if otherURI != nil {
-				nextURI = otherURI.String()
-				retrier.Reset()
-			} else {
-				nextURI, offset = nextURIOrBackoff(nextURI, uris, offset, failedURIs, retrier)
-			}
-		} else {
-			// The response was not a failure in any way, return the error
-			return resp, err
+	retrier := internal.NewRequestRetrier(uris, retry.Start(ctx, c.backoffOptions...), c.maxRetries)
+	for retrier.ShouldGetNextURI(resp, err) {
+		uri, err := retrier.GetNextURI(ctx, resp, err)
+		if err != nil {
+			return nil, err
 		}
+		resp, err = c.doOnce(ctx, uri, params...)
 	}
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	return resp, werror.Error("could not find live server")
-}
-
-// If lastURI was already marked failed, we perform a backoff as determined by the retrier before returning the next URI and its offset.
-// Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately.
-func nextURIOrBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
-	_, performBackoff := failedURIs[lastURI]
-	nextURI, nextURIOffset = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
-	// If the URI has failed before, perform a backoff
-	if performBackoff {
-		retrier.Next()
-	}
-	return nextURI, nextURIOffset
-}
-
-// Marks the current URI as failed, gets the next URI, and performs a backoff as determined by the retrier.
-func nextURIAndBackoff(lastURI string, uris []string, offset int, failedURIs map[string]struct{}, retrier retry.Retrier) (nextURI string, nextURIOffset int) {
-	nextURI, nextURIOffset = markFailedAndGetNextURI(failedURIs, lastURI, offset, uris)
-	retrier.Next()
-	return nextURI, nextURIOffset
-
-}
-
-func markFailedAndGetNextURI(failedURIs map[string]struct{}, lastURI string, offset int, uris []string) (string, int) {
-	failedURIs[lastURI] = struct{}{}
-	nextURIOffset := (offset + 1) % len(uris)
-	nextURI := uris[nextURIOffset]
-	return nextURI, nextURIOffset
+	return resp, nil
 }
 
 func (c *clientImpl) doOnce(ctx context.Context, baseURI string, params ...RequestParam) (*http.Response, error) {

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -91,9 +91,9 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 
 	retrier := internal.NewRequestRetrier(uris, retry.Start(ctx, c.backoffOptions...), c.maxRetries)
 	for retrier.ShouldGetNextURI(resp, err) {
-		uri, err := retrier.GetNextURI(ctx, resp, err)
-		if err != nil {
-			return nil, err
+		uri, retryErr := retrier.GetNextURI(ctx, resp, err)
+		if retryErr != nil {
+			return nil, retryErr
 		}
 		resp, err = c.doOnce(ctx, uri, params...)
 	}

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (
@@ -42,7 +56,7 @@ func (r *RequestRetrier) ShouldGetNextURI(resp *http.Response, respErr error) bo
 	if r.retryCount == 0 {
 		return true
 	}
-	return r.retryCount <= r.maxRetries &&
+	return r.retryCount < r.maxRetries &&
 		!r.isMeshURI(r.currentURI) &&
 		r.responseAndErrRetriable(resp, respErr)
 }

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"context"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/palantir/pkg/retry"
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+const (
+	meshSchemePrefix = "mesh-"
+)
+
+type RequestRetrier struct {
+	currentURI string
+	retrier    retry.Retrier
+	uris       []string
+	offset     int
+	failedURIs map[string]struct{}
+	maxRetries int
+	retryCount int
+}
+
+func NewRequestRetrier(uris []string, retrier retry.Retrier, maxRetries int) *RequestRetrier {
+	offset := rand.Intn(len(uris))
+	return &RequestRetrier{
+		currentURI: uris[offset],
+		retrier:    retrier,
+		uris:       uris,
+		offset:     offset,
+		failedURIs: map[string]struct{}{},
+		maxRetries: maxRetries,
+		retryCount: 0,
+	}
+}
+
+func (r *RequestRetrier) ShouldGetNextURI(resp *http.Response, respErr error) bool {
+	if r.retryCount == 0 {
+		return true
+	}
+	return r.retryCount <= r.maxRetries &&
+		!r.isMeshURI(r.currentURI) &&
+		r.responseAndErrRetriable(resp, respErr)
+}
+
+func (r *RequestRetrier) GetNextURI(ctx context.Context, resp *http.Response, respErr error) (string, error) {
+	defer func() {
+		r.retryCount++
+	}()
+	if r.retryCount == 0 {
+		return r.removeMeshSchemeIfPresent(r.currentURI), nil
+	} else if !r.ShouldGetNextURI(resp, respErr) {
+		return "", r.errorFromRespError(ctx, resp, respErr)
+	}
+	return r.doRetrySelection(resp, respErr), nil
+}
+
+func (r *RequestRetrier) doRetrySelection(resp *http.Response, respErr error) string {
+	retryFn := r.getRetryFn(resp, respErr)
+	if retryFn != nil {
+		retryFn()
+		return r.currentURI
+	}
+	return ""
+}
+
+func (r *RequestRetrier) responseAndErrRetriable(resp *http.Response, respErr error) bool {
+	return r.getRetryFn(resp, respErr) != nil
+}
+
+func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() {
+	if retryOther, _ := isThrottleResponse(resp, respErr); retryOther {
+		// 429: throttle
+		// Immediately backoff and select the next URI.
+		// TODO(whickman): use the retry-after header once #81 is resolved
+		return r.nextURIAndBackoff
+	} else if isUnavailableResponse(resp, respErr) || resp == nil {
+		// 503: go to next node
+		// Or if we get a nil response, we can assume there is a problem with host and can move on to the next.
+		return r.nextURIOrBackoff
+	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp); shouldTryOther {
+		// 308: go to next node, or particular node if provided.
+		if otherURI != nil {
+			return func() {
+				r.setURIAndResetBackoff(otherURI)
+			}
+		}
+		return r.nextURIOrBackoff
+	}
+	return nil
+}
+
+func (r *RequestRetrier) setURIAndResetBackoff(otherURI *url.URL) {
+	nextURI := otherURI.String()
+	r.retrier.Reset()
+	r.currentURI = nextURI
+}
+
+// If lastURI was already marked failed, we perform a backoff as determined by the retrier before returning the next URI and its offset.
+// Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately.
+func (r *RequestRetrier) nextURIOrBackoff() {
+	_, performBackoff := r.failedURIs[r.currentURI]
+	r.markFailedAndMoveToNextURI()
+	// If the URI has failed before, perform a backoff
+	if performBackoff || len(r.uris) == 1 {
+		r.retrier.Next()
+	}
+}
+
+// Marks the current URI as failed, gets the next URI, and performs a backoff as determined by the retrier.
+func (r *RequestRetrier) nextURIAndBackoff() {
+	r.markFailedAndMoveToNextURI()
+	r.retrier.Next()
+}
+
+func (r *RequestRetrier) markFailedAndMoveToNextURI() {
+	r.failedURIs[r.currentURI] = struct{}{}
+	nextURIOffset := (r.offset + 1) % len(r.uris)
+	nextURI := r.uris[nextURIOffset]
+	r.currentURI = nextURI
+	r.offset = nextURIOffset
+}
+
+func (r *RequestRetrier) removeMeshSchemeIfPresent(uri string) string {
+	if r.isMeshURI(uri) {
+		return strings.Replace(uri, meshSchemePrefix, "", 1)
+	}
+	return uri
+}
+
+func (r *RequestRetrier) isMeshURI(uri string) bool {
+	return strings.HasPrefix(uri, meshSchemePrefix)
+}
+
+func (r *RequestRetrier) errorFromRespError(ctx context.Context, resp *http.Response, respErr error) error {
+	message := "GetNextURI called, but retry should not be attempted"
+	params := []werror.Param{
+		werror.SafeParam("retryCount", r.retryCount),
+		werror.SafeParam("maxRetries", r.maxRetries),
+		werror.SafeParam("statusCodeRetriable", r.responseAndErrRetriable(resp, respErr)),
+		werror.SafeParam("uriInMesh", r.isMeshURI(r.currentURI)),
+	}
+	if respErr != nil {
+		return werror.WrapWithContextParams(ctx, respErr, message, params...)
+	}
+	return werror.ErrorWithContextParams(ctx, message, params...)
+}

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (
@@ -33,7 +47,7 @@ func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 	}
 	respWithLocationHeader.Header.Add("Location", "http://example.com")
 	ctx := context.Background()
-	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 1)
+	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 2)
 	require.True(t, r.ShouldGetNextURI(nil, nil))
 	_, err := r.GetNextURI(ctx, nil, nil)
 	require.NoError(t, err)

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -1,0 +1,229 @@
+package internal
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/palantir/pkg/retry"
+	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/stretchr/testify/require"
+)
+
+var _ retry.Retrier = &mockRetrier{}
+
+func TestRequestRetrier_HandleMeshURI(t *testing.T) {
+	ctx := context.Background()
+	r := NewRequestRetrier([]string{"mesh-http://example.com"}, retry.Start(context.Background()), 1)
+	require.True(t, r.ShouldGetNextURI(nil, nil))
+	uri, err := r.GetNextURI(ctx, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, uri, "http://example.com")
+	respErr := werror.ErrorWithContextParams(context.Background(), "error", werror.SafeParam("statusCode", 429))
+	require.False(t, r.ShouldGetNextURI(nil, respErr))
+	_, err = r.GetNextURI(ctx, nil, respErr)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "GetNextURI called, but retry should not be attempted")
+}
+
+func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
+	respWithLocationHeader := &http.Response{
+		StatusCode: StatusCodeRetryOther,
+		Header:     map[string][]string{},
+	}
+	respWithLocationHeader.Header.Add("Location", "http://example.com")
+	ctx := context.Background()
+	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 1)
+	require.True(t, r.ShouldGetNextURI(nil, nil))
+	_, err := r.GetNextURI(ctx, nil, nil)
+	require.NoError(t, err)
+	require.True(t, r.ShouldGetNextURI(respWithLocationHeader, nil))
+	uri, err := r.GetNextURI(ctx, respWithLocationHeader, nil)
+	require.NoError(t, err)
+	require.Equal(t, uri, "http://example.com")
+}
+
+func TestRequestRetrier_GetNextURI(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		resp               *http.Response
+		respErr            error
+		uris               []string
+		shouldRetry        bool
+		shouldRetrySameURI bool
+		shouldRetryBackoff bool
+		shouldRetryReset   bool
+	}{
+		{
+			name:               "returns error if response exists and doesn't appear retryable",
+			resp:               &http.Response{},
+			respErr:            nil,
+			uris:               []string{"a", "b"},
+			shouldRetry:        false,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "returns error if error code not retryable",
+			resp:               &http.Response{},
+			respErr:            nil,
+			uris:               []string{"a", "b"},
+			shouldRetry:        false,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "returns a URI if response and error are nil",
+			resp:               nil,
+			respErr:            nil,
+			uris:               []string{"a", "b"},
+			shouldRetry:        true,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "returns a URI if response and error are nil",
+			resp:               nil,
+			respErr:            nil,
+			uris:               []string{"a", "b"},
+			shouldRetry:        true,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "retries and backs off the single URI if response and error are nil",
+			resp:               nil,
+			respErr:            nil,
+			uris:               []string{"a"},
+			shouldRetry:        true,
+			shouldRetrySameURI: true,
+			shouldRetryBackoff: true,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "returns a new URI if unavailable",
+			resp:               nil,
+			respErr:            werror.ErrorWithContextParams(context.Background(), "503", werror.SafeParam("statusCode", 503)),
+			uris:               []string{"a", "b"},
+			shouldRetry:        true,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "retries and backs off the single URI if unavailable",
+			resp:               nil,
+			respErr:            werror.ErrorWithContextParams(context.Background(), "503", werror.SafeParam("statusCode", 503)),
+			uris:               []string{"a"},
+			shouldRetry:        true,
+			shouldRetrySameURI: true,
+			shouldRetryBackoff: true,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "returns a new URI and backs off if throttled",
+			resp:               nil,
+			respErr:            werror.ErrorWithContextParams(context.Background(), "429", werror.SafeParam("statusCode", 429)),
+			uris:               []string{"a", "b"},
+			shouldRetry:        true,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: true,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "retries single URI and backs off if throttled",
+			resp:               nil,
+			respErr:            werror.ErrorWithContextParams(context.Background(), "429", werror.SafeParam("statusCode", 429)),
+			uris:               []string{"a"},
+			shouldRetry:        true,
+			shouldRetrySameURI: true,
+			shouldRetryBackoff: true,
+			shouldRetryReset:   false,
+		},
+		{
+			name: "retries another URI if gets retry other response without location",
+			resp: &http.Response{
+				StatusCode: StatusCodeRetryOther,
+			},
+			respErr:            nil,
+			uris:               []string{"a", "b"},
+			shouldRetry:        true,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name: "retries single URI and backs off if gets retry other response without location",
+			resp: &http.Response{
+				StatusCode: StatusCodeRetryOther,
+			},
+			respErr:            nil,
+			uris:               []string{"a"},
+			shouldRetry:        true,
+			shouldRetrySameURI: true,
+			shouldRetryBackoff: true,
+			shouldRetryReset:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			retrier := newMockRetrier()
+			r := NewRequestRetrier(tc.uris, retrier, 2)
+			// first URI isn't a retry
+			firstURI, _ := r.GetNextURI(ctx, nil, nil)
+			if !tc.shouldRetry {
+				require.False(t, r.ShouldGetNextURI(tc.resp, tc.respErr))
+			} else {
+				require.True(t, r.ShouldGetNextURI(tc.resp, tc.respErr))
+			}
+			retryURI, err := r.GetNextURI(ctx, tc.resp, tc.respErr)
+			if tc.shouldRetry {
+				require.NoError(t, err)
+				require.Contains(t, tc.uris, retryURI)
+				if tc.shouldRetrySameURI {
+					require.Equal(t, retryURI, firstURI)
+				} else {
+					require.NotEqual(t, retryURI, firstURI)
+				}
+				if tc.shouldRetryReset {
+					require.True(t, retrier.DidReset)
+				}
+				if tc.shouldRetryBackoff {
+					require.True(t, retrier.DidGetNext)
+				}
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "GetNextURI called, but retry should not be attempted")
+			}
+		})
+	}
+}
+
+func newMockRetrier() *mockRetrier {
+	return &mockRetrier{
+		DidGetNext: false,
+		DidReset:   false,
+	}
+}
+
+type mockRetrier struct {
+	DidGetNext bool
+	DidReset   bool
+}
+
+func (m *mockRetrier) Reset() {
+	m.DidReset = true
+}
+
+func (m *mockRetrier) Next() bool {
+	m.DidGetNext = true
+	return true
+}
+
+func (m *mockRetrier) CurrentAttempt() int {
+	return 0
+}

--- a/conjure-go-client/httpclient/internal/retry.go
+++ b/conjure-go-client/httpclient/internal/retry.go
@@ -57,7 +57,7 @@ const (
 	StatusCodeUnavailable = http.StatusServiceUnavailable
 )
 
-func IsRetryOtherResponse(resp *http.Response) (bool, *url.URL) {
+func isRetryOtherResponse(resp *http.Response) (bool, *url.URL) {
 	if resp == nil || resp.StatusCode != StatusCodeRetryOther {
 		return false, nil
 	}
@@ -73,7 +73,7 @@ func IsRetryOtherResponse(resp *http.Response) (bool, *url.URL) {
 	return true, locationURL
 }
 
-func IsThrottleResponse(resp *http.Response, err error) (bool, time.Duration) {
+func isThrottleResponse(resp *http.Response, err error) (bool, time.Duration) {
 	errCode, ok := StatusCodeFromError(err)
 	if ok && errCode == StatusCodeThrottle {
 		return true, 0
@@ -97,7 +97,7 @@ func IsThrottleResponse(resp *http.Response, err error) (bool, time.Duration) {
 	return true, time.Until(retryAfterDate)
 }
 
-func IsUnavailableResponse(resp *http.Response, err error) bool {
+func isUnavailableResponse(resp *http.Response, err error) bool {
 	errCode, ok := StatusCodeFromError(err)
 	if ok && errCode == StatusCodeUnavailable {
 		return true

--- a/conjure-go-client/httpclient/internal/retry_test.go
+++ b/conjure-go-client/httpclient/internal/retry_test.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal_test
+package internal
 
 import (
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/stretchr/testify/assert"
 )
@@ -99,19 +98,19 @@ func TestRetryResponseParsers(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			isRetryOther, retryOtherURL := internal.IsRetryOtherResponse(test.Response)
+			isRetryOther, retryOtherURL := isRetryOtherResponse(test.Response)
 			if assert.Equal(t, test.IsRetryOther, isRetryOther) && test.RetryOtherURL != "" {
 				if assert.NotNil(t, retryOtherURL) {
 					assert.Equal(t, test.RetryOtherURL, retryOtherURL.String())
 				}
 			}
 
-			isThrottle, throttleDur := internal.IsThrottleResponse(test.Response, test.RespErr)
+			isThrottle, throttleDur := isThrottleResponse(test.Response, test.RespErr)
 			if assert.Equal(t, test.IsThrottle, isThrottle) {
 				assert.WithinDuration(t, time.Now().Add(test.ThrottleDuration), time.Now().Add(throttleDur), time.Second)
 			}
 
-			isUnavailable := internal.IsUnavailableResponse(test.Response, test.RespErr)
+			isUnavailable := isUnavailableResponse(test.Response, test.RespErr)
 			assert.Equal(t, test.IsUnavailable, isUnavailable)
 		})
 	}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
retry logic was all over the client file, which makes it hard to extend and abstract.

additionally, I added handling for our in-house service mesh managing retries (with a scheme defined by our infra team), and fixed a small bug (flagged in comments).

I haven't addressed either the fact that we currently retry everything with error code > 400 or the fact that our retry counts are off by 1, as I didn't want to break any existing tests for this change


sorry this is a bit long, most if it is tests, though
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
improvement: pull out retry logic and handle mesh URIs
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/126)
<!-- Reviewable:end -->
