### PR TITLE
Remove duplicate 'count' on TLS metric names

### DIFF
--- a/changelog/@unreleased/pr-141.v2.yml
+++ b/changelog/@unreleased/pr-141.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove duplicate 'count' on TLS metric names
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/141

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -39,9 +39,9 @@ const (
 	metricTagFamily4xx   = "4xx"
 	metricTagFamily5xx   = "5xx"
 
-	MetricTLSHandshakeAttempt = "tls.handshake.attempt.count"
-	MetricTLSHandshakeFailure = "tls.handshake.failure.count"
-	MetricTLSHandshake        = "tls.handshake.count"
+	MetricTLSHandshakeAttempt = "tls.handshake.attempt"
+	MetricTLSHandshakeFailure = "tls.handshake.failure"
+	MetricTLSHandshake        = "tls.handshake"
 	CipherTagKey              = "cipher"
 	NextProtocolTagKey        = "next_protocol"
 	TLSVersionTagKey          = "tls_version"


### PR DESCRIPTION
Fixes produced metrics like `tls.handshakes.count.count`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/141)
<!-- Reviewable:end -->
