### PR TITLE
Add WithUnlimitedRetries client param

### DIFF
--- a/changelog/@unreleased/pr-147.v2.yml
+++ b/changelog/@unreleased/pr-147.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add `WithUnlimitedRetries` client param, which sets an unlimited number of retries on transport errors for every request.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/147

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -35,9 +35,10 @@ import (
 type clientBuilder struct {
 	httpClientBuilder
 
-	uris           []string
-	maxRetries     int
-	backoffOptions []retry.Option
+	uris                   []string
+	maxRetries             int
+	enableUnlimitedRetries bool
+	backoffOptions         []retry.Option
 
 	errorDecoder                  ErrorDecoder
 	disableTraceHeaderPropagation bool
@@ -99,7 +100,10 @@ func NewClient(params ...ClientParam) (Client, error) {
 		edm = errorDecoderMiddleware(b.errorDecoder)
 	}
 
-	if b.maxRetries == 0 {
+	if b.enableUnlimitedRetries {
+		// max retries of 0 indicates no limit
+		b.maxRetries = 0
+	} else if b.maxRetries == 0 {
 		b.maxRetries = 2 * len(b.uris)
 	}
 	return &clientImpl{

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -392,6 +392,15 @@ func WithMaxRetries(maxTransportRetries int) ClientParam {
 	})
 }
 
+// WithUnlimitedRetries sets an unlimited number of retries on transport errors for every request.
+// If set, this supersedes any retry limits set with WithMaxRetries.
+func WithUnlimitedRetries() ClientParam {
+	return clientParamFunc(func(b *clientBuilder) error {
+		b.enableUnlimitedRetries = true
+		return nil
+	})
+}
+
 // WithDisableRestErrors disables the middleware which sets Do()'s returned
 // error to a non-nil value in the case of >= 400 HTTP response.
 func WithDisableRestErrors() ClientParam {

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -103,6 +103,13 @@ func TestBuilder(t *testing.T) {
 				// No-op: passing nil should not cause panic
 			},
 		},
+		{
+			Name:  "UnlimitedRetries",
+			Param: WithUnlimitedRetries(),
+			Test: func(t *testing.T, client *clientImpl) {
+				assert.Equal(t, 0, client.maxRetries)
+			},
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			client, err := NewClient(test.Param)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add WithUnlimitedRetries client param, which sets an unlimited number of retries on transport errors for every request.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/147)
<!-- Reviewable:end -->
