### PR TITLE
Make http transport settings refreshable

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -130,7 +130,7 @@ func NewClient(params ...ClientParam) (Client, error) {
 		bufferPool:                    b.BytesBufferPool,
 	}
 
-	// watch for config updates that require the client to be rebuilt
+	// watch for config updates that require the transport to be updated
 	b.handleIdleConnUpdate(c)
 	b.handleTLSHandshakeTimeoutUpdate(c)
 	b.handleExpectContinueTimeoutUpdate(c)

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -37,9 +37,12 @@ const (
 	defaultIdleConnTimeout       = 90 * time.Second
 	defaultTLSHandshakeTimeout   = 10 * time.Second
 	defaultExpectContinueTimeout = 1 * time.Second
-	defaultMaxIdleConns          = 200
-	defaultMaxIdleConnsPerHost   = 100
 	defaultClientTimeout         = 1 * time.Minute
+	// defaultMaxIdleConns and defaultMaxIdleConnsPerHost are higher than the
+	// defaults, but match Java and heuristically work better for our relatively
+	// large services.
+	defaultMaxIdleConns        = 200
+	defaultMaxIdleConnsPerHost = 100
 )
 
 type clientBuilder struct {
@@ -155,10 +158,8 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 		IdleConnTimeout:       refreshable.NewDuration(refreshable.NewDefaultRefreshable(defaultIdleConnTimeout)),
 		TLSHandshakeTimeout:   refreshable.NewDuration(refreshable.NewDefaultRefreshable(defaultTLSHandshakeTimeout)),
 		ExpectContinueTimeout: refreshable.NewDuration(refreshable.NewDefaultRefreshable(defaultExpectContinueTimeout)),
-		// These are higher than the defaults, but match Java and
-		// heuristically work better for our relatively large services.
-		MaxIdleConns:        refreshable.NewInt(refreshable.NewDefaultRefreshable(defaultMaxIdleConns)),
-		MaxIdleConnsPerHost: refreshable.NewInt(refreshable.NewDefaultRefreshable(defaultMaxIdleConnsPerHost)),
+		MaxIdleConns:          refreshable.NewInt(refreshable.NewDefaultRefreshable(defaultMaxIdleConns)),
+		MaxIdleConnsPerHost:   refreshable.NewInt(refreshable.NewDefaultRefreshable(defaultMaxIdleConnsPerHost)),
 	}
 }
 

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -307,7 +307,7 @@ func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 // If unset, the client defaults to 30 seconds.
 func WithDialTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
-		b.DialTimeout = refreshable.NewDuration(refreshable.NewDefaultRefreshable(timeout))
+		b.DialTimeout = timeout
 		return nil
 	})
 }
@@ -457,37 +457,31 @@ func WithRefreshableConfig(config RefreshableClientConfig) ClientParam {
 
 		b.IdleConnTimeout = refreshable.NewDuration(config.IdleConnTimeout().MapDurationPtr(func(duration *time.Duration) interface{} {
 			if duration == nil {
-				return 90 * time.Second
+				return defaultIdleConnTimeout
 			}
 			return *duration
 		}))
 		b.TLSHandshakeTimeout = refreshable.NewDuration(config.TLSHandshakeTimeout().MapDurationPtr(func(duration *time.Duration) interface{} {
 			if duration == nil {
-				return 10 * time.Second
+				return defaultTLSHandshakeTimeout
 			}
 			return *duration
 		}))
 		b.ExpectContinueTimeout = refreshable.NewDuration(config.ExpectContinueTimeout().MapDurationPtr(func(duration *time.Duration) interface{} {
 			if duration == nil {
-				return 1 * time.Second
-			}
-			return *duration
-		}))
-		b.DialTimeout = refreshable.NewDuration(config.ConnectTimeout().MapDurationPtr(func(duration *time.Duration) interface{} {
-			if duration == nil {
-				return 30 * time.Second
+				return defaultExpectContinueTimeout
 			}
 			return *duration
 		}))
 		b.MaxIdleConns = refreshable.NewInt(config.MaxIdleConns().MapIntPtr(func(i *int) interface{} {
 			if i == nil {
-				return 200
+				return defaultMaxIdleConns
 			}
 			return *i
 		}))
 		b.MaxIdleConnsPerHost = refreshable.NewInt(config.MaxIdleConnsPerHost().MapIntPtr(func(i *int) interface{} {
 			if i == nil {
-				return 100
+				return defaultMaxIdleConnsPerHost
 			}
 			return *i
 		}))

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -216,7 +216,7 @@ func WithDisableTraceHeaderPropagation() ClientParam {
 // If unset, the client defaults to 1 minute.
 func WithHTTPTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
-		b.Timeout = timeout
+		b.Timeout = refreshable.NewDuration(refreshable.NewDefaultRefreshable(timeout))
 		return nil
 	})
 }
@@ -472,6 +472,13 @@ func WithRefreshableConfig(config RefreshableClientConfig) ClientParam {
 				return defaultExpectContinueTimeout
 			}
 			return *duration
+		}))
+		b.Timeout = refreshable.NewDuration(config.MapClientConfig(func(i ClientConfig) interface{} {
+			// N.B. we only have one timeout field (not based on method) so just take the max of read and write for now.
+			if timeout := maxTimeout(i.WriteTimeout, i.ReadTimeout); timeout != 0 {
+				return timeout
+			}
+			return defaultClientTimeout
 		}))
 		b.MaxIdleConns = refreshable.NewInt(config.MaxIdleConns().MapIntPtr(func(i *int) interface{} {
 			if i == nil {

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -16,7 +16,6 @@ package httpclient
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -124,16 +123,19 @@ func TestBuilder(t *testing.T) {
 				assert.Equal(t, []string{testAddr}, client.uris.CurrentStringSlice())
 				// update the client config with a new URI
 				timeout := 1 * time.Minute
+				maxIdleConns := 200
 				newConfig := ClientConfig{
-					ServiceName:     "test",
-					URIs:            []string{"https://changed-uri.local"},
-					IdleConnTimeout: &timeout,
+					ServiceName:         "test",
+					URIs:                []string{"https://changed-uri.local"},
+					IdleConnTimeout:     &timeout,
+					MaxIdleConnsPerHost: &maxIdleConns,
 				}
 				err := refreshableCfg.Update(newConfig)
 				require.NoError(t, err)
 				assert.Equal(t, newConfig.URIs, client.uris.CurrentStringSlice(), "client URIs should be updated with the refreshed values")
 				transport := unwrapTransport(client.client.Transport)
 				assert.Equal(t, timeout, transport.IdleConnTimeout)
+				assert.Equal(t, maxIdleConns, transport.MaxIdleConnsPerHost)
 			},
 		},
 	} {
@@ -142,19 +144,5 @@ func TestBuilder(t *testing.T) {
 			require.NoError(t, err)
 			test.Test(t, client.(*clientImpl))
 		})
-	}
-}
-
-func unwrapTransport(rt http.RoundTripper) *http.Transport {
-	unwrapped := rt
-	for {
-		switch v := unwrapped.(type) {
-		case *wrappedClient:
-			unwrapped = v.baseTransport
-		case *http.Transport:
-			return v
-		default:
-			panic(fmt.Sprintf("unknown roundtripper type %T", unwrapped))
-		}
 	}
 }

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -123,13 +123,17 @@ func TestBuilder(t *testing.T) {
 				// check URIs is set prior to the change
 				assert.Equal(t, []string{testAddr}, client.uris.CurrentStringSlice())
 				// update the client config with a new URI
+				timeout := 1 * time.Minute
 				newConfig := ClientConfig{
-					ServiceName: "test",
-					URIs:        []string{"https://changed-uri.local"},
+					ServiceName:     "test",
+					URIs:            []string{"https://changed-uri.local"},
+					IdleConnTimeout: &timeout,
 				}
 				err := refreshableCfg.Update(newConfig)
 				require.NoError(t, err)
 				assert.Equal(t, newConfig.URIs, client.uris.CurrentStringSlice(), "client URIs should be updated with the refreshed values")
+				transport := unwrapTransport(client.client.Transport)
+				assert.Equal(t, timeout, transport.IdleConnTimeout)
 			},
 		},
 	} {

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -122,19 +122,19 @@ func TestBuilder(t *testing.T) {
 				// check URIs is set prior to the change
 				assert.Equal(t, []string{testAddr}, client.uris.CurrentStringSlice())
 				// update the client config with a new URI
-				timeout := 1 * time.Minute
+				timeout := 3 * time.Minute
 				maxIdleConns := 200
 				newConfig := ClientConfig{
 					ServiceName:         "test",
 					URIs:                []string{"https://changed-uri.local"},
-					IdleConnTimeout:     &timeout,
+					WriteTimeout:        &timeout,
 					MaxIdleConnsPerHost: &maxIdleConns,
 				}
 				err := refreshableCfg.Update(newConfig)
 				require.NoError(t, err)
 				assert.Equal(t, newConfig.URIs, client.uris.CurrentStringSlice(), "client URIs should be updated with the refreshed values")
 				transport := unwrapTransport(client.client.Transport)
-				assert.Equal(t, timeout, transport.IdleConnTimeout)
+				assert.Equal(t, timeout, client.client.Timeout)
 				assert.Equal(t, maxIdleConns, transport.MaxIdleConnsPerHost)
 			},
 		},

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -289,12 +289,7 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 	}
 
 	// N.B. we only have one timeout field (not based on method) so just take the max of read and write for now.
-	var timeout time.Duration
-	if orZero(c.WriteTimeout) > orZero(c.ReadTimeout) {
-		timeout = *c.WriteTimeout
-	} else if c.ReadTimeout != nil {
-		timeout = *c.ReadTimeout
-	}
+	timeout := maxTimeout(c.WriteTimeout, c.ReadTimeout)
 	if timeout != 0 {
 		params = append(params, WithHTTPTimeout(timeout))
 	}
@@ -324,4 +319,14 @@ func orZero(d *time.Duration) time.Duration {
 		return 0
 	}
 	return *d
+}
+
+func maxTimeout(w, r *time.Duration) time.Duration {
+	var timeout time.Duration
+	if orZero(w) > orZero(r) {
+		timeout = *w
+	} else if r != nil {
+		timeout = *r
+	}
+	return timeout
 }

--- a/conjure-go-client/httpclient/refreshable_config.go
+++ b/conjure-go-client/httpclient/refreshable_config.go
@@ -15,48 +15,57 @@
 package httpclient
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 )
 
 func (b *httpClientBuilder) handleIdleConnUpdate(c *clientImpl) {
 	b.IdleConnTimeout.SubscribeToDuration(func(v time.Duration) {
-		t := unwrapTransport(c.client.Transport)
-		t.IdleConnTimeout = v
-		c.client.Transport = t
+		unwrappedTransport := unwrapTransport(c.client.Transport)
+		if unwrappedTransport != nil {
+			unwrappedTransport.IdleConnTimeout = v
+			c.client.Transport = unwrappedTransport
+		}
 	})
 }
 
 func (b *httpClientBuilder) handleTLSHandshakeTimeoutUpdate(c *clientImpl) {
 	b.TLSHandshakeTimeout.SubscribeToDuration(func(v time.Duration) {
-		t := unwrapTransport(c.client.Transport)
-		t.TLSHandshakeTimeout = v
-		c.client.Transport = t
+		unwrappedTransport := unwrapTransport(c.client.Transport)
+		if unwrappedTransport != nil {
+			unwrappedTransport.TLSHandshakeTimeout = v
+			c.client.Transport = unwrappedTransport
+		}
 	})
 }
 
 func (b *httpClientBuilder) handleExpectContinueTimeoutUpdate(c *clientImpl) {
 	b.ExpectContinueTimeout.SubscribeToDuration(func(v time.Duration) {
-		t := unwrapTransport(c.client.Transport)
-		t.ExpectContinueTimeout = v
-		c.client.Transport = t
+		unwrappedTransport := unwrapTransport(c.client.Transport)
+		if unwrappedTransport != nil {
+			unwrappedTransport.ExpectContinueTimeout = v
+			c.client.Transport = unwrappedTransport
+		}
 	})
 }
 
 func (b *httpClientBuilder) handleMaxIdleConnsUpdate(c *clientImpl) {
 	b.MaxIdleConns.SubscribeToInt(func(v int) {
-		t := unwrapTransport(c.client.Transport)
-		t.MaxIdleConns = v
-		c.client.Transport = t
+		unwrappedTransport := unwrapTransport(c.client.Transport)
+		if unwrappedTransport != nil {
+			unwrappedTransport.MaxIdleConns = v
+			c.client.Transport = unwrappedTransport
+		}
 	})
 }
 
 func (b *httpClientBuilder) handleMaxIdleConnsPerHostUpdate(c *clientImpl) {
 	b.MaxIdleConnsPerHost.SubscribeToInt(func(v int) {
-		t := unwrapTransport(c.client.Transport)
-		t.MaxIdleConnsPerHost = v
-		c.client.Transport = t
+		unwrappedTransport := unwrapTransport(c.client.Transport)
+		if unwrappedTransport != nil {
+			unwrappedTransport.MaxIdleConnsPerHost = v
+			c.client.Transport = unwrappedTransport
+		}
 	})
 }
 
@@ -69,7 +78,7 @@ func unwrapTransport(rt http.RoundTripper) *http.Transport {
 		case *http.Transport:
 			return v
 		default:
-			panic(fmt.Sprintf("unknown roundtripper type %T", unwrapped))
+			return nil
 		}
 	}
 }

--- a/conjure-go-client/httpclient/refreshable_config.go
+++ b/conjure-go-client/httpclient/refreshable_config.go
@@ -69,6 +69,12 @@ func (b *httpClientBuilder) handleMaxIdleConnsPerHostUpdate(c *clientImpl) {
 	})
 }
 
+func (b *httpClientBuilder) handleHTTPClientTimeoutUpdate(c *clientImpl) {
+	b.Timeout.SubscribeToDuration(func(v time.Duration) {
+		c.client.Timeout = v
+	})
+}
+
 func unwrapTransport(rt http.RoundTripper) *http.Transport {
 	unwrapped := rt
 	for {

--- a/conjure-go-client/httpclient/refreshable_config.go
+++ b/conjure-go-client/httpclient/refreshable_config.go
@@ -21,8 +21,7 @@ import (
 
 func (b *httpClientBuilder) handleIdleConnUpdate(c *clientImpl) {
 	b.IdleConnTimeout.SubscribeToDuration(func(v time.Duration) {
-		unwrappedTransport := unwrapTransport(c.client.Transport)
-		if unwrappedTransport != nil {
+		if unwrappedTransport := unwrapTransport(c.client.Transport); unwrappedTransport != nil {
 			unwrappedTransport.IdleConnTimeout = v
 			c.client.Transport = unwrappedTransport
 		}
@@ -31,8 +30,7 @@ func (b *httpClientBuilder) handleIdleConnUpdate(c *clientImpl) {
 
 func (b *httpClientBuilder) handleTLSHandshakeTimeoutUpdate(c *clientImpl) {
 	b.TLSHandshakeTimeout.SubscribeToDuration(func(v time.Duration) {
-		unwrappedTransport := unwrapTransport(c.client.Transport)
-		if unwrappedTransport != nil {
+		if unwrappedTransport := unwrapTransport(c.client.Transport); unwrappedTransport != nil {
 			unwrappedTransport.TLSHandshakeTimeout = v
 			c.client.Transport = unwrappedTransport
 		}
@@ -41,8 +39,7 @@ func (b *httpClientBuilder) handleTLSHandshakeTimeoutUpdate(c *clientImpl) {
 
 func (b *httpClientBuilder) handleExpectContinueTimeoutUpdate(c *clientImpl) {
 	b.ExpectContinueTimeout.SubscribeToDuration(func(v time.Duration) {
-		unwrappedTransport := unwrapTransport(c.client.Transport)
-		if unwrappedTransport != nil {
+		if unwrappedTransport := unwrapTransport(c.client.Transport); unwrappedTransport != nil {
 			unwrappedTransport.ExpectContinueTimeout = v
 			c.client.Transport = unwrappedTransport
 		}
@@ -51,8 +48,7 @@ func (b *httpClientBuilder) handleExpectContinueTimeoutUpdate(c *clientImpl) {
 
 func (b *httpClientBuilder) handleMaxIdleConnsUpdate(c *clientImpl) {
 	b.MaxIdleConns.SubscribeToInt(func(v int) {
-		unwrappedTransport := unwrapTransport(c.client.Transport)
-		if unwrappedTransport != nil {
+		if unwrappedTransport := unwrapTransport(c.client.Transport); unwrappedTransport != nil {
 			unwrappedTransport.MaxIdleConns = v
 			c.client.Transport = unwrappedTransport
 		}
@@ -61,8 +57,7 @@ func (b *httpClientBuilder) handleMaxIdleConnsUpdate(c *clientImpl) {
 
 func (b *httpClientBuilder) handleMaxIdleConnsPerHostUpdate(c *clientImpl) {
 	b.MaxIdleConnsPerHost.SubscribeToInt(func(v int) {
-		unwrappedTransport := unwrapTransport(c.client.Transport)
-		if unwrappedTransport != nil {
+		if unwrappedTransport := unwrapTransport(c.client.Transport); unwrappedTransport != nil {
 			unwrappedTransport.MaxIdleConnsPerHost = v
 			c.client.Transport = unwrappedTransport
 		}

--- a/conjure-go-client/httpclient/refreshable_config.go
+++ b/conjure-go-client/httpclient/refreshable_config.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"fmt"
+	"time"
+)
+
+func (b *httpClientBuilder) handleIdleConnUpdate(c *clientImpl) {
+	errs := make(chan error, 1)
+	unsubscribeIdleConn := b.IdleConnTimeout.SubscribeToDuration(func(_ time.Duration) {
+		err := rebuildClient(c, b)
+		if err != nil {
+			errs <- err
+		}
+	})
+	go func() {
+		select {
+		case err := <-errs:
+			// TODO: Find a way to pass this back to the service log
+			fmt.Printf("encountered an error whilst updating IdleConn: %s\n", err)
+			unsubscribeIdleConn()
+			close(errs)
+			return
+		case <-b.ctx.Done():
+			close(errs)
+			return
+		}
+	}()
+}
+
+func (b *httpClientBuilder) handleTLSHandshakeTimeoutUpdate(c *clientImpl) {
+	errs := make(chan error, 1)
+	unsubscribeTLSHandshakeTimeout := b.TLSHandshakeTimeout.SubscribeToDuration(func(_ time.Duration) {
+		err := rebuildClient(c, b)
+		if err != nil {
+			errs <- err
+		}
+	})
+	go func() {
+		select {
+		case err := <-errs:
+			// TODO: Find a way to pass this back to the service log
+			fmt.Printf("encountered an error whilst updating TLSHandshakeTimeout: %s\n", err)
+			unsubscribeTLSHandshakeTimeout()
+			close(errs)
+			return
+		case <-b.ctx.Done():
+			close(errs)
+			return
+		}
+	}()
+}
+
+func (b *httpClientBuilder) handleExpectContinueTimeoutUpdate(c *clientImpl) {
+	errs := make(chan error, 1)
+	unsubscribeExpectContinueTimeout := b.ExpectContinueTimeout.SubscribeToDuration(func(_ time.Duration) {
+		err := rebuildClient(c, b)
+		if err != nil {
+			errs <- err
+		}
+	})
+	go func() {
+		select {
+		case err := <-errs:
+			// TODO: Find a way to pass this back to the service log
+			fmt.Printf("encountered an error whilst updating ExpectContinueTimeout: %s\n", err)
+			unsubscribeExpectContinueTimeout()
+			close(errs)
+			return
+		case <-b.ctx.Done():
+			close(errs)
+			return
+		}
+	}()
+}
+
+func (b *httpClientBuilder) handleDialTimeoutUpdate(c *clientImpl) {
+	errs := make(chan error, 1)
+	unsubscribeDialTimeout := b.DialTimeout.SubscribeToDuration(func(_ time.Duration) {
+		err := rebuildClient(c, b)
+		if err != nil {
+			errs <- err
+		}
+	})
+	go func() {
+		select {
+		case err := <-errs:
+			// TODO: Find a way to pass this back to the service log
+			fmt.Printf("encountered an error whilst updating DialTimeout: %s\n", err)
+			unsubscribeDialTimeout()
+			close(errs)
+			return
+		case <-b.ctx.Done():
+			close(errs)
+			return
+		}
+	}()
+}
+
+func rebuildClient(c *clientImpl, b *httpClientBuilder) error {
+	nc, nm, err := httpClientAndRoundTripHandlersFromBuilder(b)
+	if err != nil {
+		return err
+	}
+	c.client = *nc
+	c.middlewares = nm
+	return nil
+}


### PR DESCRIPTION
Makes the following client config options refreshable:
- `IdleConnTimeout`
- `TLSHandshakeTimeout` 
- `ExpectContinueTimeout`
- `MaxIdleConns`
- `MaxIdleConnsPerHost`

Each option is updated via a subscribe triggered from `NewClient`, on change the existing client transport is unwrapped and updated with the new value then the updated transport is added back to the existing client

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/149)
<!-- Reviewable:end -->
