### PR TITLE
Http Client Timeout refreshable support

### DIFF
--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -473,10 +473,9 @@ func WithRefreshableConfig(config RefreshableClientConfig) ClientParam {
 			}
 			return *duration
 		}))
-		b.Timeout = refreshable.NewDuration(config.Map(func(i interface{}) interface{} {
+		b.Timeout = refreshable.NewDuration(config.MapClientConfig(func(i ClientConfig) interface{} {
 			// N.B. we only have one timeout field (not based on method) so just take the max of read and write for now.
-			timeout := maxTimeout(i.(ClientConfig).WriteTimeout, i.(ClientConfig).ReadTimeout)
-			if timeout != 0 {
+			if timeout := maxTimeout(i.WriteTimeout, i.ReadTimeout); timeout != 0 {
 				return timeout
 			}
 			return defaultClientTimeout

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -122,19 +122,19 @@ func TestBuilder(t *testing.T) {
 				// check URIs is set prior to the change
 				assert.Equal(t, []string{testAddr}, client.uris.CurrentStringSlice())
 				// update the client config with a new URI
-				timeout := 1 * time.Minute
+				timeout := 3 * time.Minute
 				maxIdleConns := 200
 				newConfig := ClientConfig{
 					ServiceName:         "test",
 					URIs:                []string{"https://changed-uri.local"},
-					IdleConnTimeout:     &timeout,
+					WriteTimeout:        &timeout,
 					MaxIdleConnsPerHost: &maxIdleConns,
 				}
 				err := refreshableCfg.Update(newConfig)
 				require.NoError(t, err)
 				assert.Equal(t, newConfig.URIs, client.uris.CurrentStringSlice(), "client URIs should be updated with the refreshed values")
 				transport := unwrapTransport(client.client.Transport)
-				assert.Equal(t, timeout, transport.IdleConnTimeout)
+				assert.Equal(t, timeout, client.client.Timeout)
 				assert.Equal(t, maxIdleConns, transport.MaxIdleConnsPerHost)
 			},
 		},

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -289,12 +289,7 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 	}
 
 	// N.B. we only have one timeout field (not based on method) so just take the max of read and write for now.
-	var timeout time.Duration
-	if orZero(c.WriteTimeout) > orZero(c.ReadTimeout) {
-		timeout = *c.WriteTimeout
-	} else if c.ReadTimeout != nil {
-		timeout = *c.ReadTimeout
-	}
+	timeout := maxTimeout(c.WriteTimeout, c.ReadTimeout)
 	if timeout != 0 {
 		params = append(params, WithHTTPTimeout(timeout))
 	}
@@ -324,4 +319,14 @@ func orZero(d *time.Duration) time.Duration {
 		return 0
 	}
 	return *d
+}
+
+func maxTimeout(w, r *time.Duration) time.Duration {
+	var timeout time.Duration
+	if orZero(w) > orZero(r) {
+		timeout = *w
+	} else if r != nil {
+		timeout = *r
+	}
+	return timeout
 }

--- a/conjure-go-client/httpclient/refreshable_config.go
+++ b/conjure-go-client/httpclient/refreshable_config.go
@@ -69,6 +69,12 @@ func (b *httpClientBuilder) handleMaxIdleConnsPerHostUpdate(c *clientImpl) {
 	})
 }
 
+func (b *httpClientBuilder) handleHTTPClientTimeoutUpdate(c *clientImpl) {
+	b.Timeout.SubscribeToDuration(func(v time.Duration) {
+		c.client.Timeout = v
+	})
+}
+
 func unwrapTransport(rt http.RoundTripper) *http.Transport {
 	unwrapped := rt
 	for {


### PR DESCRIPTION
This PR allows HTTP Client timeout to be reloaded from config changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/150)
<!-- Reviewable:end -->
