### PR TITLE
Replace internal usage of "retries" with "attempts"

### DIFF
--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -54,7 +54,7 @@ type clientImpl struct {
 	metricsMiddleware      Middleware
 
 	uris                          []string
-	maxRetries                    int
+	maxAttempts                   int
 	disableTraceHeaderPropagation bool
 	backoffOptions                []retry.Option
 	bufferPool                    bytesbuffers.Pool
@@ -89,7 +89,7 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 	var err error
 	var resp *http.Response
 
-	retrier := internal.NewRequestRetrier(uris, retry.Start(ctx, c.backoffOptions...), c.maxRetries)
+	retrier := internal.NewRequestRetrier(uris, retry.Start(ctx, c.backoffOptions...), c.maxAttempts)
 	for retrier.ShouldGetNextURI(resp, err) {
 		uri, retryErr := retrier.GetNextURI(ctx, resp, err)
 		if retryErr != nil {

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -36,7 +36,7 @@ type clientBuilder struct {
 	httpClientBuilder
 
 	uris                   []string
-	maxRetries             int
+	maxAttempts            int
 	enableUnlimitedRetries bool
 	backoffOptions         []retry.Option
 
@@ -101,15 +101,15 @@ func NewClient(params ...ClientParam) (Client, error) {
 	}
 
 	if b.enableUnlimitedRetries {
-		// max retries of 0 indicates no limit
-		b.maxRetries = 0
-	} else if b.maxRetries == 0 {
-		b.maxRetries = 2 * len(b.uris)
+		// maxAttempts of 0 indicates no limit
+		b.maxAttempts = 0
+	} else if b.maxAttempts == 0 {
+		b.maxAttempts = 2 * len(b.uris)
 	}
 	return &clientImpl{
 		client:                        *client,
 		uris:                          b.uris,
-		maxRetries:                    b.maxRetries,
+		maxAttempts:                   b.maxAttempts,
 		backoffOptions:                b.backoffOptions,
 		disableTraceHeaderPropagation: b.disableTraceHeaderPropagation,
 		middlewares:                   middlewares,

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -385,9 +385,9 @@ func WithInitialBackoff(initialBackoff time.Duration) ClientParam {
 // WithMaxRetries sets the maximum number of retries on transport errors for every request. Backoffs are
 // also capped at this.
 // If unset, the client defaults to 2 * size of URIs
-func WithMaxRetries(maxTransportRetries int) ClientParam {
+func WithMaxRetries(maxTransportAttempts int) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
-		b.maxRetries = maxTransportRetries
+		b.maxAttempts = maxTransportAttempts
 		return nil
 	})
 }

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -107,7 +107,7 @@ func TestBuilder(t *testing.T) {
 			Name:  "UnlimitedRetries",
 			Param: WithUnlimitedRetries(),
 			Test: func(t *testing.T, client *clientImpl) {
-				assert.Equal(t, 0, client.maxRetries)
+				assert.Equal(t, 0, client.maxAttempts)
 			},
 		},
 	} {

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -34,37 +34,37 @@ const (
 // In the case of servers in a service-mesh, requests will never be retried and the mesh URI will only be returned on the
 // first call to GetNextURI
 type RequestRetrier struct {
-	currentURI string
-	retrier    retry.Retrier
-	uris       []string
-	offset     int
-	failedURIs map[string]struct{}
-	maxRetries int
-	retryCount int
+	currentURI   string
+	retrier      retry.Retrier
+	uris         []string
+	offset       int
+	failedURIs   map[string]struct{}
+	maxAttempts  int
+	attemptCount int
 }
 
 // NewRequestRetrier creates a new request retrier.
-// Regardless of maxRetries, mesh URIs will never be retried.
-func NewRequestRetrier(uris []string, retrier retry.Retrier, maxRetries int) *RequestRetrier {
+// Regardless of maxAttempts, mesh URIs will never be retried.
+func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *RequestRetrier {
 	offset := rand.Intn(len(uris))
 	return &RequestRetrier{
-		currentURI: uris[offset],
-		retrier:    retrier,
-		uris:       uris,
-		offset:     offset,
-		failedURIs: map[string]struct{}{},
-		maxRetries: maxRetries,
-		retryCount: 0,
+		currentURI:   uris[offset],
+		retrier:      retrier,
+		uris:         uris,
+		offset:       offset,
+		failedURIs:   map[string]struct{}{},
+		maxAttempts:  maxAttempts,
+		attemptCount: 0,
 	}
 }
 
 // ShouldGetNextURI returns true if GetNextURI has never been called or if the request and its corresponding error
 // indicate the request should be retried.
 func (r *RequestRetrier) ShouldGetNextURI(resp *http.Response, respErr error) bool {
-	if r.retryCount == 0 {
+	if r.attemptCount == 0 {
 		return true
 	}
-	return r.retryCount <= r.maxRetries &&
+	return r.attemptCount <= r.maxAttempts &&
 		!r.isMeshURI(r.currentURI) &&
 		r.responseAndErrRetriable(resp, respErr)
 }
@@ -74,9 +74,9 @@ func (r *RequestRetrier) ShouldGetNextURI(resp *http.Response, respErr error) bo
 // an error will never be returned.
 func (r *RequestRetrier) GetNextURI(ctx context.Context, resp *http.Response, respErr error) (string, error) {
 	defer func() {
-		r.retryCount++
+		r.attemptCount++
 	}()
-	if r.retryCount == 0 {
+	if r.attemptCount == 0 {
 		return r.removeMeshSchemeIfPresent(r.currentURI), nil
 	} else if !r.ShouldGetNextURI(resp, respErr) {
 		return "", r.getErrorForUnretriableResponse(ctx, resp, respErr)
@@ -164,8 +164,8 @@ func (r *RequestRetrier) isMeshURI(uri string) bool {
 func (r *RequestRetrier) getErrorForUnretriableResponse(ctx context.Context, resp *http.Response, respErr error) error {
 	message := "GetNextURI called, but retry should not be attempted"
 	params := []werror.Param{
-		werror.SafeParam("retryCount", r.retryCount),
-		werror.SafeParam("maxRetries", r.maxRetries),
+		werror.SafeParam("attemptCount", r.attemptCount),
+		werror.SafeParam("maxAttempts", r.maxAttempts),
 		werror.SafeParam("statusCodeRetriable", r.responseAndErrRetriable(resp, respErr)),
 		werror.SafeParam("uriInMesh", r.isMeshURI(r.currentURI)),
 	}

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -40,15 +40,15 @@ func TestRequestRetrier_HandleMeshURI(t *testing.T) {
 	require.Contains(t, err.Error(), "GetNextURI called, but retry should not be attempted")
 }
 
-func TestRequestRetrier_RetryCount(t *testing.T) {
+func TestRequestRetrier_AttemptCount(t *testing.T) {
 	ctx := context.Background()
-	maxRetries := 3
-	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(context.Background()), maxRetries)
+	maxAttempts := 3
+	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(context.Background()), maxAttempts)
 	require.True(t, r.ShouldGetNextURI(nil, nil))
 	// first request is not a retry
 	_, err := r.GetNextURI(ctx, nil, nil)
 	require.NoError(t, err)
-	for i := 0; i < maxRetries; i++ {
+	for i := 0; i < maxAttempts; i++ {
 		_, err = r.GetNextURI(ctx, nil, nil)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Replace internal usage of "retries" with "attempts". This does not modify any exporting fields or functions. See https://github.com/palantir/conjure-go-runtime/issues/151 for more information.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/152)
<!-- Reviewable:end -->
