### PR TITLE
Fix request retrier to handle zero retry cases

### DIFF
--- a/changelog/@unreleased/pr-153.v2.yml
+++ b/changelog/@unreleased/pr-153.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fix request retrier to handle `httpclient.WithMaxRetries(0)` client configuration.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/153

--- a/changelog/@unreleased/pr-153.v2.yml
+++ b/changelog/@unreleased/pr-153.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Fix request retrier to handle `httpclient.WithMaxRetries(0)` client configuration.
   links:
   - https://github.com/palantir/conjure-go-runtime/pull/153

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -385,9 +385,10 @@ func WithInitialBackoff(initialBackoff time.Duration) ClientParam {
 // WithMaxRetries sets the maximum number of retries on transport errors for every request. Backoffs are
 // also capped at this.
 // If unset, the client defaults to 2 * size of URIs
-func WithMaxRetries(maxTransportAttempts int) ClientParam {
+// TODO (#151): Rename to WithMaxAttempts and set maxAttempts directly using the argument provided to the function.
+func WithMaxRetries(maxTransportRetries int) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
-		b.maxAttempts = maxTransportAttempts
+		b.maxAttempts = maxTransportRetries + 1
 		return nil
 	})
 }

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -64,7 +64,7 @@ func (r *RequestRetrier) ShouldGetNextURI(resp *http.Response, respErr error) bo
 	if r.attemptCount == 0 {
 		return true
 	}
-	return r.attemptCount <= r.maxAttempts &&
+	return r.attemptCount < r.maxAttempts &&
 		!r.isMeshURI(r.currentURI) &&
 		r.responseAndErrRetriable(resp, respErr)
 }

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -48,7 +48,7 @@ func TestRequestRetrier_AttemptCount(t *testing.T) {
 	// first request is not a retry
 	_, err := r.GetNextURI(ctx, nil, nil)
 	require.NoError(t, err)
-	for i := 0; i < maxAttempts; i++ {
+	for i := 0; i < maxAttempts-1; i++ {
 		_, err = r.GetNextURI(ctx, nil, nil)
 		require.NoError(t, err)
 	}
@@ -65,7 +65,7 @@ func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 	}
 	respWithLocationHeader.Header.Add("Location", "http://example.com")
 	ctx := context.Background()
-	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 1)
+	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 2)
 	require.True(t, r.ShouldGetNextURI(nil, nil))
 	_, err := r.GetNextURI(ctx, nil, nil)
 	require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			retrier := newMockRetrier()
-			r := NewRequestRetrier(tc.uris, retrier, 1)
+			r := NewRequestRetrier(tc.uris, retrier, 2)
 			// first URI isn't a retry
 			firstURI, _ := r.GetNextURI(ctx, nil, nil)
 			if !tc.shouldRetry {


### PR DESCRIPTION
## Before this PR
The current implementation does not allow you to configure the client to make exactly one attempt since the request retrier performs the conditional check `retryCount <= maxRetries` when determining whether it should [retry](https://github.com/palantir/conjure-go-runtime/blob/develop/conjure-go-client/httpclient/internal/request_retrier.go#L67) but the client builder [overrides](https://github.com/palantir/conjure-go-runtime/blob/v2.9.0/conjure-go-client/httpclient/client_builder.go#L106-L108) instances where `maxRetries == 0` with `maxRetries = 2 * len(b.uris)`.

See https://github.com/palantir/conjure-go-runtime/issues/151 for more information.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix request retrier to handle `httpclient.WithMaxRetries(0)` client configuration.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/153)
<!-- Reviewable:end -->
