### PR TITLE
Fix request retrier to handle unlimited retries

### DIFF
--- a/changelog/@unreleased/pr-154.v2.yml
+++ b/changelog/@unreleased/pr-154.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix request retrier to handle unlimited retries.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/154

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -64,9 +64,17 @@ func (r *RequestRetrier) ShouldGetNextURI(resp *http.Response, respErr error) bo
 	if r.attemptCount == 0 {
 		return true
 	}
-	return r.attemptCount < r.maxAttempts &&
+	return r.attemptsRemaining() &&
 		!r.isMeshURI(r.currentURI) &&
 		r.responseAndErrRetriable(resp, respErr)
+}
+
+func (r *RequestRetrier) attemptsRemaining() bool {
+	// maxAttempts of 0 indicates no limit
+	if r.maxAttempts == 0 {
+		return true
+	}
+	return r.attemptCount < r.maxAttempts
 }
 
 // GetNextURI returns the next URI a client should use, or an error if there's no suitable URI.

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -58,6 +58,15 @@ func TestRequestRetrier_AttemptCount(t *testing.T) {
 	require.Contains(t, err.Error(), "GetNextURI called, but retry should not be attempted")
 }
 
+func TestRequestRetrier_UnlimitedAttempts(t *testing.T) {
+	ctx := context.Background()
+	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(context.Background()), 0)
+	_, err := r.GetNextURI(ctx, nil, nil)
+	require.NoError(t, err)
+	// it's probably safe to assume that it will succeed again if it succeeds once
+	require.True(t, r.ShouldGetNextURI(nil, nil))
+}
+
 func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 	respWithLocationHeader := &http.Response{
 		StatusCode: StatusCodeRetryOther,


### PR DESCRIPTION
## Before this PR
The current implementation does not handle the case where [`maxAttempts = 0`](https://github.com/palantir/conjure-go-runtime/blob/v2.9.0/conjure-go-client/httpclient/internal/request_retrier.go#L67) to indicate unlimited attempts.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix request retrier to handle unlimited retries.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/154)
<!-- Reviewable:end -->
