### PR TITLE
Improvement: Surface option for allowing insecure TLS.

### DIFF
--- a/changelog/@unreleased/pr-157.v2.yml
+++ b/changelog/@unreleased/pr-157.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
-fix:
+improvement:
   description: Surface option for allowing insecure TLS
   links:
   - https://github.com/palantir/conjure-go-runtime/pull/157

--- a/changelog/@unreleased/pr-157.v2.yml
+++ b/changelog/@unreleased/pr-157.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+fix:
+  description: Surface option for allowing insecure TLS
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/157

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -302,6 +302,15 @@ func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 	})
 }
 
+// WithTLSInsecureSkipVerify sets the InsecureSkipVerify field for the HTTP client's tls config.
+// This option should only be used in clients that have way to establish trust with servers.
+func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TLSClientConfig.InsecureSkipVerify = true
+		return nil
+	})
+}
+
 // WithDialTimeout sets the timeout on the Dialer.
 // If unset, the client defaults to 30 seconds.
 func WithDialTimeout(timeout time.Duration) ClientOrHTTPClientParam {

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -110,6 +110,14 @@ func TestBuilder(t *testing.T) {
 				assert.Equal(t, 0, client.maxAttempts)
 			},
 		},
+		{
+			Name:  "TLSInsecureSkipVerify",
+			Param: WithTLSInsecureSkipVerify(),
+			Test: func(t *testing.T, client *clientImpl) {
+				transport := unwrapTransport(client.client.Transport)
+				assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+			},
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			client, err := NewClient(test.Param)

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -106,7 +106,6 @@ type SecurityConfig struct {
 	CAFiles  []string `json:"ca-files,omitempty" yaml:"ca-files,omitempty"`
 	CertFile string   `json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
 	KeyFile  string   `json:"key-file,omitempty" yaml:"key-file,omitempty"`
-	CAs      []string `json:"cas"`
 }
 
 // MustClientConfig returns an error if the service name is not configured.

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -106,6 +106,7 @@ type SecurityConfig struct {
 	CAFiles  []string `json:"ca-files,omitempty" yaml:"ca-files,omitempty"`
 	CertFile string   `json:"cert-file,omitempty" yaml:"cert-file,omitempty"`
 	KeyFile  string   `json:"key-file,omitempty" yaml:"key-file,omitempty"`
+	CAs      []string `json:"cas"`
 }
 
 // MustClientConfig returns an error if the service name is not configured.


### PR DESCRIPTION
## Before this PR
CGR users cannot construct clients with tls.Config.InsecureSkipVerify=true without having to repeat the TLS config construction CGR does in its `httpclient.WithConfig()` method.

## After this PR
CGR users can now set InsecureSkipVerify while still leveraging CGR's other handling of tls Config construction in the `httpclient.WithConfig()` method.
==COMMIT_MSG==
Surface option for allowing insecure TLS.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/157)
<!-- Reviewable:end -->
