### PR TITLE
Set default connect-timeout to match the one in CJR

### DIFF
--- a/changelog/@unreleased/pr-160.v2.yml
+++ b/changelog/@unreleased/pr-160.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Set default connect-timeout to 10s
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/160

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -125,7 +125,7 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 		// These values are primarily pulled from http.DefaultTransport.
 		TLSClientConfig:       defaultTLSConfig,
 		Timeout:               1 * time.Minute,
-		DialTimeout:           30 * time.Second,
+		DialTimeout:           10 * time.Second,
 		KeepAlive:             30 * time.Second,
 		EnableIPV6:            false,
 		DisableHTTP2:          false,


### PR DESCRIPTION
Why?

Having a connect timeout of 30s causes a lot of delay in switching to the next URI when a host or service is unavailable. This can result in other timeouts like upgrade plans etc failing as state has not propagated through various systems. We have had to override the connect timeout in various services to protect against a single node fault causing service failures. Since CJR sets the [default dial/connect timeout to 10s](https://github.com/palantir/conjure-java-runtime/blob/develop/client-config/src/main/java/com/palantir/conjure/java/client/config/ClientConfigurations.java#L49), this PR matches for consistency and avoiding failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/160)
<!-- Reviewable:end -->
