### PR TITLE
Allow retry and fetch next URI on status code 307

### DIFF
--- a/changelog/@unreleased/pr-174.v2.yml
+++ b/changelog/@unreleased/pr-174.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow retry and fetch next URI on status code 307
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/174

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -116,7 +116,7 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() {
 		// Or if we get a nil response, we can assume there is a problem with host and can move on to the next.
 		return r.nextURIOrBackoff
 	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp); shouldTryOther {
-		// 308: go to next node, or particular node if provided.
+		// 307 or 308: go to next node, or particular node if provided.
 		if otherURI != nil {
 			return func() {
 				r.setURIAndResetBackoff(otherURI)

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -209,6 +209,30 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			shouldRetryBackoff: true,
 			shouldRetryReset:   false,
 		},
+		{
+			name: "retries another URI if gets retry temporary redirect response without location",
+			resp: &http.Response{
+				StatusCode: StatusCodeRetryTemporaryRedirect,
+			},
+			respErr:            nil,
+			uris:               []string{"a", "b"},
+			shouldRetry:        true,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name: "retries single URI and backs off if gets retry temporary redirect response without location",
+			resp: &http.Response{
+				StatusCode: StatusCodeRetryTemporaryRedirect,
+			},
+			respErr:            nil,
+			uris:               []string{"a"},
+			shouldRetry:        true,
+			shouldRetrySameURI: true,
+			shouldRetryBackoff: true,
+			shouldRetryReset:   false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/conjure-go-client/httpclient/internal/retry.go
+++ b/conjure-go-client/httpclient/internal/retry.go
@@ -34,6 +34,7 @@ The QosExceptions have a stable mapping to HTTP status codes and response header
 
 * throttle: 429 Too Many Requests, plus optional Retry-After header
 * retryOther: 308 Permanent Redirect, plus Location header indicating the target host
+* retryTemporaryRedirect: 307 Temporary Redirect, plus Location header indicating the target host
 * unavailable: 503 Unavailable
 
 http-remoting clients (both Retrofit2 and JaxRs) handle the above error codes and take the appropriate action:
@@ -52,13 +53,18 @@ The number of retries for 503 and connection errors can be configured via Client
 */
 
 const (
-	StatusCodeRetryOther  = http.StatusPermanentRedirect
-	StatusCodeThrottle    = http.StatusTooManyRequests
-	StatusCodeUnavailable = http.StatusServiceUnavailable
+	StatusCodeRetryOther             = http.StatusPermanentRedirect
+	StatusCodeRetryTemporaryRedirect = http.StatusTemporaryRedirect
+	StatusCodeThrottle               = http.StatusTooManyRequests
+	StatusCodeUnavailable            = http.StatusServiceUnavailable
 )
 
 func isRetryOtherResponse(resp *http.Response) (bool, *url.URL) {
-	if resp == nil || resp.StatusCode != StatusCodeRetryOther {
+	if resp == nil {
+		return false, nil
+	}
+	if resp.StatusCode != StatusCodeRetryOther &&
+		resp.StatusCode != StatusCodeRetryTemporaryRedirect {
 		return false, nil
 	}
 	locationStr := resp.Header.Get("Location")

--- a/conjure-go-client/httpclient/internal/retry_test.go
+++ b/conjure-go-client/httpclient/internal/retry_test.go
@@ -42,6 +42,23 @@ func TestRetryResponseParsers(t *testing.T) {
 			},
 		},
 		{
+			Name: "307 RetryTemporaryRedirect without Location",
+			Response: &http.Response{
+				Header:     http.Header{},
+				StatusCode: 307,
+			},
+			IsRetryOther: true,
+		},
+		{
+			Name: "307 RetryTemporaryRedirect with Location",
+			Response: &http.Response{
+				Header:     http.Header{"Location": []string{"https://host-2:8443/app"}},
+				StatusCode: 307,
+			},
+			IsRetryOther:  true,
+			RetryOtherURL: "https://host-2:8443/app",
+		},
+		{
 			Name: "308 RetryOther without Location",
 			Response: &http.Response{
 				Header:     http.Header{},


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Allow retry and fetch next URI on status code 307

Currently the retrier only retry the request when getting 308s not 307s. This change will allow the client to retry on 307s as well with next location from header.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow retry and fetch next URI on status code 307
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/174)
<!-- Reviewable:end -->
