### PR TITLE
Skip decoding the body if response status is redirect

### DIFF
--- a/changelog/@unreleased/pr-177.v2.yml
+++ b/changelog/@unreleased/pr-177.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Skip decoding the body if response status is redirect
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/177

--- a/conjure-go-client/httpclient/body_handler.go
+++ b/conjure-go-client/httpclient/body_handler.go
@@ -16,11 +16,11 @@ package httpclient
 
 import (
 	"bytes"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"io"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/bytesbuffers"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -119,6 +119,7 @@ func (b *bodyMiddleware) readResponse(resp *http.Response, respErr error) error 
 
 	// Verify the response status. If the response is redirect, no need to decode the body
 	// the client will retry on the new location in the header
+	// TODO: could remove this once #81 is resolved
 	if resp.StatusCode == internal.StatusCodeRetryOther ||
 		resp.StatusCode == internal.StatusCodeRetryTemporaryRedirect {
 		return nil

--- a/conjure-go-client/httpclient/body_handler.go
+++ b/conjure-go-client/httpclient/body_handler.go
@@ -16,6 +16,7 @@ package httpclient
 
 import (
 	"bytes"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -113,6 +114,13 @@ func (b *bodyMiddleware) readResponse(resp *http.Response, respErr error) error 
 	// Verify we have a body to unmarshal. If the request was unsuccessful, the errorMiddleware will
 	// set a non-nil error and return no response.
 	if b.responseOutput == nil || resp == nil || resp.Body == nil || resp.ContentLength == 0 {
+		return nil
+	}
+
+	// Verify the response status. If the response is redirect, no need to decode the body
+	// the client will retry on the new location in the header
+	if resp.StatusCode == internal.StatusCodeRetryOther ||
+		resp.StatusCode == internal.StatusCodeRetryTemporaryRedirect {
 		return nil
 	}
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Skip decoding the body if response status is redirect

Currently if the response status code is 307/308 (redirect) and the response body is in a format (e.g. text/html) that the decoder does not expected, the request will fail. 

Add a logic to skip the body decoding if redirecting.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Skip decoding the body if response status is redirect
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/177)
<!-- Reviewable:end -->
