### PR TITLE
Fix: Avoid double encoding URL parameters

### DIFF
--- a/changelog/@unreleased/pr-182.v2.yml
+++ b/changelog/@unreleased/pr-182.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Avoid double encoding URL parameters
+    Fixes: #181
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/182

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -137,10 +137,7 @@ func (c *clientImpl) doOnce(
 	if b.method == "" {
 		return nil, werror.Error("httpclient: use WithRequestMethod() to specify HTTP method")
 	}
-	reqURI, err := joinURIAndPath(baseURI, b.path)
-	if err != nil {
-		return nil, err
-	}
+	reqURI := joinURIAndPath(baseURI, b.path)
 	req, err := http.NewRequest(b.method, reqURI, nil)
 	if err != nil {
 		return nil, werror.Wrap(err, "failed to build new HTTP request")
@@ -223,15 +220,10 @@ func (c *clientImpl) initializeRequestHeaders(ctx context.Context) http.Header {
 	return headers
 }
 
-func joinURIAndPath(baseURI, reqPath string) (string, error) {
-	uri, err := url.Parse(baseURI)
-	if err != nil {
-		return "", werror.Wrap(err, "failed to parse request URL")
-	}
-
+func joinURIAndPath(baseURI, reqPath string) string {
+	fullURI := strings.Trim(baseURI, "/")
 	if reqPath != "" {
-		uri.Path = strings.TrimRight(uri.Path, "/") + "/" + strings.TrimLeft(reqPath, "/")
+		fullURI += "/" + strings.TrimLeft(reqPath, "/")
 	}
-
-	return uri.String(), nil
+	return fullURI
 }

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -221,7 +221,7 @@ func (c *clientImpl) initializeRequestHeaders(ctx context.Context) http.Header {
 }
 
 func joinURIAndPath(baseURI, reqPath string) string {
-	fullURI := strings.Trim(baseURI, "/")
+	fullURI := strings.TrimRight(baseURI, "/")
 	if reqPath != "" {
 		fullURI += "/" + strings.TrimLeft(reqPath, "/")
 	}

--- a/conjure-go-client/httpclient/client_path_test.go
+++ b/conjure-go-client/httpclient/client_path_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestJoinURIandPath(t *testing.T) {
@@ -72,10 +71,14 @@ func TestJoinURIandPath(t *testing.T) {
 			"",
 			"https://localhost/api",
 		},
+		{
+			"https://localhost",
+			"/api/+ti%2FQojjmKJxpxmY%2FA=",
+			"https://localhost/api/+ti%2FQojjmKJxpxmY%2FA=",
+		},
 	} {
 		t.Run("", func(t *testing.T) {
-			actual, err := joinURIAndPath(test.baseURI, test.reqPath)
-			require.NoError(t, err)
+			actual := joinURIAndPath(test.baseURI, test.reqPath)
 			assert.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
## Before this PR
When joining the base URI and request path, the `url.String()` method would encode any parameters that were already encoded. This was introduced as a result of #155.
See #181 for more details.

This came up from an issue I encountered with an internal product where transaction IDs can contain `/` and they were being double encoded causing transactions to fail due to mismatched IDs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Avoid double encoding URL parameters
Fixes: #181 
==COMMIT_MSG==

## Notes
- I opted for a fairly naive implementation that still passes all tests for URI/path joining and is more similar to the previous implementation before #155. I am open to any alternatives if you have thoughts.
- It is possible to use the `net/url` pkg for this but it seems even more brittle. Basically you set the `url.RawPath` to the already escaped path, then unescape the `url.Path` so that the following logic ([here](https://github.com/golang/go/blob/8b462d75670dcd8b6a08cf9af225eb8e7628d412/src/net/url/url.go#L701-L704)) will work.
```go
uri, err := url.Parse(baseURI)
if err != nil {
	return "", werror.Wrap(err, "failed to parse request URL")
}

if reqPath != "" {
	// set the RawPath instead of Path
	uri.RawPath = strings.TrimRight(uri.Path, "/") + "/" + strings.TrimLeft(reqPath, "/")
}
// unescape the RawPath and set the original path
uri.Path, err = url.PathUnescape(uri.RawPath)
if err != nil {
	return "", werror.Wrap(err, "failed to unescape the raw path")
}

return uri.String(), nil
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/182)
<!-- Reviewable:end -->
