### PR TITLE
improvement: Add metric tag family:timeout for timeout/cancel errors

### DIFF
--- a/changelog/@unreleased/pr-187.v2.yml
+++ b/changelog/@unreleased/pr-187.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metric tag family:timeout for timeout/cancel errors
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/187

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -17,6 +17,7 @@ package httpclient
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -60,6 +61,7 @@ var (
 )
 
 // A TagsProvider returns metrics tags based on an http round trip.
+// The 'error' argument is that returned from the request (if any).
 type TagsProvider interface {
 	Tags(*http.Request, *http.Response, error) metrics.Tags
 }
@@ -244,10 +246,10 @@ func isTimeoutError(respErr error) bool {
 	if nerr, ok := rootErr.(net.Error); ok && nerr.Timeout() {
 		return true
 	}
-	if rootErr == context.Canceled || rootErr == context.DeadlineExceeded {
+	if errors.Is(rootErr, context.Canceled) || errors.Is(rootErr, context.DeadlineExceeded) {
 		return true
 	}
-	//N.B. the http package does not expose these error types
+	// N.B. the http package does not expose these error types
 	if rootErr.Error() == "net/http: request canceled" || rootErr.Error() == "net/http: request canceled while waiting for connection" {
 		return true
 	}

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -57,7 +57,6 @@ var (
 	metricTagFamily5xx     = metrics.MustNewTag(metricTagFamily, "5xx")
 	metricTagFamilyOther   = metrics.MustNewTag(metricTagFamily, "other")
 	metricTagFamilyTimeout = metrics.MustNewTag(metricTagFamily, "timeout")
-	metricTagFamilyUnknown = metrics.MustNewTag(metricTagFamily, "unknown")
 )
 
 // A TagsProvider returns metrics tags based on an http round trip.
@@ -148,7 +147,7 @@ func tagStatusFamily(_ *http.Request, resp *http.Response, respErr error) metric
 		return metrics.Tags{metricTagFamily5xx}
 	}
 	// unreachable
-	return metrics.Tags{metricTagFamilyUnknown}
+	return metrics.Tags{}
 }
 
 func tagRequestMethod(req *http.Request, _ *http.Response, _ error) metrics.Tags {

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -229,10 +229,6 @@ func TestMetricsMiddleware_ClientTimeout(t *testing.T) {
 		httpclient.WithMetrics())
 	require.NoError(t, err)
 
-	//req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	//require.NoError(t, err)
-	//req = req.WithContext(httpclient.ContextWithRPCMethodName(ctx, "test-endpoint"))
-
 	_, err = client.Get(ctx, httpclient.WithRPCMethodName("test-endpoint"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -250,7 +250,7 @@ func TestMetricsMiddleware_ClientTimeout(t *testing.T) {
 	assert.True(t, found, "did not find client.response metric")
 }
 
-func TestMetricsMiddleware_ContextCancelled(t *testing.T) {
+func TestMetricsMiddleware_ContextCanceled(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
 	}))

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -33,7 +33,7 @@ type fakeTagsProviderFunc struct {
 	key, val string
 }
 
-func (ftpf fakeTagsProviderFunc) Tags(_ *http.Request, _ *http.Response) metrics.Tags {
+func (ftpf fakeTagsProviderFunc) Tags(_ *http.Request, _ *http.Response, _ error) metrics.Tags {
 	return metrics.Tags{
 		metrics.MustNewTag(ftpf.key, ftpf.val),
 	}
@@ -207,6 +207,49 @@ func TestMetricsMiddleware_HTTPClient(t *testing.T) {
 			metrics.MustNewTag("service-name", "test-service"): {},
 		}
 		assert.Equal(t, expectedTags, tags.ToSet())
+	})
+	assert.True(t, found, "did not find client.response metric")
+}
+
+func TestMetricsMiddleware_ClientTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(time.Second)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	rootRegistry := metrics.NewRootMetricsRegistry()
+	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
+
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{srv.URL}),
+		httpclient.WithTLSInsecureSkipVerify(),
+		httpclient.WithServiceName("test-service"),
+		httpclient.WithHTTPTimeout(time.Millisecond),
+		httpclient.WithMetrics())
+	require.NoError(t, err)
+
+	//req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	//require.NoError(t, err)
+	//req = req.WithContext(httpclient.ContextWithRPCMethodName(ctx, "test-endpoint"))
+
+	_, err = client.Get(ctx, httpclient.WithRPCMethodName("test-endpoint"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
+
+	found := false
+	rootRegistry.Each(func(name string, tags metrics.Tags, value metrics.MetricVal) {
+		if name != "client.response" {
+			return
+		}
+		found = true
+		expectedTags := map[metrics.Tag]struct{}{
+			metrics.MustNewTag("family", "timeout"):            {},
+			metrics.MustNewTag("method", "get"):                {},
+			metrics.MustNewTag("method-name", "test-endpoint"): {},
+			metrics.MustNewTag("service-name", "test-service"): {},
+		}
+		assert.Equal(t, expectedTags, tags.ToSet(), "expected timeout tags for %v", err)
 	})
 	assert.True(t, found, "did not find client.response metric")
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/187)
<!-- Reviewable:end -->
