### PR TITLE
Check return value of retrier.Next() before retrying

### DIFF
--- a/changelog/@unreleased/pr-188.v2.yml
+++ b/changelog/@unreleased/pr-188.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Check return value of `retrier.Next()` before retrying
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/188


### PR DESCRIPTION
## Before this PR
Previously we would ignore the value of `retrier.Next()`, which should be used to determine whether to retry

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Check return value of `retrier.Next()` before retrying
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/188)
<!-- Reviewable:end -->
