### PR TITLE
randomize order of URIs in request retrier

### DIFF
--- a/changelog/@unreleased/pr-190.v2.yml
+++ b/changelog/@unreleased/pr-190.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: randomize order of URIs in request retrier
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/190

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -192,13 +192,13 @@ func TestFailoverDistribution(t *testing.T) {
 	// Disable one server
 	servers[0].Close()
 	for i := 0; i < requests; i++ {
-			_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
-			assert.NoError(t, err)
+		_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
+		assert.NoError(t, err)
 	}
 	assert.Equal(t, requests, totalHits)
 	for i := 0; i < serverCount; i++ {
 		// Validate that requests are evenly distributed across servers
-		assert.True(t, serverHits[i] < 2 * requests / serverCount)
+		assert.True(t, serverHits[i] < 2*requests/serverCount)
 	}
 }
 
@@ -227,10 +227,10 @@ func TestSleep(t *testing.T) {
 }
 
 func TestRoundRobin(t *testing.T) {
-	requestsPerSever := make([]int, 3)
+	requestsPerServer := make([]int, 3)
 	getHandler := func(i int) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			requestsPerSever[i]++
+			requestsPerServer[i]++
 			rw.WriteHeader(http.StatusServiceUnavailable)
 		})
 	}
@@ -241,7 +241,7 @@ func TestRoundRobin(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
 	assert.Error(t, err)
-	assert.Equal(t, []int{2, 2, 2}, requestsPerSever)
+	assert.Equal(t, []int{2, 2, 2}, requestsPerServer)
 }
 
 func TestFailover_ConnectionRefused(t *testing.T) {

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -46,7 +46,8 @@ type RequestRetrier struct {
 // Regardless of maxAttempts, mesh URIs will never be retried.
 func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *RequestRetrier {
 	offset := 0
-	urisCopy := append([]string(nil), uris...)
+	urisCopy := make([]string, len(uris))
+	copy(urisCopy, uris)
 	rand.Shuffle(len(urisCopy), func(i, j int) { urisCopy[i], urisCopy[j] = urisCopy[j], urisCopy[i] })
 	return &RequestRetrier{
 		currentURI:    uris[offset],

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -50,7 +50,7 @@ func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *R
 	copy(urisCopy, uris)
 	rand.Shuffle(len(urisCopy), func(i, j int) { urisCopy[i], urisCopy[j] = urisCopy[j], urisCopy[i] })
 	return &RequestRetrier{
-		currentURI:    uris[offset],
+		currentURI:    urisCopy[offset],
 		retrier:       retrier,
 		uris:          urisCopy,
 		offset:        offset,

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -45,11 +45,13 @@ type RequestRetrier struct {
 // NewRequestRetrier creates a new request retrier.
 // Regardless of maxAttempts, mesh URIs will never be retried.
 func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *RequestRetrier {
-	offset := rand.Intn(len(uris))
+	offset := 0
+	urisCopy := append([]string(nil), uris...)
+	rand.Shuffle(len(urisCopy), func(i, j int) { urisCopy[i], urisCopy[j] = urisCopy[j], urisCopy[i] })
 	return &RequestRetrier{
 		currentURI:    uris[offset],
 		retrier:       retrier,
-		uris:          uris,
+		uris:          urisCopy,
 		offset:        offset,
 		relocatedURIs: map[string]struct{}{},
 		failedURIs:    map[string]struct{}{},


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Since the ordering of URIs in the request retrier is unchanged across requests, when a single URI is unavailable it means that the next URI in the sequence has a 2/N probability of being hit instead of 1/N because requests to the down URI are also sent to it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
randomize order of URIs in request retrier
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/190)
<!-- Reviewable:end -->
