### PR TITLE
Use http.ProxyFromEnvironment by default

### DIFF
--- a/changelog/@unreleased/pr-192.v2.yml
+++ b/changelog/@unreleased/pr-192.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Respect proxy information specified via environment variables by default
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/192

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -123,6 +123,7 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 	defaultTLSConfig, _ := tlsconfig.NewClientConfig()
 	return &httpClientBuilder{
 		// These values are primarily pulled from http.DefaultTransport.
+		Proxy:                 http.ProxyFromEnvironment,
 		TLSClientConfig:       defaultTLSConfig,
 		Timeout:               1 * time.Minute,
 		DialTimeout:           10 * time.Second,

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -52,15 +52,6 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			Name:  "NoProxy",
-			Param: WithNoProxy(),
-			Test: func(t *testing.T, client *clientImpl) {
-				transport := unwrapTransport(client.client.Transport)
-				proxy := transport.Proxy
-				assert.Nil(t, proxy)
-			},
-		},
-		{
 			Name:  "MaxIdleConns",
 			Param: WithMaxIdleConns(100),
 			Test: func(t *testing.T, client *clientImpl) {
@@ -77,10 +68,42 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			Name:  "ProxyURL",
+			Name:  "ProxyFromEnvironment by default",
+			Param: nil,
+			Test: func(t *testing.T, client *clientImpl) {
+				require.NoError(t, os.Setenv("https_proxy", testURL.String()))
+				transport := unwrapTransport(client.client.Transport)
+				resp, err := transport.Proxy(&http.Request{URL: testURL})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Equal(t, testURL.String(), resp.String())
+			},
+		},
+		{
+			Name:  "NoProxy",
+			Param: WithNoProxy(),
+			Test: func(t *testing.T, client *clientImpl) {
+				transport := unwrapTransport(client.client.Transport)
+				proxy := transport.Proxy
+				assert.Nil(t, proxy)
+			},
+		},
+		{
+			Name:  "ProxyFromEnvironment",
 			Param: WithProxyFromEnvironment(),
 			Test: func(t *testing.T, client *clientImpl) {
 				require.NoError(t, os.Setenv("https_proxy", testURL.String()))
+				transport := unwrapTransport(client.client.Transport)
+				resp, err := transport.Proxy(&http.Request{URL: testURL})
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Equal(t, testURL.String(), resp.String())
+			},
+		},
+		{
+			Name:  "ProxyURL",
+			Param: WithProxyURL(testURL.String()),
+			Test: func(t *testing.T, client *clientImpl) {
 				transport := unwrapTransport(client.client.Transport)
 				resp, err := transport.Proxy(&http.Request{URL: testURL})
 				require.NoError(t, err)

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -192,7 +192,7 @@ func TestErrorDecoderMiddlewares(t *testing.T) {
 			tsURL, err := url.Parse(ts.URL)
 			require.NoError(t, err)
 
-			client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{ts.URL}), tc.decoderParam)
+			client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{ts.URL}), httpclient.WithNoProxy(), tc.decoderParam)
 			require.NoError(t, err)
 
 			_, err = client.Get(ctx, httpclient.WithPath("/path"))


### PR DESCRIPTION
## Before this PR
We do not respect proxy information specified via environment variables by default.

This is despite what our docs say at the moment: https://github.com/palantir/conjure-go-runtime/blob/develop/conjure-go-client/httpclient/client_params.go#L278

This is also inline with default Golang behaviour with `http.DefaultTransport`: https://github.com/golang/go/blob/master/src/net/http/transport.go#L43

## After this PR
==COMMIT_MSG==
Respect proxy information specified via environment variables by default
==COMMIT_MSG==

## Possible downsides?
Misconfigured proxy information where only `http_proxy` is set and not coupled with an appropriate `no_proxy` could cause the proxy to get used incorrectly, causing a break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/192)
<!-- Reviewable:end -->
