### PR TITLE
Improvement: Generic conjure errors include errorName safe param

### DIFF
--- a/changelog/@unreleased/pr-198.v2.yml
+++ b/changelog/@unreleased/pr-198.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Generic conjure errors include errorName safe param
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/198

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -159,7 +159,7 @@ func TestErrorDecoderMiddlewares(t *testing.T) {
 				assert.Equal(t, errors.DefaultNotFound.Name(), conjureErr.Name())
 
 				safeParams, unsafeParams := werror.ParamsFromError(err)
-				assert.Equal(t, map[string]interface{}{"requestHost": u.Host, "requestMethod": "Get", "errorInstanceId": id, "statusCode": 404}, safeParams)
+				assert.Equal(t, map[string]interface{}{"requestHost": u.Host, "requestMethod": "Get", "errorInstanceId": id, "errorName": "Default:NotFound", "statusCode": 404}, safeParams)
 				assert.Equal(t, map[string]interface{}{"requestPath": "/path", "stringParam": "stringValue"}, unsafeParams)
 			},
 		},

--- a/conjure-go-contract/errors/generic_error.go
+++ b/conjure-go-contract/errors/generic_error.go
@@ -105,6 +105,7 @@ func (e genericError) safeParams() map[string]interface{} {
 		safeParams[k] = v
 	}
 	safeParams["errorInstanceId"] = e.errorInstanceID
+	safeParams["errorName"] = e.Name()
 	return safeParams
 }
 

--- a/conjure-go-contract/errors/unmarshal_test.go
+++ b/conjure-go-contract/errors/unmarshal_test.go
@@ -44,7 +44,7 @@ func TestUnmarshalError(t *testing.T) {
 				Parameters:      json.RawMessage(`{"ttl":"10s"}`),
 			},
 			verify: func(t *testing.T, actual errors.Error) {
-				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{"ttl": "10s"}, actual.UnsafeParams())
 			},
 		},
@@ -57,7 +57,7 @@ func TestUnmarshalError(t *testing.T) {
 				Parameters:      json.RawMessage(`{"ttl":"10s"}`),
 			},
 			verify: func(t *testing.T, actual errors.Error) {
-				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{"ttl": "10s"}, actual.UnsafeParams())
 			},
 		},
@@ -69,7 +69,7 @@ func TestUnmarshalError(t *testing.T) {
 				ErrorInstanceID: uuid.NewUUID(),
 			},
 			verify: func(t *testing.T, actual errors.Error) {
-				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{}, actual.UnsafeParams())
 			},
 		},
@@ -81,7 +81,7 @@ func TestUnmarshalError(t *testing.T) {
 				ErrorInstanceID: uuid.NewUUID(),
 			},
 			verify: func(t *testing.T, actual errors.Error) {
-				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{}, actual.UnsafeParams())
 			},
 		},
@@ -93,7 +93,7 @@ func TestUnmarshalError(t *testing.T) {
 				ErrorInstanceID: uuid.NewUUID(),
 			},
 			verify: func(t *testing.T, actual errors.Error) {
-				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{}, actual.UnsafeParams())
 			},
 		},
@@ -107,7 +107,7 @@ func TestUnmarshalError(t *testing.T) {
 			},
 			verify: func(t *testing.T, actual errors.Error) {
 				assert.Equal(t, testErrorTypeParams{IntArg: 3, StringArg: "foo"}, actual.(*testErrorType).Parameters)
-				assert.Equal(t, map[string]interface{}{"intArg": 3, "errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"intArg": 3, "errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{"stringArg": "foo"}, actual.UnsafeParams())
 			},
 		},
@@ -120,7 +120,7 @@ func TestUnmarshalError(t *testing.T) {
 				Parameters:      json.RawMessage(`{"intArg": 3, "stringArg": "foo"}`),
 			},
 			verify: func(t *testing.T, actual errors.Error) {
-				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
 				assert.Equal(t, map[string]interface{}{"intArg": json.Number("3"), "stringArg": "foo"}, actual.UnsafeParams())
 			},
 		},
@@ -196,7 +196,7 @@ func (e *testErrorType) InstanceID() uuid.UUID {
 }
 
 func (e *testErrorType) SafeParams() map[string]interface{} {
-	return map[string]interface{}{"intArg": e.Parameters.IntArg, "errorInstanceId": e.InstanceID()}
+	return map[string]interface{}{"intArg": e.Parameters.IntArg, "errorInstanceId": e.InstanceID(), "errorName": e.Name()}
 }
 
 func (e *testErrorType) UnsafeParams() map[string]interface{} {

--- a/conjure-go-contract/errors/wrap_test.go
+++ b/conjure-go-contract/errors/wrap_test.go
@@ -31,7 +31,7 @@ func TestNewWrappedError(t *testing.T) {
 
 		result := errors.NewWrappedError(cerr, err)
 		assert.Contains(t, result.Error(), "an error: INTERNAL Default:Internal")
-		assert.Equal(t, map[string]interface{}{"intParam": 42, "errorInstanceId": cerr.InstanceID()}, result.(wparams.ParamStorer).SafeParams())
+		assert.Equal(t, map[string]interface{}{"intParam": 42, "errorInstanceId": cerr.InstanceID(), "errorName": cerr.Name()}, result.(wparams.ParamStorer).SafeParams())
 		assert.Equal(t, map[string]interface{}{"stringParam": "stringValue"}, result.(wparams.ParamStorer).UnsafeParams())
 	})
 	t.Run("wrap with plain error", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestNewWrappedError(t *testing.T) {
 
 		result := errors.NewWrappedError(cerr, err)
 		assert.Contains(t, result.Error(), "an error: INTERNAL Default:Internal")
-		assert.Equal(t, map[string]interface{}{"intParam": 42, "errorInstanceId": cerr.InstanceID()}, result.(wparams.ParamStorer).SafeParams())
+		assert.Equal(t, map[string]interface{}{"intParam": 42, "errorInstanceId": cerr.InstanceID(), "errorName": cerr.Name()}, result.(wparams.ParamStorer).SafeParams())
 		assert.Equal(t, map[string]interface{}{}, result.(wparams.ParamStorer).UnsafeParams())
 	})
 }

--- a/conjure-go-server/httpserver/handlers_test.go
+++ b/conjure-go-server/httpserver/handlers_test.go
@@ -167,7 +167,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "ERROR", logLine["level"])
 				assert.Equal(t, fmt.Sprintf("error handling request: INTERNAL Default:Internal (%v)", conjure500Err.InstanceID()), logLine["message"])
-				assert.Equal(t, map[string]interface{}{"param": "value", "errorInstanceId": conjure500Err.InstanceID().String()}, logLine["params"])
+				assert.Equal(t, map[string]interface{}{"param": "value", "errorInstanceId": conjure500Err.InstanceID().String(), "errorName": conjure500Err.Name()}, logLine["params"])
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "INFO", logLine["level"])
 				assert.Equal(t, fmt.Sprintf("error handling request: NOT_FOUND Default:NotFound (%v)", conjure404Err.InstanceID()), logLine["message"])
-				assert.Equal(t, map[string]interface{}{"param": "value", "errorInstanceId": conjure404Err.InstanceID().String()}, logLine["params"])
+				assert.Equal(t, map[string]interface{}{"param": "value", "errorInstanceId": conjure404Err.InstanceID().String(), "errorName": conjure404Err.Name()}, logLine["params"])
 			},
 		},
 		{
@@ -213,7 +213,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "INFO", logLine["level"])
 				assert.Equal(t, fmt.Sprintf("error handling request: a bad thing: NOT_FOUND Default:NotFound (%v)", conjure404Err.InstanceID()), logLine["message"])
-				assert.Equal(t, map[string]interface{}{"param": "value", "errorInstanceId": conjure404Err.InstanceID().String()}, logLine["params"])
+				assert.Equal(t, map[string]interface{}{"param": "value", "errorInstanceId": conjure404Err.InstanceID().String(), "errorName": conjure404Err.Name()}, logLine["params"])
 				assert.Equal(t, map[string]interface{}{"unsafeParam": "unsafeValue"}, logLine["unsafeParams"])
 			},
 		},


### PR DESCRIPTION

==COMMIT_MSG==
Generic conjure errors include errorName safe param
==COMMIT_MSG==

This brings generic errors to parity with generated conjure errors after https://github.com/palantir/conjure-go/pull/211.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/198)
<!-- Reviewable:end -->
