### PR TITLE
Add balanced scoring middleware to improve client-side load-balancing based on server responses

### DIFF
--- a/changelog/@unreleased/pr-208.v2.yml
+++ b/changelog/@unreleased/pr-208.v2.yml
@@ -1,6 +1,9 @@
 type: improvement
 improvement:
-  description: Add balanced scoring middleware to improve client-side load-balancing
-    based on server responses
+  description: |
+    Add balanced scoring middleware to improve client-side load-balancing based on server responses. Middleware tracks
+    in-flight requests and recent failures per URI to prioritize URIs with fewer in-flight requests and recent failures.
+    This improves average latency in cases which some URIs are unavailable or respond significantly faster or slower
+    than others.
   links:
   - https://github.com/palantir/conjure-go-runtime/pull/208

--- a/changelog/@unreleased/pr-208.v2.yml
+++ b/changelog/@unreleased/pr-208.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Add balanced scoring middleware to improve client-side load-balancing
+    based on server responses
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/208

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -55,8 +55,7 @@ type clientImpl struct {
 	errorDecoderMiddleware Middleware
 	metricsMiddleware      Middleware
 
-	uris                          []string
-	uriScorer                     internal.BalancedURIScoringMiddleware
+	uriScorer                     internal.URIScoringMiddleware
 	maxAttempts                   int
 	disableTraceHeaderPropagation bool
 	backoffOptions                []retry.Option

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -161,6 +161,8 @@ func (c *clientImpl) doOnce(
 		// must precede the error decoders because they return a nil response and the metrics need the status code of
 		// the raw response.
 		c.metricsMiddleware,
+		// must precede the error decoders because they return a nil response and the scorer needs the status code of
+		// the raw response.
 		c.uriScorer,
 		// must precede the client error decoder
 		b.errorDecoderMiddleware,

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -18,6 +18,7 @@ package httpclient
 import (
 	"context"
 	"crypto/tls"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"net"
 	"net/http"
 	"net/url"
@@ -109,6 +110,7 @@ func NewClient(params ...ClientParam) (Client, error) {
 	return &clientImpl{
 		client:                        *client,
 		uris:                          b.uris,
+		uriScorer:                     internal.NewBalancedURIScoringMiddleware(b.uris, time.Now().UnixNano),
 		maxAttempts:                   b.maxAttempts,
 		backoffOptions:                b.backoffOptions,
 		disableTraceHeaderPropagation: b.disableTraceHeaderPropagation,

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -18,12 +18,12 @@ package httpclient
 import (
 	"context"
 	"crypto/tls"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
 
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/retry"

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -231,10 +231,22 @@ func BenchmarkAllocWithBytesBufferPool(b *testing.B) {
 }
 
 func BenchmarkUnavailableURIs(b *testing.B) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	server1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+	defer server1.Close()
+	server2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server2.Close()
+	server3 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server3.Close()
+	server4 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server4.Close()
 	unavailableServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusServiceUnavailable)
 	}))
@@ -259,28 +271,28 @@ func BenchmarkUnavailableURIs(b *testing.B) {
 	}
 	b.Run("FourAvailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server.URL, server.URL, server.URL, server.URL}),
+			httpclient.WithBaseURLs([]string{server1.URL, server2.URL, server3.URL, server4.URL}),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfFourUnavailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server.URL, server.URL, server.URL, unavailableServer.URL}),
+			httpclient.WithBaseURLs([]string{server1.URL, server2.URL, server3.URL, unavailableServer.URL}),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfThreeUnavailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server.URL, server.URL, unavailableServer.URL}),
+			httpclient.WithBaseURLs([]string{server1.URL, server2.URL, unavailableServer.URL}),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfTwoUnavailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server.URL, unavailableServer.URL}),
+			httpclient.WithBaseURLs([]string{server1.URL, unavailableServer.URL}),
 		)
 		require.NoError(b, err)
 		runBench(b, client)

--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -44,7 +44,7 @@ func NewBalancedURIScoringMiddleware(uris []string, nanoClock func() int64) Bala
 }
 
 func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
-	uris := make([]string, len(u.uriInfos))
+	uris := make([]string, 0, len(u.uriInfos))
 	scores := make(map[string]int32, len(u.uriInfos))
 	for uri, info := range u.uriInfos {
 		uris = append(uris, uri)

--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -36,6 +36,7 @@ type URIScoringMiddleware interface {
 
 type balancedScorer struct {
 	uriInfos map[string]uriInfo
+	rand     *rand.Rand
 }
 
 type uriInfo struct {
@@ -59,6 +60,7 @@ func NewBalancedURIScoringMiddleware(uris []string, nanoClock func() int64) URIS
 	}
 	return &balancedScorer{
 		uriInfos,
+		rand.New(rand.NewSource(nanoClock())),
 	}
 }
 
@@ -70,7 +72,7 @@ func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
 		scores[uri] = info.computeScore()
 	}
 	// Pre-shuffle to avoid overloading first URI when no request are in-flight
-	rand.Shuffle(len(uris), func(i, j int) {
+	u.rand.Shuffle(len(uris), func(i, j int) {
 		uris[i], uris[j] = uris[j], uris[i]
 	})
 	sort.Slice(uris, func(i, j int) bool {

--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -1,0 +1,109 @@
+package internal
+
+import (
+	"math"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"sort"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	failureWeight = 10.0
+	failureMemory = 30 * time.Second
+)
+
+type BalancedURIScoringMiddleware interface {
+	GetURIsInOrderOfIncreasingScore() []string
+	RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error)
+}
+
+var _ BalancedURIScoringMiddleware = (*balancedScorer)(nil)
+
+type balancedScorer struct {
+	uriInfos map[string]uriInfo
+}
+
+type uriInfo struct {
+	inflight       int32
+	recentFailures CourseExponentialDecayReservoir
+}
+
+func NewBalancedURIScoringMiddleware(uris []string, nanoClock func() int64) BalancedURIScoringMiddleware {
+	uriInfos := make(map[string]uriInfo, len(uris))
+	for _, uri := range uris {
+		uriInfos[uri] = uriInfo{
+			recentFailures: NewCourseExponentialDecayReservoir(nanoClock, failureMemory),
+		}
+	}
+	return &balancedScorer{
+		uriInfos,
+	}
+}
+
+func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
+	uris := make([]string, len(u.uriInfos))
+	scores := make(map[string]int32, len(u.uriInfos))
+	for uri, info := range u.uriInfos {
+		uris = append(uris, uri)
+		scores[uri] = info.computeScore()
+	}
+	// Pre-shuffle to avoid overloading first URI when no request are in-flight
+	rand.Shuffle(len(uris), func(i, j int) {
+		uris[i], uris[j] = uris[j], uris[i]
+	})
+	sort.Slice(uris, func(i, j int) bool {
+		return scores[uris[i]] < scores[uris[j]]
+	})
+	return uris
+}
+
+func (u *balancedScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+	baseUri := getBaseURI(req.URL)
+	info, foundInfo := u.uriInfos[baseUri]
+	if foundInfo {
+		atomic.AddInt32(&info.inflight, 1)
+		defer atomic.AddInt32(&info.inflight, -1)
+	}
+	resp, err := next.RoundTrip(req)
+	if resp == nil || err != nil {
+		return nil, err
+	}
+	if foundInfo {
+		statusCode := resp.StatusCode
+		if isGlobalQosStatus(statusCode) || isServerErrorRange(statusCode) {
+			info.recentFailures.Update(failureWeight)
+		} else if isClientError(statusCode) {
+			info.recentFailures.Update(failureWeight / 100)
+		}
+	}
+	return resp, nil
+}
+
+func (i *uriInfo) computeScore() int32 {
+	return atomic.LoadInt32(&i.inflight) + int32(math.Round(i.recentFailures.Get()))
+}
+
+func getBaseURI(u *url.URL) string {
+	uCopy := url.URL{
+		Scheme: u.Scheme,
+		Opaque: u.Opaque,
+		User:   u.User,
+		Host:   u.Host,
+	}
+	return uCopy.String()
+}
+
+func isGlobalQosStatus(statusCode int) bool {
+	return statusCode == StatusCodeRetryOther || statusCode == StatusCodeUnavailable
+}
+
+func isServerErrorRange(statusCode int) bool {
+	return statusCode/100 == 5
+}
+
+func isClientError(statusCode int) bool {
+	return statusCode/100 == 4
+}

--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (
@@ -61,8 +75,8 @@ func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
 }
 
 func (u *balancedScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-	baseUri := getBaseURI(req.URL)
-	info, foundInfo := u.uriInfos[baseUri]
+	baseURI := getBaseURI(req.URL)
+	info, foundInfo := u.uriInfos[baseURI]
 	if foundInfo {
 		atomic.AddInt32(&info.inflight, 1)
 		defer atomic.AddInt32(&info.inflight, -1)

--- a/conjure-go-client/httpclient/internal/balanced_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer_test.go
@@ -46,11 +46,13 @@ func TestBalancedScoring(t *testing.T) {
 	uris := []string{server503.URL, server429.URL, server200.URL}
 	scorer := NewBalancedURIScoringMiddleware(uris, func() int64 { return 0 })
 	for _, server := range []*httptest.Server{server200, server429, server503} {
-		req, err := http.NewRequest("GET", server.URL, nil)
-		assert.NoError(t, err)
-		_, err = scorer.RoundTrip(req, server.Client().Transport)
-		assert.NoError(t, err)
+		for i := 0; i < 10; i++ {
+			req, err := http.NewRequest("GET", server.URL, nil)
+			assert.NoError(t, err)
+			_, err = scorer.RoundTrip(req, server.Client().Transport)
+			assert.NoError(t, err)
+		}
 	}
 	scoredUris := scorer.GetURIsInOrderOfIncreasingScore()
-	assert.Equal(t, scoredUris, []string{server200.URL, server429.URL, server503.URL})
+	assert.Equal(t, []string{server200.URL, server429.URL, server503.URL}, scoredUris)
 }

--- a/conjure-go-client/httpclient/internal/balanced_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer_test.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBalancedScorerRandomizesWithNoneInflight(t *testing.T) {
+	uris := []string{"uri1", "uri2", "uri3", "uri4", "uri5"}
+	scorer := NewBalancedURIScoringMiddleware(uris, func() int64 { return 0 })
+	scoredUris := scorer.GetURIsInOrderOfIncreasingScore()
+	assert.ElementsMatch(t, scoredUris, uris)
+	assert.NotEqual(t, scoredUris, uris)
+}
+
+func TestBalancedScoring(t *testing.T) {
+	server200 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server200.Close()
+	server429 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server429.Close()
+	server503 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server503.Close()
+	uris := []string{server503.URL, server429.URL, server200.URL}
+	scorer := NewBalancedURIScoringMiddleware(uris, func() int64 { return 0 })
+	for _, server := range []*httptest.Server{server200, server429, server503} {
+		req, err := http.NewRequest("GET", server.URL, nil)
+		assert.NoError(t, err)
+		_, err = scorer.RoundTrip(req, server.Client().Transport)
+		assert.NoError(t, err)
+	}
+	scoredUris := scorer.GetURIsInOrderOfIncreasingScore()
+	assert.Equal(t, scoredUris, []string{server200.URL, server429.URL, server503.URL})
+}

--- a/conjure-go-client/httpclient/internal/balanced_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer_test.go
@@ -1,10 +1,25 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBalancedScorerRandomizesWithNoneInflight(t *testing.T) {

--- a/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir.go
+++ b/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir.go
@@ -1,0 +1,70 @@
+package internal
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	decaysPerHalfLife = 10
+)
+
+var (
+	decayFactor = math.Pow(0.5, 1.0/decaysPerHalfLife)
+)
+
+type CourseExponentialDecayReservoir interface {
+	Update(updates float64)
+	Get() float64
+}
+
+var _ CourseExponentialDecayReservoir = (*reservoir)(nil)
+
+type reservoir struct {
+	value                    float64
+	lastDecay                int64
+	nanoClock                func() int64
+	decayIntervalNanoseconds int64
+	mu                       sync.Mutex
+}
+
+func NewCourseExponentialDecayReservoir(nanoClock func() int64, halfLife time.Duration) CourseExponentialDecayReservoir {
+	return &reservoir{
+		lastDecay:                nanoClock(),
+		nanoClock:                nanoClock,
+		decayIntervalNanoseconds: halfLife.Nanoseconds() / decaysPerHalfLife,
+	}
+}
+
+func (r *reservoir) Update(updates float64) {
+	r.decayIfNecessary()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.value = r.value + updates
+}
+
+func (r *reservoir) Get() float64 {
+	r.decayIfNecessary()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.value
+}
+
+func (r *reservoir) decayIfNecessary() {
+	now := r.nanoClock()
+	lastDecaySnapshot := r.lastDecay
+	nanosSinceLastDecay := now - lastDecaySnapshot
+	decays := nanosSinceLastDecay / r.decayIntervalNanoseconds
+	// If CAS fails another thread will execute decay instead
+	if decays > 0 && atomic.CompareAndSwapInt64(&r.lastDecay, lastDecaySnapshot, lastDecaySnapshot+decays*r.decayIntervalNanoseconds) {
+		r.decay(decays)
+	}
+}
+
+func (r *reservoir) decay(decayIterations int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.value = r.value * math.Pow(decayFactor, float64(decayIterations))
+}

--- a/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir.go
+++ b/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir.go
@@ -37,11 +37,11 @@ type CourseExponentialDecayReservoir interface {
 var _ CourseExponentialDecayReservoir = (*reservoir)(nil)
 
 type reservoir struct {
-	value                    float64
 	lastDecay                int64
 	nanoClock                func() int64
 	decayIntervalNanoseconds int64
 	mu                       sync.Mutex
+	value                    float64
 }
 
 func NewCourseExponentialDecayReservoir(nanoClock func() int64, halfLife time.Duration) CourseExponentialDecayReservoir {

--- a/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir.go
+++ b/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (

--- a/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir_test.go
+++ b/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir_test.go
@@ -26,11 +26,11 @@ func TestDecayToZero(t *testing.T) {
 		return time
 	}
 	r := NewCourseExponentialDecayReservoir(clock, 10)
-	assert.InDelta(t, r.Get(), 0.0, 0.001)
+	assert.InDelta(t, 0.0, r.Get(), 0.001)
 	r.Update(1)
-	assert.InDelta(t, r.Get(), 1.0, 0.001)
+	assert.InDelta(t, 1.0, r.Get(), 0.001)
 	time = 300000
-	assert.InDelta(t, r.Get(), 0.0, 0.001)
+	assert.InDelta(t, 0.0, r.Get(), 0.001)
 }
 
 func TestDecayByHalf(t *testing.T) {
@@ -40,11 +40,11 @@ func TestDecayByHalf(t *testing.T) {
 	}
 	r := NewCourseExponentialDecayReservoir(clock, 10)
 	r.Update(2)
-	assert.InDelta(t, r.Get(), 2.0, 0.001)
+	assert.InDelta(t, 2.0, r.Get(), 0.001)
 	time = 10
-	assert.InDelta(t, r.Get(), 1.0, 0.001)
+	assert.InDelta(t, 1.0, r.Get(), 0.001)
 	time = 20
-	assert.InDelta(t, r.Get(), 0.5, 0.001)
+	assert.InDelta(t, 0.5, r.Get(), 0.001)
 }
 
 func TestIntermediateDecay(t *testing.T) {
@@ -54,10 +54,10 @@ func TestIntermediateDecay(t *testing.T) {
 	}
 	r := NewCourseExponentialDecayReservoir(clock, 10)
 	r.Update(100)
-	assert.InDelta(t, r.Get(), 100.0, 0.001)
+	assert.InDelta(t, 100.0, r.Get(), 0.001)
 	time = 2
 	assert.Less(t, r.Get(), 100.0)
 	assert.Greater(t, r.Get(), 50.0)
 	time = 10
-	assert.InDelta(t, r.Get(), 50.0, 0.001)
+	assert.InDelta(t, 50.0, r.Get(), 0.001)
 }

--- a/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir_test.go
+++ b/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir_test.go
@@ -1,8 +1,23 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDecayToZero(t *testing.T) {

--- a/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir_test.go
+++ b/conjure-go-client/httpclient/internal/course_exponential_decay_reservoir_test.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDecayToZero(t *testing.T) {
+	time := int64(0)
+	clock := func() int64 {
+		return time
+	}
+	r := NewCourseExponentialDecayReservoir(clock, 10)
+	assert.InDelta(t, r.Get(), 0.0, 0.001)
+	r.Update(1)
+	assert.InDelta(t, r.Get(), 1.0, 0.001)
+	time = 300000
+	assert.InDelta(t, r.Get(), 0.0, 0.001)
+}
+
+func TestDecayByHalf(t *testing.T) {
+	time := int64(0)
+	clock := func() int64 {
+		return time
+	}
+	r := NewCourseExponentialDecayReservoir(clock, 10)
+	r.Update(2)
+	assert.InDelta(t, r.Get(), 2.0, 0.001)
+	time = 10
+	assert.InDelta(t, r.Get(), 1.0, 0.001)
+	time = 20
+	assert.InDelta(t, r.Get(), 0.5, 0.001)
+}
+
+func TestIntermediateDecay(t *testing.T) {
+	time := int64(0)
+	clock := func() int64 {
+		return time
+	}
+	r := NewCourseExponentialDecayReservoir(clock, 10)
+	r.Update(100)
+	assert.InDelta(t, r.Get(), 100.0, 0.001)
+	time = 2
+	assert.Less(t, r.Get(), 100.0)
+	assert.Greater(t, r.Get(), 50.0)
+	time = 10
+	assert.InDelta(t, r.Get(), 50.0, 0.001)
+}

--- a/conjure-go-client/httpclient/internal/noop_scorer.go
+++ b/conjure-go-client/httpclient/internal/noop_scorer.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+)
+
+type noopScorer struct {
+	uris []string
+}
+
+func (n *noopScorer) GetURIsInOrderOfIncreasingScore() []string {
+	return n.uris
+}
+
+func (n *noopScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+	return next.RoundTrip(req)
+}
+
+func NewNoopURIScoringMiddleware(uris []string) URIScoringMiddleware {
+	return &noopScorer{
+		uris,
+	}
+}

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -15,7 +15,6 @@
 package internal
 
 import (
-	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -46,13 +45,10 @@ type RequestRetrier struct {
 // Regardless of maxAttempts, mesh URIs will never be retried.
 func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *RequestRetrier {
 	offset := 0
-	urisCopy := make([]string, len(uris))
-	copy(urisCopy, uris)
-	rand.Shuffle(len(urisCopy), func(i, j int) { urisCopy[i], urisCopy[j] = urisCopy[j], urisCopy[i] })
 	return &RequestRetrier{
-		currentURI:    urisCopy[offset],
+		currentURI:    uris[offset],
 		retrier:       retrier,
-		uris:          urisCopy,
+		uris:          uris,
 		offset:        offset,
 		relocatedURIs: map[string]struct{}{},
 		failedURIs:    map[string]struct{}{},

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -417,6 +417,7 @@ func TestMetricsMiddleware_InFlightRequests(t *testing.T) {
 	dialerMetric := rootRegistry.Counter(httpclient.MetricConnInflight, serviceNameTag)
 	assert.Equal(t, int64(1), dialerMetric.Count(), "%s should be nonzero immediately after a request", httpclient.MetricConnInflight)
 	srv.Close()
-	// N.B. (bmoylan): if this test ends up being flaky, it's because the client-side closes fast but asynchronously and we could add a small time.Sleep.
+	// Sleep to handle client-side closing fast but asynchronously
+	time.Sleep(time.Second)
 	assert.Equal(t, int64(0), dialerMetric.Count(), "%s should be zero after the server closes the connection", httpclient.MetricConnInflight)
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
CGR client does not account for server responses when load-balancing across multiple URIs and just randomizes order of URIs when retrying.

This can lead to undesirably retrying a URI many times even when the server is unavailable, such as during a node restart.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Add middleware based on Dialogue's '[balanced' load balancing strategy](https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java) that uses an exponentially decaying reservoir to track recent response errors and prioritize URIs with fewer in-flight requests and recent failures.

Fixes https://github.com/palantir/conjure-go-runtime/issues/194

Benchmark results:
```
benchmark                                                                  old ns/op     new ns/op     delta
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=1-16              93798         98068         +4.55%
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=10-16             931710        991491        +6.42%
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=100-16            9291976       9621014       +3.54%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=1-16            91936         96066         +4.49%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=10-16           903859        977292        +8.12%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=100-16          9042090       9767101       +8.02%
BenchmarkUnavailableURIs/OneAvailableServer/count=10-16                    949802        963606        +1.45%
BenchmarkUnavailableURIs/OneAvailableServer/count=100-16                   9191157       9566737       +4.09%
BenchmarkUnavailableURIs/OneAvailableServer/count=1000-16                  91739632      96296739      +4.97%
BenchmarkUnavailableURIs/FourAvailableServers/count=10-16                  943496        1009042       +6.95%
BenchmarkUnavailableURIs/FourAvailableServers/count=100-16                 9426424       9882186       +4.83%
BenchmarkUnavailableURIs/FourAvailableServers/count=1000-16                93641142      100149462     +6.95%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=10-16        1224338       1003200       -18.06%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=100-16       12311181      10127655      -17.74%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=1000-16      122187011     102564133     -16.06%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=10-16       1310920       1015474       -22.54%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=100-16      13159841      10126297      -23.05%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=1000-16     130296842     100600932     -22.79%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=10-16         1474337       993779        -32.59%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=100-16        14900138      9999934       -32.89%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=1000-16       147037762     100873436     -31.40%

benchmark                                                                  old allocs     new allocs     delta
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=1-16              105            105            +0.00%
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=10-16             1051           1051           +0.00%
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=100-16            10519          10517          -0.02%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=1-16            104            104            +0.00%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=10-16           1041           1041           +0.00%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=100-16          10416          10416          +0.00%
BenchmarkUnavailableURIs/OneAvailableServer/count=10-16                    1051           1051           +0.00%
BenchmarkUnavailableURIs/OneAvailableServer/count=100-16                   10514          10516          +0.02%
BenchmarkUnavailableURIs/OneAvailableServer/count=1000-16                  105175         105167         -0.01%
BenchmarkUnavailableURIs/FourAvailableServers/count=10-16                  1051           1121           +6.66%
BenchmarkUnavailableURIs/FourAvailableServers/count=100-16                 10517          11215          +6.64%
BenchmarkUnavailableURIs/FourAvailableServers/count=1000-16                105194         112162         +6.62%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=10-16        1475           1121           -24.00%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=100-16       14868          11218          -24.55%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=1000-16      146090         112173         -23.22%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=10-16       1611           1121           -30.42%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=100-16      16192          11216          -30.73%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=1000-16     160540         112181         -30.12%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=10-16         1877           1121           -40.28%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=100-16        18845          11217          -40.48%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=1000-16       188889         112191         -40.60%

benchmark                                                                  old bytes     new bytes     delta
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=1-16              7990          8046          +0.70%
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=10-16             79878         80515         +0.80%
BenchmarkAllocWithBytesBufferPool/NoByteBufferPool/count=100-16            803411        806921        +0.44%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=1-16            7898          7950          +0.66%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=10-16           78979         79677         +0.88%
BenchmarkAllocWithBytesBufferPool/WithByteBufferPool/count=100-16          791049        795755        +0.59%
BenchmarkUnavailableURIs/OneAvailableServer/count=10-16                    79910         80433         +0.65%
BenchmarkUnavailableURIs/OneAvailableServer/count=100-16                   799244        806119        +0.86%
BenchmarkUnavailableURIs/OneAvailableServer/count=1000-16                  7998631       8057533       +0.74%
BenchmarkUnavailableURIs/FourAvailableServers/count=10-16                  80503         82500         +2.48%
BenchmarkUnavailableURIs/FourAvailableServers/count=100-16                 805206        824364        +2.38%
BenchmarkUnavailableURIs/FourAvailableServers/count=1000-16                8069882       8258605       +2.34%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=10-16        117464        82460         -29.80%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=100-16       1183451       825758        -30.22%
BenchmarkUnavailableURIs/OneOutOfFourUnavailableServers/count=1000-16      11607855      8265169       -28.80%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=10-16       129511        82496         -36.30%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=100-16      1299289       823909        -36.59%
BenchmarkUnavailableURIs/OneOutOfThreeUnavailableServers/count=1000-16     12871795      8266066       -35.78%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=10-16         152420        82647         -45.78%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=100-16        1529061       823380        -46.15%
BenchmarkUnavailableURIs/OneOutOfTwoUnavailableServers/count=1000-16       15334106      8261072       -46.13%
```

==COMMIT_MSG==
Add balanced scoring middleware to improve client-side load-balancing based on server responses
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Small performance regression (<5%) when client is used with a single URI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/208)
<!-- Reviewable:end -->
