### PR TITLE
improvement: Make balanced URI scoring configurable

### DIFF
--- a/changelog/@unreleased/pr-210.v2.yml
+++ b/changelog/@unreleased/pr-210.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Make balanced URI scoring optional behavior that can be enabled by
+    configuring the HTTP client.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/210

--- a/changelog/@unreleased/pr-210.v2.yml
+++ b/changelog/@unreleased/pr-210.v2.yml
@@ -1,6 +1,7 @@
 type: improvement
 improvement:
-  description: Make balanced URI scoring optional behavior that can be enabled by
-    configuring the HTTP client.
+  description: |
+    Add WithBalancedURIScoring option to HTTP client params to enable the balanced URI scoring feature. HTTP client
+    defaults to randomizing priority of URIs for each request when this option is not used.
   links:
   - https://github.com/palantir/conjure-go-runtime/pull/210

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -50,13 +50,13 @@ type httpClientBuilder struct {
 	Timeout           time.Duration
 	Middlewares       []Middleware
 	metricsMiddleware Middleware
+	URIScorerBuilder  func([]string) internal.URIScoringMiddleware
 
 	// http.Transport modifiers
 	MaxIdleConns          int
 	MaxIdleConnsPerHost   int
 	Proxy                 func(*http.Request) (*url.URL, error)
 	ProxyDialerBuilder    func(*net.Dialer) (proxy.Dialer, error)
-	URIScorerBuilder      func([]string) internal.URIScoringMiddleware
 	TLSClientConfig       *tls.Config
 	DisableHTTP2          bool
 	DisableRecovery       bool
@@ -125,7 +125,7 @@ func NewClient(params ...ClientParam) (Client, error) {
 func getDefaultHTTPClientBuilder() *httpClientBuilder {
 	defaultTLSConfig, _ := tlsconfig.NewClientConfig()
 	uriScorerBuilder := func(uris []string) internal.URIScoringMiddleware {
-		return internal.NewBalancedURIScoringMiddleware(uris, func() int64 {
+		return internal.NewRandomURIScoringMiddleware(uris, func() int64 {
 			return time.Now().UnixNano()
 		})
 	}

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -108,10 +108,9 @@ func NewClient(params ...ClientParam) (Client, error) {
 	} else if b.maxAttempts == 0 {
 		b.maxAttempts = 2 * len(b.uris)
 	}
-	uriScorer := b.httpClientBuilder.URIScorerBuilder(b.uris)
 	return &clientImpl{
 		client:                        *client,
-		uriScorer:                     uriScorer,
+		uriScorer: b.httpClientBuilder.URIScorerBuilder(b.uris),
 		maxAttempts:                   b.maxAttempts,
 		backoffOptions:                b.backoffOptions,
 		disableTraceHeaderPropagation: b.disableTraceHeaderPropagation,
@@ -130,9 +129,9 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 		})
 	}
 	return &httpClientBuilder{
+		URIScorerBuilder:      uriScorerBuilder,
 		// These values are primarily pulled from http.DefaultTransport.
 		Proxy:                 http.ProxyFromEnvironment,
-		URIScorerBuilder:      uriScorerBuilder,
 		TLSClientConfig:       defaultTLSConfig,
 		Timeout:               1 * time.Minute,
 		DialTimeout:           10 * time.Second,

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -110,7 +110,7 @@ func NewClient(params ...ClientParam) (Client, error) {
 	}
 	return &clientImpl{
 		client:                        *client,
-		uriScorer: b.httpClientBuilder.URIScorerBuilder(b.uris),
+		uriScorer:                     b.httpClientBuilder.URIScorerBuilder(b.uris),
 		maxAttempts:                   b.maxAttempts,
 		backoffOptions:                b.backoffOptions,
 		disableTraceHeaderPropagation: b.disableTraceHeaderPropagation,
@@ -129,7 +129,7 @@ func getDefaultHTTPClientBuilder() *httpClientBuilder {
 		})
 	}
 	return &httpClientBuilder{
-		URIScorerBuilder:      uriScorerBuilder,
+		URIScorerBuilder: uriScorerBuilder,
 		// These values are primarily pulled from http.DefaultTransport.
 		Proxy:                 http.ProxyFromEnvironment,
 		TLSClientConfig:       defaultTLSConfig,

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/retry"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -468,6 +469,19 @@ func WithBasicAuth(username, password string) ClientParam {
 		setBasicAuth(req.Header, username, password)
 		return next.RoundTrip(req)
 	}))
+}
+
+// WithBalancedURIScoring adds middleware that prioritizes sending requests to URIs with the fewest in-flight requests
+// and least recent errors.
+func WithBalancedURIScoring() ClientParam {
+	return clientParamFunc(func(b *clientBuilder) error {
+		b.URIScorerBuilder = func(uris []string) internal.URIScoringMiddleware {
+			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 {
+				return time.Now().UnixNano()
+			})
+		}
+		return nil
+	})
 }
 
 func setBasicAuth(h http.Header, username, password string) {

--- a/conjure-go-client/httpclient/internal/random_scorer.go
+++ b/conjure-go-client/httpclient/internal/random_scorer.go
@@ -20,15 +20,15 @@ import (
 )
 
 type randomScorer struct {
-	uris []string
-	rand *rand.Rand
+	uris      []string
+	nanoClock func() int64
 }
 
 func (n *randomScorer) GetURIsInOrderOfIncreasingScore() []string {
 	uris := make([]string, len(n.uris))
 	copy(uris, n.uris)
-	n.rand.Shuffle(len(uris), func(i, j int) {
-		uris[i] = uris[j]
+	rand.New(rand.NewSource(n.nanoClock())).Shuffle(len(uris), func(i, j int) {
+		uris[i], uris[j] = uris[j], uris[i]
 	})
 	return uris
 }
@@ -42,6 +42,6 @@ func (n *randomScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*ht
 func NewRandomURIScoringMiddleware(uris []string, nanoClock func() int64) URIScoringMiddleware {
 	return &randomScorer{
 		uris,
-		rand.New(rand.NewSource(nanoClock())),
+		nanoClock,
 	}
 }

--- a/conjure-go-client/httpclient/internal/random_scorer.go
+++ b/conjure-go-client/httpclient/internal/random_scorer.go
@@ -41,7 +41,7 @@ func (n *randomScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*ht
 // seeded by the nanoClock function. The middleware no-ops on each request.
 func NewRandomURIScoringMiddleware(uris []string, nanoClock func() int64) URIScoringMiddleware {
 	return &randomScorer{
-		uris: uris,
+		uris:      uris,
 		nanoClock: nanoClock,
 	}
 }

--- a/conjure-go-client/httpclient/internal/random_scorer.go
+++ b/conjure-go-client/httpclient/internal/random_scorer.go
@@ -37,11 +37,11 @@ func (n *randomScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*ht
 	return next.RoundTrip(req)
 }
 
-// NewRandomURIScoringMiddleware returns a URI scorer that randomizes the order of URIs when scoring.  The middleware
-// no-ops on each request.
+// NewRandomURIScoringMiddleware returns a URI scorer that randomizes the order of URIs when scoring using a rand.Rand
+// seeded by the nanoClock function. The middleware no-ops on each request.
 func NewRandomURIScoringMiddleware(uris []string, nanoClock func() int64) URIScoringMiddleware {
 	return &randomScorer{
-		uris,
-		nanoClock,
+		uris: uris,
+		nanoClock: nanoClock,
 	}
 }

--- a/conjure-go-client/httpclient/internal/random_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/random_scorer_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomScorerGetURIsRandomizes(t *testing.T) {
+	uris := []string{"uri1", "uri2", "uri3", "uri4", "uri5"}
+	scorer := NewRandomURIScoringMiddleware(uris, func() int64 { return time.Now().UnixNano() })
+	scoredUris1 := scorer.GetURIsInOrderOfIncreasingScore()
+	scoredUris2 := scorer.GetURIsInOrderOfIncreasingScore()
+	assert.ElementsMatch(t, scoredUris1, scoredUris2)
+	assert.NotEqual(t, scoredUris1, scoredUris2)
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Balanced scoring was the default behavior with no way to disable it, this change makes it optional to enable when constructing an HTTP client.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make balanced URI scoring optional behavior that can be enabled by configuring the HTTP client.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/210)
<!-- Reviewable:end -->
