### PR TITLE
improvement: Fail during client construction when no URIs provided

### DIFF
--- a/changelog/@unreleased/pr-212.v2.yml
+++ b/changelog/@unreleased/pr-212.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fail during client construction when no URIs provided
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/212

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -28,6 +28,7 @@ import (
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/retry"
 	"github.com/palantir/pkg/tlsconfig"
+	werror "github.com/palantir/witchcraft-go-error"
 	"golang.org/x/net/proxy"
 )
 
@@ -92,6 +93,9 @@ func NewClient(params ...ClientParam) (Client, error) {
 		if err := p.apply(b); err != nil {
 			return nil, err
 		}
+	}
+	if len(b.uris) == 0 {
+		return nil, werror.Error("httpclient URLs must not be empty", werror.SafeParam("serviceName", b.ServiceName))
 	}
 	client, middlewares, err := httpClientAndRoundTripHandlersFromBuilder(&b.httpClientBuilder)
 	if err != nil {

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -143,7 +143,9 @@ func TestBuilder(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			client, err := NewClient(test.Param)
+			// Must provide URLs for client creation
+			urls := WithBaseURLs([]string{"https://localhost"})
+			client, err := NewClient(urls, test.Param)
 			require.NoError(t, err)
 			test.Test(t, client.(*clientImpl))
 		})

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -32,10 +32,8 @@ import (
 
 func TestNoBaseURIs(t *testing.T) {
 	client, err := httpclient.NewClient()
-	require.NoError(t, err)
-
-	_, err = client.Do(context.Background(), httpclient.WithRequestMethod("GET"))
-	require.Error(t, err)
+	require.EqualError(t, err, "httpclient URLs must not be empty")
+	require.Nil(t, client)
 }
 
 func TestCanReadBodyWithBufferPool(t *testing.T) {

--- a/conjure-go-client/httpclient/config_test.go
+++ b/conjure-go-client/httpclient/config_test.go
@@ -63,6 +63,7 @@ func TestWithConfigParam(t *testing.T) {
 			"my-service": {
 				ReadTimeout:  &[]time.Duration{2 * time.Second}[0],
 				WriteTimeout: &[]time.Duration{3 * time.Second}[0],
+				URIs:         []string{"https://localhost"},
 			},
 		},
 	}

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -120,7 +120,7 @@ func TestRoundTripperWithMetrics(t *testing.T) {
 
 		// create client
 		client, err := httpclient.NewClient(
-			httpclient.WithHTTPTimeout(time.Second),
+			httpclient.WithHTTPTimeout(5*time.Second),
 			httpclient.WithServiceName("my-service"),
 			httpclient.WithMetrics(tagsProviders...),
 			httpclient.WithBaseURLs([]string{serverURLstr}))
@@ -138,10 +138,10 @@ func TestRoundTripperWithMetrics(t *testing.T) {
 		// assert metrics exist in registry
 		var metricName string
 		var metricTags metrics.Tags
-		rootRegistry.Each(metrics.MetricVisitor(func(name string, tags metrics.Tags, _ metrics.MetricVal) {
+		rootRegistry.Each(func(name string, tags metrics.Tags, _ metrics.MetricVal) {
 			metricName = name
 			metricTags = tags
-		}))
+		})
 		assert.Equal(t, "client.response", metricName)
 		expectedTags := append(
 			customTags,


### PR DESCRIPTION
Before, empty URLs would not error until a request is attempted. This moves the error earlier and closer to where the client is (mis)constructed.

I've added this validation in #171 (refreshable config) because we want to ensure that the updated config is valid before accepting it. I figured it is a behavior change that deserves its own changelog entry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/212)
<!-- Reviewable:end -->
