### PR TITLE
fix: BalancedURIScoringMiddleware uses global math/rand for concurrent safety.

### DIFF
--- a/changelog/@unreleased/pr-219.v2.yml
+++ b/changelog/@unreleased/pr-219.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    BalancedURIScoringMiddleware uses global math/rand for concurrent safety.
+
+    Individual instances of `math/rand.(*Rand)` are not safe for concurrent use, but the global random source is.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/219

--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -36,7 +36,6 @@ type URIScoringMiddleware interface {
 
 type balancedScorer struct {
 	uriInfos map[string]uriInfo
-	rand     *rand.Rand
 }
 
 type uriInfo struct {
@@ -58,10 +57,7 @@ func NewBalancedURIScoringMiddleware(uris []string, nanoClock func() int64) URIS
 			recentFailures: NewCourseExponentialDecayReservoir(nanoClock, failureMemory),
 		}
 	}
-	return &balancedScorer{
-		uriInfos,
-		rand.New(rand.NewSource(nanoClock())),
-	}
+	return &balancedScorer{uriInfos}
 }
 
 func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
@@ -72,7 +68,7 @@ func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
 		scores[uri] = info.computeScore()
 	}
 	// Pre-shuffle to avoid overloading first URI when no request are in-flight
-	u.rand.Shuffle(len(uris), func(i, j int) {
+	rand.Shuffle(len(uris), func(i, j int) {
 		uris[i], uris[j] = uris[j], uris[i]
 	})
 	sort.Slice(uris, func(i, j int) bool {


### PR DESCRIPTION
Individual instances of `math/rand.(*Rand)` are not safe for concurrent use, but the global random source is.

From https://pkg.go.dev/math/rand:
> The default Source is safe for concurrent use by multiple goroutines, but Sources created by NewSource are not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/219)
<!-- Reviewable:end -->
