### PR TITLE
Propose fix for avoiding non-429, 4xx retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ We use round trip middleware to inject headers, instument metrics, and more.
 Custom middleware can be provided using the `httpclient.RoundTripMiddleware` param.
 
 ### Docs TODOs
-* Retry behavior
 * Request body behavior
 * Response body behavior
 
@@ -123,6 +122,15 @@ clients:
       - https://api-2b.example.com/api
       - https://api-2c.example.com/api
 ```
+
+## Retry Behavior
+Conjure-go-runtime HTTP clients provide the following retry behavior:
+- HTTP Status Code Handling
+  - 429 (Too Many Requests): the client retries the request to a different node based on its URI configuration. TODO: support deriving backoff from the retry-after HTTP response header
+  - 503 (Service Unavailable): the client retries the request to a different node based on its URI configuration.
+  - 307 (Temporary Redirect), 308 (Permanent Redirect): the client retries the request with the URL included in the HTTP response's 'Location' header.
+  - 5XX responses: the client retries the request to a different node based on its URI configuration.
+- Network Error Handling: the client retries the request to a different node based on its URI configuration.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ clients:
 ## Retry Behavior
 Conjure-go-runtime HTTP clients provide the following retry behavior:
 - HTTP Status Code Handling
+  - 307 (Temporary Redirect), 308 (Permanent Redirect): the client retries the request with the URL included in the HTTP response's 'Location' header.
   - 429 (Too Many Requests): the client retries the request to a different node based on its URI configuration. TODO: support deriving backoff from the retry-after HTTP response header
   - 503 (Service Unavailable): the client retries the request to a different node based on its URI configuration.
-  - 307 (Temporary Redirect), 308 (Permanent Redirect): the client retries the request with the URL included in the HTTP response's 'Location' header.
   - 5XX responses: the client retries the request to a different node based on its URI configuration.
 - Network Error Handling: the client retries the request to a different node based on its URI configuration.
 

--- a/changelog/@unreleased/pr-223.v2.yml
+++ b/changelog/@unreleased/pr-223.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    Retry requests with 4xx responses only in the case of 429.
+  links:
+    - https://github.com/palantir/conjure-go-runtime/pull/223

--- a/conjure-go-client/httpclient/body_handler_test.go
+++ b/conjure-go-client/httpclient/body_handler_test.go
@@ -112,7 +112,7 @@ func TestRawRequestRetry(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, requestBytes, gotReqBytes)
 		if count == 0 {
-			rw.WriteHeader(http.StatusBadRequest)
+			rw.WriteHeader(http.StatusInternalServerError)
 		}
 		// Otherwise 200 is returned
 		count++

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -117,6 +117,8 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() b
 			}
 		}
 		return r.nextURIOrBackoff
+	} else if errCode >= http.StatusBadRequest && errCode < http.StatusInternalServerError {
+		return nil
 	} else if resp == nil {
 		// if we get a nil response, we can assume there is a problem with host and can move on to the next.
 		return r.nextURIOrBackoff

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -277,6 +277,46 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			shouldRetryBackoff: true,
 			shouldRetryReset:   false,
 		},
+		{
+			name: "does not retry 400 responses",
+			resp: &http.Response{
+				StatusCode: 400,
+			},
+			uris:               []string{"a", "b"},
+			shouldRetry:        false,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name: "does not retry 404 responses",
+			resp: &http.Response{
+				StatusCode: 404,
+			},
+			uris:               []string{"a", "b"},
+			shouldRetry:        false,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "does not retry 400 errors",
+			respErr:            werror.ErrorWithContextParams(context.Background(), "400", werror.SafeParam("statusCode", 400)),
+			uris:               []string{"a", "b"},
+			shouldRetry:        false,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
+		{
+			name:               "does not retry 404s",
+			respErr:            werror.ErrorWithContextParams(context.Background(), "404", werror.SafeParam("statusCode", 404)),
+			uris:               []string{"a", "b"},
+			shouldRetry:        false,
+			shouldRetrySameURI: false,
+			shouldRetryBackoff: false,
+			shouldRetryReset:   false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			retrier := newMockRetrier()


### PR DESCRIPTION
## Before this PR
Default client retries all 4xx responses except for 429

## After this PR
The only 4xx response the default client retries is 429
==COMMIT_MSG==
Avoid retries for 4xx responses, excepting 429.
==COMMIT_MSG==

## Possible downsides?
People expect certain 4xx responses to get retried - in this case, we can review those status codes to see which merit retrying. Reading through https://en.wikipedia.org/wiki/List_of_HTTP_status_codes, I only see 408 (Request Timeout) and 425 (Too Early) as valid candidates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/223)
<!-- Reviewable:end -->
