### PR TITLE
fix: Default proxy-from-environment to true in refreshable config

### DIFF
--- a/changelog/@unreleased/pr-225.v2.yml
+++ b/changelog/@unreleased/pr-225.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Default proxy-from-environment to true in refreshable config
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/225

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -362,7 +362,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		ExpectContinueTimeout: derefDurationPtr(config.ExpectContinueTimeout, defaultExpectContinueTimeout),
 		HTTP2PingTimeout:      derefDurationPtr(config.HTTP2PingTimeout, defaultHTTP2PingTimeout),
 		HTTP2ReadIdleTimeout:  derefDurationPtr(config.HTTP2ReadIdleTimeout, defaultHTTP2ReadIdleTimeout),
-		ProxyFromEnvironment:  derefBoolPtr(config.ProxyFromEnvironment, false),
+		ProxyFromEnvironment:  derefBoolPtr(config.ProxyFromEnvironment, true),
 		TLSHandshakeTimeout:   derefDurationPtr(config.TLSHandshakeTimeout, defaultTLSHandshakeTimeout),
 	}
 


### PR DESCRIPTION
The docs specify that we enable proxy-from-environment by default, but when constructing a refreshable config we (incorrectly) defaulted to `false`.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/225)
<!-- Reviewable:end -->
