### PR TITLE
Improvement: Add IsErrorOfType support for generic errors

### DIFF
--- a/changelog/@unreleased/pr-262.v2.yml
+++ b/changelog/@unreleased/pr-262.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add IsErrorOfType support for generic errors
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/262

--- a/conjure-go-contract/errors/error.go
+++ b/conjure-go-contract/errors/error.go
@@ -55,6 +55,11 @@ func WrapWithUnauthorized(cause error, parameters ...wparams.ParamStorer) Error 
 	return newGenericError(cause, DefaultUnauthorized, wparams.NewParamStorer(parameters...))
 }
 
+// IsUnauthorized returns true if an error is an instance of default unauthorized type.
+func IsUnauthorized(err error) bool {
+	return isErrorOfType(err, DefaultUnauthorized)
+}
+
 // NewPermissionDenied returns new error instance of default permission denied type.
 func NewPermissionDenied(parameters ...wparams.ParamStorer) Error {
 	return newGenericError(nil, DefaultPermissionDenied, wparams.NewParamStorer(parameters...))
@@ -63,6 +68,11 @@ func NewPermissionDenied(parameters ...wparams.ParamStorer) Error {
 // WrapWithPermissionDenied returns new error instance of default permission denied type wrapping an existing error.
 func WrapWithPermissionDenied(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultPermissionDenied, wparams.NewParamStorer(parameters...))
+}
+
+// IsPermissionDenied returns true if an error is an instance of default unauthorized type.
+func IsPermissionDenied(err error) bool {
+	return isErrorOfType(err, DefaultPermissionDenied)
 }
 
 // NewInvalidArgument returns new error instance of default invalid argument type.
@@ -75,6 +85,11 @@ func WrapWithInvalidArgument(cause error, parameters ...wparams.ParamStorer) Err
 	return newGenericError(cause, DefaultInvalidArgument, wparams.NewParamStorer(parameters...))
 }
 
+// IsInvalidArgument returns true if an error is an instance of default unauthorized type.
+func IsInvalidArgument(err error) bool {
+	return isErrorOfType(err, DefaultInvalidArgument)
+}
+
 // NewNotFound returns new error instance of default not found type.
 func NewNotFound(parameters ...wparams.ParamStorer) Error {
 	return newGenericError(nil, DefaultNotFound, wparams.NewParamStorer(parameters...))
@@ -83,6 +98,11 @@ func NewNotFound(parameters ...wparams.ParamStorer) Error {
 // WrapWithNotFound returns new error instance of default not found type wrapping an existing error.
 func WrapWithNotFound(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultNotFound, wparams.NewParamStorer(parameters...))
+}
+
+// IsNotFound returns true if an error is an instance of default unauthorized type.
+func IsNotFoundError(err error) bool {
+	return isErrorOfType(err, DefaultNotFound)
 }
 
 // NewConflict returns new error instance of default conflict type.
@@ -95,6 +115,11 @@ func WrapWithConflict(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultConflict, wparams.NewParamStorer(parameters...))
 }
 
+// IsConflict returns true if an error is an instance of default unauthorized type.
+func IsConflict(err error) bool {
+	return isErrorOfType(err, DefaultConflict)
+}
+
 // NewRequestEntityTooLarge returns new error instance of default request entity too large type.
 func NewRequestEntityTooLarge(parameters ...wparams.ParamStorer) Error {
 	return newGenericError(nil, DefaultRequestEntityTooLarge, wparams.NewParamStorer(parameters...))
@@ -103,6 +128,11 @@ func NewRequestEntityTooLarge(parameters ...wparams.ParamStorer) Error {
 // WrapWithRequestEntityTooLarge returns new error instance of default request entity too large type wrapping an existing error.
 func WrapWithRequestEntityTooLarge(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultRequestEntityTooLarge, wparams.NewParamStorer(parameters...))
+}
+
+// IsRequestEntityTooLarge returns true if an error is an instance of default unauthorized type.
+func IsRequestEntityTooLarge(err error) bool {
+	return isErrorOfType(err, DefaultRequestEntityTooLarge)
 }
 
 // NewFailedPrecondition returns new error instance of default failed precondition type.
@@ -115,6 +145,11 @@ func WrapWithFailedPrecondition(cause error, parameters ...wparams.ParamStorer) 
 	return newGenericError(cause, DefaultFailedPrecondition, wparams.NewParamStorer(parameters...))
 }
 
+// IsFailedPrecondition returns true if an error is an instance of default unauthorized type.
+func IsFailedPrecondition(err error) bool {
+	return isErrorOfType(err, DefaultFailedPrecondition)
+}
+
 // NewInternal returns new error instance of default internal type.
 func NewInternal(parameters ...wparams.ParamStorer) Error {
 	return newGenericError(nil, DefaultInternal, wparams.NewParamStorer(parameters...))
@@ -125,6 +160,11 @@ func WrapWithInternal(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultInternal, wparams.NewParamStorer(parameters...))
 }
 
+// IsInternal returns true if an error is an instance of default unauthorized type.
+func IsInternal(err error) bool {
+	return isErrorOfType(err, DefaultInternal)
+}
+
 // NewTimeout returns new error instance of default timeout type.
 func NewTimeout(parameters ...wparams.ParamStorer) Error {
 	return newGenericError(nil, DefaultTimeout, wparams.NewParamStorer(parameters...))
@@ -133,4 +173,9 @@ func NewTimeout(parameters ...wparams.ParamStorer) Error {
 // WrapWithTimeout returns new error instance of default timeout type wrapping an existing error.
 func WrapWithTimeout(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultTimeout, wparams.NewParamStorer(parameters...))
+}
+
+// IsTimeout returns true if an error is an instance of default unauthorized type.
+func IsTimeout(err error) bool {
+	return isErrorOfType(err, DefaultTimeout)
 }

--- a/conjure-go-contract/errors/error.go
+++ b/conjure-go-contract/errors/error.go
@@ -70,7 +70,7 @@ func WrapWithPermissionDenied(cause error, parameters ...wparams.ParamStorer) Er
 	return newGenericError(cause, DefaultPermissionDenied, wparams.NewParamStorer(parameters...))
 }
 
-// IsPermissionDenied returns true if an error is an instance of default unauthorized type.
+// IsPermissionDenied returns true if an error is an instance of default permission denied type.
 func IsPermissionDenied(err error) bool {
 	return isErrorOfType(err, DefaultPermissionDenied)
 }
@@ -85,7 +85,7 @@ func WrapWithInvalidArgument(cause error, parameters ...wparams.ParamStorer) Err
 	return newGenericError(cause, DefaultInvalidArgument, wparams.NewParamStorer(parameters...))
 }
 
-// IsInvalidArgument returns true if an error is an instance of default unauthorized type.
+// IsInvalidArgument returns true if an error is an instance of default invalid argument type.
 func IsInvalidArgument(err error) bool {
 	return isErrorOfType(err, DefaultInvalidArgument)
 }
@@ -100,7 +100,7 @@ func WrapWithNotFound(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultNotFound, wparams.NewParamStorer(parameters...))
 }
 
-// IsNotFound returns true if an error is an instance of default unauthorized type.
+// IsNotFound returns true if an error is an instance of default not found type.
 func IsNotFound(err error) bool {
 	return isErrorOfType(err, DefaultNotFound)
 }
@@ -115,7 +115,7 @@ func WrapWithConflict(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultConflict, wparams.NewParamStorer(parameters...))
 }
 
-// IsConflict returns true if an error is an instance of default unauthorized type.
+// IsConflict returns true if an error is an instance of default conflict type.
 func IsConflict(err error) bool {
 	return isErrorOfType(err, DefaultConflict)
 }
@@ -130,7 +130,7 @@ func WrapWithRequestEntityTooLarge(cause error, parameters ...wparams.ParamStore
 	return newGenericError(cause, DefaultRequestEntityTooLarge, wparams.NewParamStorer(parameters...))
 }
 
-// IsRequestEntityTooLarge returns true if an error is an instance of default unauthorized type.
+// IsRequestEntityTooLarge returns true if an error is an instance of default request entity too large type.
 func IsRequestEntityTooLarge(err error) bool {
 	return isErrorOfType(err, DefaultRequestEntityTooLarge)
 }
@@ -145,7 +145,7 @@ func WrapWithFailedPrecondition(cause error, parameters ...wparams.ParamStorer) 
 	return newGenericError(cause, DefaultFailedPrecondition, wparams.NewParamStorer(parameters...))
 }
 
-// IsFailedPrecondition returns true if an error is an instance of default unauthorized type.
+// IsFailedPrecondition returns true if an error is an instance of default failed precondition type.
 func IsFailedPrecondition(err error) bool {
 	return isErrorOfType(err, DefaultFailedPrecondition)
 }
@@ -160,7 +160,7 @@ func WrapWithInternal(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultInternal, wparams.NewParamStorer(parameters...))
 }
 
-// IsInternal returns true if an error is an instance of default unauthorized type.
+// IsInternal returns true if an error is an instance of default internal type.
 func IsInternal(err error) bool {
 	return isErrorOfType(err, DefaultInternal)
 }
@@ -175,7 +175,7 @@ func WrapWithTimeout(cause error, parameters ...wparams.ParamStorer) Error {
 	return newGenericError(cause, DefaultTimeout, wparams.NewParamStorer(parameters...))
 }
 
-// IsTimeout returns true if an error is an instance of default unauthorized type.
+// IsTimeout returns true if an error is an instance of default timeout type.
 func IsTimeout(err error) bool {
 	return isErrorOfType(err, DefaultTimeout)
 }

--- a/conjure-go-contract/errors/error.go
+++ b/conjure-go-contract/errors/error.go
@@ -101,7 +101,7 @@ func WrapWithNotFound(cause error, parameters ...wparams.ParamStorer) Error {
 }
 
 // IsNotFound returns true if an error is an instance of default unauthorized type.
-func IsNotFoundError(err error) bool {
+func IsNotFound(err error) bool {
 	return isErrorOfType(err, DefaultNotFound)
 }
 

--- a/conjure-go-contract/errors/generic_error.go
+++ b/conjure-go-contract/errors/generic_error.go
@@ -175,3 +175,15 @@ func mergeParams(storer wparams.ParamStorer) map[string]interface{} {
 	}
 	return params
 }
+
+func isErrorOfType(err error, errorType ErrorType) bool {
+	if err == nil {
+		return false
+	}
+	conjureErr := GetConjureError(err)
+	if conjureErr == nil {
+		return false
+	}
+	return conjureErr.Name() == errorType.Name() &&
+		conjureErr.Code() == errorType.Code()
+}

--- a/conjure-go-contract/errors/generic_error_test.go
+++ b/conjure-go-contract/errors/generic_error_test.go
@@ -83,4 +83,10 @@ func TestIsErrorOfType(t *testing.T) {
 	err := NewNotFound()
 	assert.True(t, isErrorOfType(err, DefaultNotFound))
 	assert.False(t, isErrorOfType(err, DefaultInvalidArgument))
+
+	// nil error
+	assert.False(t, isErrorOfType(nil, DefaultNotFound))
+
+	// non-conjure error
+	assert.False(t, isErrorOfType(fmt.Errorf("error"), DefaultNotFound))
 }

--- a/conjure-go-contract/errors/generic_error_test.go
+++ b/conjure-go-contract/errors/generic_error_test.go
@@ -78,3 +78,9 @@ func TestError_NewError_Then_MarshalJSON_Then_UnmarshalJSON_And_Unpack(t *testin
 	assert.Equal(t, e.InstanceID(), unmarshaledError.InstanceID())
 	assert.Equal(t, mergeParams(e), mergeParams(unmarshaledError))
 }
+
+func TestIsErrorOfType(t *testing.T) {
+	err := NewNotFound()
+	assert.True(t, isErrorOfType(err, DefaultNotFound))
+	assert.False(t, isErrorOfType(err, DefaultInvalidArgument))
+}


### PR DESCRIPTION

==COMMIT_MSG==
Add IsErrorOfType support for generic errors
==COMMIT_MSG==

We generate these functions for typed errors, but they're often also very useful for generic error handling cases like `IsNotFound(err)` as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/262)
<!-- Reviewable:end -->
