### PR TITLE
fix: Don't propagate unhelpful json error in restErrorDecoder

### DIFF
--- a/changelog/@unreleased/pr-283.v2.yml
+++ b/changelog/@unreleased/pr-283.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Don't propagate unhelpful json error in restErrorDecoder
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/283

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -99,9 +99,9 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	if isJSON := strings.Contains(resp.Header.Get("Content-Type"), codecs.JSON.ContentType()); !isJSON {
 		return werror.Error(resp.Status, wSafeParams, wUnsafeParams, werror.UnsafeParam("responseBody", string(body)))
 	}
-	conjureErr, err := errors.UnmarshalError(body)
-	if err != nil {
-		return werror.Wrap(err, "", wSafeParams, wUnsafeParams, werror.UnsafeParam("responseBody", string(body)))
+	conjureErr, jsonErr := errors.UnmarshalError(body)
+	if jsonErr != nil {
+		return werror.Error(resp.Status, wSafeParams, wUnsafeParams, werror.UnsafeParam("responseBody", string(body)))
 	}
 	return werror.Wrap(conjureErr, "", wSafeParams, wUnsafeParams)
 }

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -135,9 +135,9 @@ func TestErrorDecoderMiddlewares(t *testing.T) {
 			},
 			verify: func(t *testing.T, u *url.URL, err error) {
 				verify404(t, err)
-				assert.EqualError(t, err, "httpclient request failed: failed to unmarshal body using registered type: errors: error name does not match regexp `^(([A-Z][a-z0-9]+)+):(([A-Z][a-z0-9]+)+)$`")
+				assert.EqualError(t, err, "httpclient request failed: 404 Not Found")
 				safeParams, unsafeParams := werror.ParamsFromError(err)
-				assert.Equal(t, map[string]interface{}{"requestHost": u.Host, "requestMethod": "Get", "statusCode": 404, "type": "errors.genericError"}, safeParams)
+				assert.Equal(t, map[string]interface{}{"requestHost": u.Host, "requestMethod": "Get", "statusCode": 404}, safeParams)
 				assert.Equal(t, map[string]interface{}{"requestPath": "/path", "responseBody": `{"foo":"bar"}`}, unsafeParams)
 			},
 		},


### PR DESCRIPTION
## Before this PR
We get ugly errors like below when a server returns a JSON content type that doesn't look like a conjure error.
```
httpclient request failed: failed to unmarshal body using registered type: errors: error name does not match regexp `^(([A-Z][a-z0-9]+)+):(([A-Z][a-z0-9]+)+)$`
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Don't propagate unhelpful json error in restErrorDecoder
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/283)
<!-- Reviewable:end -->
