### PR TITLE
improvement: Add a secret string comparison function

### DIFF
--- a/changelog/@unreleased/pr-294.v2.yml
+++ b/changelog/@unreleased/pr-294.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add a secret string comparison function
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/294

--- a/conjure-go-server/httpserver/rest.go
+++ b/conjure-go-server/httpserver/rest.go
@@ -15,6 +15,8 @@
 package httpserver
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -49,4 +51,20 @@ func ParseBearerTokenHeader(req *http.Request) (string, error) {
 		return "", werror.Error("Illegal authorization header, expected Bearer")
 	}
 	return headerSplit[1], nil
+}
+
+// SecretStringEqual will compare two strings and return true if they are
+// equal. The time taken for the comparison does not depend on the string
+// contents.
+func SecretStringEqual(expected, actual string) bool {
+	// compute hash of inputs since ConstantTimeCompare will leak if the
+	// length of the expected and actual secrets do not match.
+	expectedHash := sha256.Sum256([]byte(expected))
+	actualHash := sha256.Sum256([]byte(actual))
+
+	if subtle.ConstantTimeCompare(expectedHash[:], actualHash[:]) == 1 {
+		return true
+	}
+	return false
+
 }

--- a/conjure-go-server/httpserver/rest.go
+++ b/conjure-go-server/httpserver/rest.go
@@ -62,9 +62,5 @@ func SecretStringEqual(a, b string) bool {
 	aHash := sha256.Sum256([]byte(a))
 	bHash := sha256.Sum256([]byte(b))
 
-	if subtle.ConstantTimeCompare(aHash[:], bHash[:]) == 1 {
-		return true
-	}
-	return false
-
+	return subtle.ConstantTimeCompare(aHash[:], bHash[:]) == 1
 }

--- a/conjure-go-server/httpserver/rest.go
+++ b/conjure-go-server/httpserver/rest.go
@@ -56,13 +56,13 @@ func ParseBearerTokenHeader(req *http.Request) (string, error) {
 // SecretStringEqual will compare two strings and return true if they are
 // equal. The time taken for the comparison does not depend on the string
 // contents.
-func SecretStringEqual(expected, actual string) bool {
+func SecretStringEqual(a, b string) bool {
 	// compute hash of inputs since ConstantTimeCompare will leak if the
 	// length of the expected and actual secrets do not match.
-	expectedHash := sha256.Sum256([]byte(expected))
-	actualHash := sha256.Sum256([]byte(actual))
+	aHash := sha256.Sum256([]byte(a))
+	bHash := sha256.Sum256([]byte(b))
 
-	if subtle.ConstantTimeCompare(expectedHash[:], actualHash[:]) == 1 {
+	if subtle.ConstantTimeCompare(aHash[:], bHash[:]) == 1 {
 		return true
 	}
 	return false

--- a/conjure-go-server/httpserver/rest_test.go
+++ b/conjure-go-server/httpserver/rest_test.go
@@ -8,38 +8,38 @@ import (
 
 func TestValidateSecretStringEqual(t *testing.T) {
 	for _, tc := range []struct {
-		name           string
-		input          string
-		expectedSecret string
-		expectMatch    bool
+		name        string
+		a           string
+		b           string
+		expectMatch bool
 	}{
 		{
-			name:           "input and expected match with empty strings",
-			input:          "",
-			expectedSecret: "",
-			expectMatch:    true,
+			name:        "empty strings match",
+			a:           "",
+			b:           "",
+			expectMatch: true,
 		},
 		{
-			name:           "input and expected match with a secret",
-			input:          "secret",
-			expectedSecret: "secret",
-			expectMatch:    true,
+			name:        "strings match exactly",
+			a:           "secret",
+			b:           "secret",
+			expectMatch: true,
 		},
 		{
-			name:           "input does not match secret with empty string",
-			input:          "secret",
-			expectedSecret: "",
-			expectMatch:    false,
+			name:        "string does not match empty string",
+			a:           "secret",
+			b:           "",
+			expectMatch: false,
 		},
 		{
-			name:           "input does not match secret",
-			input:          "invalid",
-			expectedSecret: "secret",
-			expectMatch:    false,
+			name:        "string does not match other string",
+			a:           "invalid",
+			b:           "secret",
+			expectMatch: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectMatch, SecretStringEqual(tc.expectedSecret, tc.input))
+			assert.Equal(t, tc.expectMatch, SecretStringEqual(tc.a, tc.b))
 		})
 	}
 }

--- a/conjure-go-server/httpserver/rest_test.go
+++ b/conjure-go-server/httpserver/rest_test.go
@@ -47,8 +47,8 @@ func TestValidateSecretStringEqual(t *testing.T) {
 		},
 		{
 			name:        "string does not match other string",
-			a:           "invalid",
-			b:           "secret",
+			a:           "secret",
+			b:           "invalid",
 			expectMatch: false,
 		},
 	} {

--- a/conjure-go-server/httpserver/rest_test.go
+++ b/conjure-go-server/httpserver/rest_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httpserver
 
 import (

--- a/conjure-go-server/httpserver/rest_test.go
+++ b/conjure-go-server/httpserver/rest_test.go
@@ -1,0 +1,45 @@
+package httpserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSecretStringEqual(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		input          string
+		expectedSecret string
+		expectMatch    bool
+	}{
+		{
+			name:           "input and expected match with empty strings",
+			input:          "",
+			expectedSecret: "",
+			expectMatch:    true,
+		},
+		{
+			name:           "input and expected match with a secret",
+			input:          "secret",
+			expectedSecret: "secret",
+			expectMatch:    true,
+		},
+		{
+			name:           "input does not match secret with empty string",
+			input:          "secret",
+			expectedSecret: "",
+			expectMatch:    false,
+		},
+		{
+			name:           "input does not match secret",
+			input:          "invalid",
+			expectedSecret: "secret",
+			expectMatch:    false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectMatch, SecretStringEqual(tc.expectedSecret, tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Before this PR
When checking secrets such as bearer tokens, one should use a comparison method that is not susceptible to timing attacks. 

## After this PR
Add a helper function for doing string comparisons into the httpserver library. This method uses the `ConstantTimeCompare` method which will return whether two byte slices are equal regardless of the contents of the input strings. Noting that `ConstantTimeCompare` will return in [constant](https://cs.opensource.google/go/go/+/refs/tags/go1.18.1:src/crypto/subtle/constant_time.go;l=13-15) time if the two strings are not of equal length, therefore we hash the inputs so that both strings are always the same length. 

==COMMIT_MSG==
Add a secret string comparison function
==COMMIT_MSG==

## Possible downsides?
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/294)
<!-- Reviewable:end -->
