### PR TITLE
Move retry backoff behavior into separate middleware

### DIFF
--- a/changelog/@unreleased/pr-313.v2.yml
+++ b/changelog/@unreleased/pr-313.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Move retry backoff behavior into separate middleware
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/313

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -194,6 +194,8 @@ func (c *clientImpl) doOnce(
 
 func (c *clientImpl) getBackoffMiddleware(ctx context.Context) Middleware {
 	retrier := c.backoffOptions.CurrentRetryParams().Start(ctx)
+	// Call Next once so that the first repeated URI has backoff
+	retrier.Next()
 	return internal.NewBackoffMiddleware(func() {
 		retrier.Next()
 	})

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -97,7 +97,7 @@ func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Resp
 	var err error
 	var resp *http.Response
 
-	retrier := internal.NewRequestRetrier(uris, c.backoffOptions.CurrentRetryParams().Start(ctx), attempts)
+	retrier := internal.NewRequestRetrier(uris, attempts)
 	for {
 		uri, isRelocated := retrier.GetNextURI(resp, err)
 		if uri == "" {

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -55,7 +55,7 @@ func TestFailover429(t *testing.T) {
 	n := 0
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		n++
-		if n == 3 {
+		if n > 3 {
 			rw.WriteHeader(http.StatusOK)
 			_, err := rw.Write([]byte("body"))
 			require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestFailover429(t *testing.T) {
 		t.Error("Timer was not complete, back-off did not appear to occur")
 	}
 	assert.Nil(t, err)
-	assert.Equal(t, 3, n)
+	assert.Equal(t, 4, n)
 }
 
 func TestFailover200(t *testing.T) {

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -55,7 +55,7 @@ func TestFailover429(t *testing.T) {
 	n := 0
 	handler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		n++
-		if n > 3 {
+		if n == 3 {
 			rw.WriteHeader(http.StatusOK)
 			_, err := rw.Write([]byte("body"))
 			require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestFailover429(t *testing.T) {
 		t.Error("Timer was not complete, back-off did not appear to occur")
 	}
 	assert.Nil(t, err)
-	assert.Equal(t, 4, n)
+	assert.Equal(t, 3, n)
 }
 
 func TestFailover200(t *testing.T) {

--- a/conjure-go-client/httpclient/internal/backoff_middleware.go
+++ b/conjure-go-client/httpclient/internal/backoff_middleware.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"net/http"
+)
+
+type backoffMiddleware struct {
+	backoff  func()
+	seenUris map[string]interface{}
+}
+
+// NewBackoffMiddleware returns a Middleware that implements backoff for URIs that have already been seen.
+// The backoff function is expected to block for the desired backoff duration.
+func NewBackoffMiddleware(backoff func()) httpclient.Middleware {
+	return &backoffMiddleware{
+		backoff:  backoff,
+		seenUris: make(map[string]interface{}),
+	}
+}
+
+func (b *backoffMiddleware) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+	baseURI := getBaseURI(req.URL)
+	_, seen := b.seenUris[baseURI]
+	if seen {
+		b.backoff()
+	}
+	return next.RoundTrip(req)
+}

--- a/conjure-go-client/httpclient/internal/backoff_middleware.go
+++ b/conjure-go-client/httpclient/internal/backoff_middleware.go
@@ -20,7 +20,7 @@ import (
 
 type BackoffMiddleware struct {
 	backoff  func()
-	seenUris map[string]interface{}
+	seenUris map[string]struct{}
 }
 
 // NewBackoffMiddleware returns a Middleware that implements backoff for URIs that have already been seen.
@@ -28,7 +28,7 @@ type BackoffMiddleware struct {
 func NewBackoffMiddleware(backoff func()) *BackoffMiddleware {
 	return &BackoffMiddleware{
 		backoff:  backoff,
-		seenUris: make(map[string]interface{}),
+		seenUris: make(map[string]struct{}),
 	}
 }
 
@@ -38,5 +38,6 @@ func (b *BackoffMiddleware) RoundTrip(req *http.Request, next http.RoundTripper)
 	if seen {
 		b.backoff()
 	}
+	b.seenUris[baseURI] = struct{}{}
 	return next.RoundTrip(req)
 }

--- a/conjure-go-client/httpclient/internal/backoff_middleware.go
+++ b/conjure-go-client/httpclient/internal/backoff_middleware.go
@@ -15,25 +15,24 @@
 package internal
 
 import (
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
 	"net/http"
 )
 
-type backoffMiddleware struct {
+type BackoffMiddleware struct {
 	backoff  func()
 	seenUris map[string]interface{}
 }
 
 // NewBackoffMiddleware returns a Middleware that implements backoff for URIs that have already been seen.
 // The backoff function is expected to block for the desired backoff duration.
-func NewBackoffMiddleware(backoff func()) httpclient.Middleware {
-	return &backoffMiddleware{
+func NewBackoffMiddleware(backoff func()) *BackoffMiddleware {
+	return &BackoffMiddleware{
 		backoff:  backoff,
 		seenUris: make(map[string]interface{}),
 	}
 }
 
-func (b *backoffMiddleware) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+func (b *BackoffMiddleware) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
 	baseURI := getBaseURI(req.URL)
 	_, seen := b.seenUris[baseURI]
 	if seen {

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -33,7 +33,6 @@ type RequestRetrier struct {
 	uris          []string
 	offset        int
 	relocatedURIs map[string]struct{}
-	failedURIs    map[string]struct{}
 	maxAttempts   int
 	attemptCount  int
 }
@@ -47,7 +46,6 @@ func NewRequestRetrier(uris []string, maxAttempts int) *RequestRetrier {
 		uris:          uris,
 		offset:        offset,
 		relocatedURIs: map[string]struct{}{},
-		failedURIs:    map[string]struct{}{},
 		maxAttempts:   maxAttempts,
 		attemptCount:  0,
 	}
@@ -79,68 +77,58 @@ func (r *RequestRetrier) GetNextURI(resp *http.Response, respErr error) (uri str
 		// Mesh uris don't get retried
 		return "", false
 	}
-	retryFn := r.getRetryFn(resp, respErr)
-	if retryFn == nil {
+	nextURI := r.getNextURI(resp, respErr)
+	if nextURI == "" {
 		// The previous response was not retryable
 		return "", false
 	}
-	// Updates currentURI
-	if !retryFn() {
-		return "", false
-	}
-	return r.currentURI, r.isRelocatedURI(r.currentURI)
+	return nextURI, r.isRelocatedURI(nextURI)
 }
 
-func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() bool {
+func (r *RequestRetrier) getNextURI(resp *http.Response, respErr error) string {
 	errCode, _ := StatusCodeFromError(respErr)
-	if retryOther, _ := isThrottleResponse(resp, errCode); retryOther {
-		// 429: throttle
-		// Immediately backoff and select the next URI.
-		// TODO(whickman): use the retry-after header once #81 is resolved
-		return r.nextURIOrBackoff
-	} else if isUnavailableResponse(resp, errCode) {
-		// 503: go to next node
-		return r.nextURIOrBackoff
-	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr, errCode); shouldTryOther {
-		// 307 or 308: go to next node, or particular node if provided.
-		if otherURI != nil {
-			return func() bool {
-				r.setURIAndResetBackoff(otherURI)
-				return true
-			}
-		}
-		return r.nextURIOrBackoff
-	} else if errCode >= http.StatusBadRequest && errCode < http.StatusInternalServerError {
-		return nil
-	} else if resp == nil {
-		// if we get a nil response, we can assume there is a problem with host and can move on to the next.
-		return r.nextURIOrBackoff
+	// 2XX and 4XX responses (except 429) are not retryable
+	if isSuccess(resp) || isNonRetryableClientError(resp, errCode) {
+		return ""
 	}
-	return nil
+	// 307 or 308: go to particular node if provided
+	if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr, errCode); shouldTryOther && otherURI != nil {
+		r.setRelocatedURI(otherURI)
+	} else {
+		r.nextURI()
+	}
+	return r.currentURI
 }
 
-func (r *RequestRetrier) setURIAndResetBackoff(otherURI *url.URL) {
-	// If the URI returned by relocation header is a relative path
-	// We will resolve it with the current URI
-	if !otherURI.IsAbs() {
-		if currentURI := parseLocationURL(r.currentURI); currentURI != nil {
-			otherURI = currentURI.ResolveReference(otherURI)
+func isSuccess(resp *http.Response) bool {
+	// Check for a 2XX status
+	return resp != nil && resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func isNonRetryableClientError(resp *http.Response, errCode int) bool {
+	// Check for a 4XX status parsed from the error or in the response
+	if isClientError(errCode) || (resp != nil && isClientError(resp.StatusCode)) {
+		// 429 is retryable
+		if isThrottle, _ := isThrottleResponse(resp, errCode); !isThrottle {
+			return true
 		}
 	}
-	nextURI := otherURI.String()
-	r.relocatedURIs[otherURI.String()] = struct{}{}
+	return false
+}
+
+func (r *RequestRetrier) setRelocatedURI(uri *url.URL) {
+	// If the URI returned by relocation header is a relative path we will resolve it with the current URI
+	if !uri.IsAbs() {
+		if currentURI := parseLocationURL(r.currentURI); currentURI != nil {
+			uri = currentURI.ResolveReference(uri)
+		}
+	}
+	nextURI := uri.String()
+	r.relocatedURIs[uri.String()] = struct{}{}
 	r.currentURI = nextURI
 }
 
-// If lastURI was already marked failed, we perform a backoff as determined by the retrier before returning the next URI and its offset.
-// Otherwise, we add lastURI to failedURIs and return the next URI and its offset immediately.
-func (r *RequestRetrier) nextURIOrBackoff() bool {
-	r.markFailedAndMoveToNextURI()
-	return true
-}
-
-func (r *RequestRetrier) markFailedAndMoveToNextURI() {
-	r.failedURIs[r.currentURI] = struct{}{}
+func (r *RequestRetrier) nextURI() {
 	nextURIOffset := (r.offset + 1) % len(r.uris)
 	nextURI := r.uris[nextURIOffset]
 	r.currentURI = nextURI

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -106,19 +106,11 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 		shouldRetrySameURI bool
 	}{
 		{
-			name:               "returns error if response exists and doesn't appear retryable",
+			name:               "returns a URI if response is empty",
 			resp:               &http.Response{},
 			respErr:            nil,
 			uris:               []string{"a", "b"},
-			shouldRetry:        false,
-			shouldRetrySameURI: false,
-		},
-		{
-			name:               "returns error if error code not retryable",
-			resp:               &http.Response{},
-			respErr:            nil,
-			uris:               []string{"a", "b"},
-			shouldRetry:        false,
+			shouldRetry:        true,
 			shouldRetrySameURI: false,
 		},
 		{

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -20,16 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/pkg/retry"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var _ retry.Retrier = &mockRetrier{}
-
 func TestRequestRetrier_HandleMeshURI(t *testing.T) {
-	r := NewRequestRetrier([]string{"mesh-http://example.com"}, retry.Start(context.Background()), 1)
+	r := NewRequestRetrier([]string{"mesh-http://example.com"}, 1)
 	uri, _ := r.GetNextURI(nil, nil)
 	require.Equal(t, uri, "http://example.com")
 
@@ -40,7 +36,7 @@ func TestRequestRetrier_HandleMeshURI(t *testing.T) {
 
 func TestRequestRetrier_AttemptCount(t *testing.T) {
 	maxAttempts := 3
-	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(context.Background()), maxAttempts)
+	r := NewRequestRetrier([]string{"https://example.com"}, maxAttempts)
 	// first request is not a retry
 	uri, _ := r.GetNextURI(nil, nil)
 	require.Equal(t, uri, "https://example.com")
@@ -54,46 +50,18 @@ func TestRequestRetrier_AttemptCount(t *testing.T) {
 }
 
 func TestRequestRetrier_UnlimitedAttempts(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	_, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(ctx, retry.WithInitialBackoff(50*time.Millisecond), retry.WithRandomizationFactor(0)), 0)
+	r := NewRequestRetrier([]string{"https://example.com"}, 0)
 
-	startTime := time.Now()
-	uri, _ := r.GetNextURI(nil, nil)
-	require.Equal(t, uri, "https://example.com")
-	require.Lessf(t, time.Since(startTime), 49*time.Millisecond, "first GetNextURI should not have any delay")
-
-	startTime = time.Now()
-	uri, _ = r.GetNextURI(nil, nil)
-	require.Equal(t, uri, "https://example.com")
-	assert.Greater(t, time.Since(startTime), 50*time.Millisecond, "delay should be at least 1 backoff")
-	assert.Less(t, time.Since(startTime), 100*time.Millisecond, "delay should be less than 2 backoffs")
-
-	startTime = time.Now()
-	uri, _ = r.GetNextURI(nil, nil)
-	require.Equal(t, uri, "https://example.com")
-	assert.Greater(t, time.Since(startTime), 100*time.Millisecond, "delay should be at least 2 backoffs")
-	assert.Less(t, time.Since(startTime), 200*time.Millisecond, "delay should be less than 3 backoffs")
+	for i := 0; i <= 10; i++ {
+		uri, _ := r.GetNextURI(nil, nil)
+		require.Equal(t, uri, "https://example.com")
+	}
 
 	// Success should stop retries
-	uri, _ = r.GetNextURI(&http.Response{StatusCode: 200}, nil)
-	require.Empty(t, uri)
-}
-
-func TestRequestRetrier_ContextCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(ctx), 0)
-
-	// First attempt should return a URI to ensure that the client can instrument the request even
-	// if the context is done
-	uri, _ := r.GetNextURI(nil, nil)
-	require.Equal(t, uri, "https://example.com")
-
-	// Subsequent attempt should stop retries
-	uri, _ = r.GetNextURI(nil, nil)
+	uri, _ := r.GetNextURI(&http.Response{StatusCode: 200}, nil)
 	require.Empty(t, uri)
 }
 
@@ -103,7 +71,7 @@ func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 		Header:     http.Header{"Location": []string{"http://example.com"}},
 	}
 
-	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 2)
+	r := NewRequestRetrier([]string{"a"}, 2)
 	uri, isRelocated := r.GetNextURI(nil, nil)
 	require.Equal(t, uri, "a")
 	require.False(t, isRelocated)
@@ -114,7 +82,7 @@ func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 }
 
 func TestRequestRetrier_UsesLocationFromErr(t *testing.T) {
-	r := NewRequestRetrier([]string{"http://example-1.com"}, retry.Start(context.Background()), 2)
+	r := NewRequestRetrier([]string{"http://example-1.com"}, 2)
 	respErr := werror.ErrorWithContextParams(context.Background(), "307",
 		werror.SafeParam("statusCode", 307),
 		werror.SafeParam("location", "http://example-2.com"))
@@ -136,8 +104,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 		uris               []string
 		shouldRetry        bool
 		shouldRetrySameURI bool
-		shouldRetryBackoff bool
-		shouldRetryReset   bool
 	}{
 		{
 			name:               "returns error if response exists and doesn't appear retryable",
@@ -146,8 +112,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        false,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "returns error if error code not retryable",
@@ -156,8 +120,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        false,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "returns a URI if response and error are nil",
@@ -166,8 +128,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        true,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "returns a URI if response and error are nil",
@@ -176,8 +136,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        true,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "retries and backs off the single URI if response and error are nil",
@@ -186,8 +144,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a"},
 			shouldRetry:        true,
 			shouldRetrySameURI: true,
-			shouldRetryBackoff: true,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "returns a new URI if unavailable",
@@ -196,8 +152,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        true,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "retries and backs off the single URI if unavailable",
@@ -206,8 +160,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a"},
 			shouldRetry:        true,
 			shouldRetrySameURI: true,
-			shouldRetryBackoff: true,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "returns a new URI and backs off if throttled",
@@ -216,8 +168,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        true,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: true,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "retries single URI and backs off if throttled",
@@ -226,8 +176,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a"},
 			shouldRetry:        true,
 			shouldRetrySameURI: true,
-			shouldRetryBackoff: true,
-			shouldRetryReset:   false,
 		},
 		{
 			name: "retries another URI if gets retry other response without location",
@@ -238,8 +186,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        true,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name: "retries single URI and backs off if gets retry other response without location",
@@ -250,8 +196,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a"},
 			shouldRetry:        true,
 			shouldRetrySameURI: true,
-			shouldRetryBackoff: true,
-			shouldRetryReset:   false,
 		},
 		{
 			name: "retries another URI if gets retry temporary redirect response without location",
@@ -262,8 +206,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        true,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name: "retries single URI and backs off if gets retry temporary redirect response without location",
@@ -274,8 +216,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a"},
 			shouldRetry:        true,
 			shouldRetrySameURI: true,
-			shouldRetryBackoff: true,
-			shouldRetryReset:   false,
 		},
 		{
 			name: "does not retry 400 responses",
@@ -285,8 +225,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        false,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name: "does not retry 404 responses",
@@ -296,8 +234,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        false,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "does not retry 400 errors",
@@ -305,8 +241,6 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        false,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 		{
 			name:               "does not retry 404s",
@@ -314,13 +248,10 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 			uris:               []string{"a", "b"},
 			shouldRetry:        false,
 			shouldRetrySameURI: false,
-			shouldRetryBackoff: false,
-			shouldRetryReset:   false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			retrier := newMockRetrier()
-			r := NewRequestRetrier(tc.uris, retrier, 2)
+			r := NewRequestRetrier(tc.uris, 2)
 			// first URI isn't a retry
 			firstURI, _ := r.GetNextURI(nil, nil)
 			require.NotEmpty(t, firstURI)
@@ -333,40 +264,9 @@ func TestRequestRetrier_GetNextURI(t *testing.T) {
 				} else {
 					require.NotEqual(t, retryURI, firstURI)
 				}
-				if tc.shouldRetryReset {
-					require.True(t, retrier.DidReset)
-				}
-				if tc.shouldRetryBackoff {
-					require.True(t, retrier.DidGetNext)
-				}
 			} else {
 				require.Empty(t, retryURI)
 			}
 		})
 	}
-}
-
-func newMockRetrier() *mockRetrier {
-	return &mockRetrier{
-		DidGetNext: false,
-		DidReset:   false,
-	}
-}
-
-type mockRetrier struct {
-	DidGetNext bool
-	DidReset   bool
-}
-
-func (m *mockRetrier) Reset() {
-	m.DidReset = true
-}
-
-func (m *mockRetrier) Next() bool {
-	m.DidGetNext = true
-	return true
-}
-
-func (m *mockRetrier) CurrentAttempt() int {
-	return 0
 }

--- a/conjure-go-client/httpclient/internal/retry.go
+++ b/conjure-go-client/httpclient/internal/retry.go
@@ -112,13 +112,3 @@ func isThrottleResponse(resp *http.Response, errCode int) (bool, time.Duration) 
 	}
 	return true, time.Until(retryAfterDate)
 }
-
-func isUnavailableResponse(resp *http.Response, errCode int) bool {
-	if errCode == StatusCodeUnavailable {
-		return true
-	}
-	if resp == nil || resp.StatusCode != StatusCodeUnavailable {
-		return false
-	}
-	return true
-}

--- a/conjure-go-client/httpclient/internal/retry_test.go
+++ b/conjure-go-client/httpclient/internal/retry_test.go
@@ -32,7 +32,6 @@ func TestRetryResponseParsers(t *testing.T) {
 		RetryOtherURL    string
 		IsThrottle       bool
 		ThrottleDuration time.Duration
-		IsUnavailable    bool
 	}{
 		{
 			Name: "200 OK",
@@ -104,10 +103,9 @@ func TestRetryResponseParsers(t *testing.T) {
 			IsThrottle: true,
 		},
 		{
-			Name:          "503 unavailable in error",
-			Response:      nil,
-			RespErr:       werror.Error("error", werror.SafeParam("statusCode", 503)),
-			IsUnavailable: true,
+			Name:     "503 unavailable in error",
+			Response: nil,
+			RespErr:  werror.Error("error", werror.SafeParam("statusCode", 503)),
 		},
 		{
 			Name: "429 throttle with Retry-After seconds",
@@ -141,9 +139,6 @@ func TestRetryResponseParsers(t *testing.T) {
 			if assert.Equal(t, test.IsThrottle, isThrottle) {
 				assert.WithinDuration(t, time.Now().Add(test.ThrottleDuration), time.Now().Add(throttleDur), time.Second)
 			}
-
-			isUnavailable := isUnavailableResponse(test.Response, errCode)
-			assert.Equal(t, test.IsUnavailable, isUnavailable)
 		})
 	}
 }

--- a/conjure-go-client/httpclient/internal/retry_test.go
+++ b/conjure-go-client/httpclient/internal/retry_test.go
@@ -103,11 +103,6 @@ func TestRetryResponseParsers(t *testing.T) {
 			IsThrottle: true,
 		},
 		{
-			Name:     "503 unavailable in error",
-			Response: nil,
-			RespErr:  werror.Error("error", werror.SafeParam("statusCode", 503)),
-		},
-		{
 			Name: "429 throttle with Retry-After seconds",
 			Response: &http.Response{
 				Header:     http.Header{"Retry-After": []string{"60"}},


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

It's difficult to reason about and modify URI selection or retry behavior because the functionality has been coupled in the `RequestRetrier`.  `RequestRetrier` as currently implemented is responsible for several things:
- Determining if a response can be retried
- Choosing the URI for the next attempt
- Implementing backoff behavior

This change simplifies backoff behavior and separates it into an independent middleware to begin cleaning this up.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Move retry backoff behavior into separate middleware
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/313)
<!-- Reviewable:end -->
