### PR TITLE
Default to using balanced scoring instead of randomizing request URIs

### DIFF
--- a/changelog/@unreleased/pr-347.v2.yml
+++ b/changelog/@unreleased/pr-347.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    Default to using balanced scoring instead of randomizing request URIs.
+    To keep the previous default behavior of randomizing URIs, use the WithRandomURIScoring ClientParam.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/347

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -155,7 +155,7 @@ func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (Cl
 	}
 	uriScorer := internal.NewRefreshableURIScoringMiddleware(b.URIs, func(uris []string) internal.URIScoringMiddleware {
 		if b.URIScorerBuilder == nil {
-			return internal.NewRandomURIScoringMiddleware(uris, func() int64 { return time.Now().UnixNano() })
+			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 { return time.Now().UnixNano() })
 		}
 		return b.URIScorerBuilder(uris)
 	})

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -535,7 +535,20 @@ func WithBasicAuth(username, password string) ClientParam {
 
 // WithBalancedURIScoring adds middleware that prioritizes sending requests to URIs with the fewest in-flight requests
 // and least recent errors.
+// Deprecated: This param is a no-op as balanced URI scoring is the default behavior.
 func WithBalancedURIScoring() ClientParam {
+	return clientParamFunc(func(b *clientBuilder) error {
+		b.URIScorerBuilder = func(uris []string) internal.URIScoringMiddleware {
+			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 {
+				return time.Now().UnixNano()
+			})
+		}
+		return nil
+	})
+}
+
+// WithRandomURIScoring adds middleware that randomizes the order URIs are prioritized in for each request.
+func WithRandomURIScoring() ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
 		b.URIScorerBuilder = func(uris []string) internal.URIScoringMiddleware {
 			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Current default behavior is to random URI scoring. In cases where a specific URI(s) is unavailable then request that attempt that URI first need to be retried.

Would like to merge and release this before parts of https://github.com/palantir/conjure-go-runtime/pull/347 are merged so that refactor can default to use balanced instead of strict round-robin.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Default to using balanced scoring instead of randomizing request URIs.
To keep the previous default behavior of randomizing URIs, use the WithRandomURIScoring ClientParam.
==COMMIT_MSG==

Default behavior is to use balanced URI scoring. Balanced scoring uses an exponentially decaying reservoir to track failures and tracks in-flight requests by URI so that URIs that have not failed recently and with fewest in-flight requests are prioritized.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Clients that relied on uniformly distributing requests regardless of failures or concurrent requests would be impacted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/347)
<!-- Reviewable:end -->
