### PR TITLE
improvement: Parse full qualified redirect URI in error handler middleware.

### DIFF
--- a/changelog/@unreleased/pr-348.v2.yml
+++ b/changelog/@unreleased/pr-348.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Parse full qualified redirect URI in error handler middleware.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/348

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -148,11 +148,11 @@ func (c *clientImpl) doOnce(
 		return nil, werror.ErrorWithContextParams(ctx, "httpclient: use WithRequestMethod() to specify HTTP method")
 	}
 	reqURI := joinURIAndPath(baseURI, b.path)
-	req, err := http.NewRequest(b.method, reqURI, nil)
+	req, err := http.NewRequestWithContext(ctx, b.method, reqURI, nil)
 	if err != nil {
 		return nil, werror.WrapWithContextParams(ctx, err, "failed to build new HTTP request")
 	}
-	req = req.WithContext(ctx)
+
 	req.Header = b.headers
 	if q := b.query.Encode(); q != "" {
 		req.URL.RawQuery = q

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -108,7 +108,7 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() b
 	} else if isUnavailableResponse(resp, errCode) {
 		// 503: go to next node
 		return r.nextURIOrBackoff
-	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr); shouldTryOther {
+	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr, errCode); shouldTryOther {
 		// 307 or 308: go to next node, or particular node if provided.
 		if otherURI != nil {
 			return func() bool {

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -108,7 +108,7 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() b
 	} else if isUnavailableResponse(resp, errCode) {
 		// 503: go to next node
 		return r.nextURIOrBackoff
-	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr, errCode); shouldTryOther {
+	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr); shouldTryOther {
 		// 307 or 308: go to next node, or particular node if provided.
 		if otherURI != nil {
 			return func() bool {
@@ -127,13 +127,6 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() b
 }
 
 func (r *RequestRetrier) setURIAndResetBackoff(otherURI *url.URL) {
-	// If the URI returned by relocation header is a relative path
-	// We will resolve it with the current URI
-	if !otherURI.IsAbs() {
-		if currentURI := parseLocationURL(r.currentURI); currentURI != nil {
-			otherURI = currentURI.ResolveReference(otherURI)
-		}
-	}
 	nextURI := otherURI.String()
 	r.relocatedURIs[otherURI.String()] = struct{}{}
 	r.retrier.Reset()

--- a/conjure-go-client/httpclient/internal/retry.go
+++ b/conjure-go-client/httpclient/internal/retry.go
@@ -59,9 +59,7 @@ const (
 	StatusCodeUnavailable            = http.StatusServiceUnavailable
 )
 
-func isRetryOtherResponse(resp *http.Response, err error) (bool, *url.URL) {
-	errCode, _ := StatusCodeFromError(err)
-	// prioritize redirect from werror first
+func isRetryOtherResponse(resp *http.Response, err error, errCode int) (bool, *url.URL) {
 	if errCode == StatusCodeRetryOther || errCode == StatusCodeRetryTemporaryRedirect {
 		locationStr, ok := LocationFromError(err)
 		if !ok {

--- a/conjure-go-client/httpclient/internal/retry_test.go
+++ b/conjure-go-client/httpclient/internal/retry_test.go
@@ -129,14 +129,14 @@ func TestRetryResponseParsers(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			errCode, _ := StatusCodeFromError(test.RespErr)
-			isRetryOther, retryOtherURL := isRetryOtherResponse(test.Response, test.RespErr, errCode)
+			isRetryOther, retryOtherURL := isRetryOtherResponse(test.Response, test.RespErr)
 			if assert.Equal(t, test.IsRetryOther, isRetryOther) && test.RetryOtherURL != "" {
 				if assert.NotNil(t, retryOtherURL) {
 					assert.Equal(t, test.RetryOtherURL, retryOtherURL.String())
 				}
 			}
 
+			errCode, _ := StatusCodeFromError(test.RespErr)
 			isThrottle, throttleDur := isThrottleResponse(test.Response, errCode)
 			if assert.Equal(t, test.IsThrottle, isThrottle) {
 				assert.WithinDuration(t, time.Now().Add(test.ThrottleDuration), time.Now().Add(throttleDur), time.Second)

--- a/conjure-go-client/httpclient/internal/retry_test.go
+++ b/conjure-go-client/httpclient/internal/retry_test.go
@@ -129,14 +129,14 @@ func TestRetryResponseParsers(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			isRetryOther, retryOtherURL := isRetryOtherResponse(test.Response, test.RespErr)
+			errCode, _ := StatusCodeFromError(test.RespErr)
+			isRetryOther, retryOtherURL := isRetryOtherResponse(test.Response, test.RespErr, errCode)
 			if assert.Equal(t, test.IsRetryOther, isRetryOther) && test.RetryOtherURL != "" {
 				if assert.NotNil(t, retryOtherURL) {
 					assert.Equal(t, test.RetryOtherURL, retryOtherURL.String())
 				}
 			}
 
-			errCode, _ := StatusCodeFromError(test.RespErr)
 			isThrottle, throttleDur := isThrottleResponse(test.Response, errCode)
 			if assert.Equal(t, test.IsThrottle, isThrottle) {
 				assert.WithinDuration(t, time.Now().Add(test.ThrottleDuration), time.Now().Add(throttleDur), time.Second)

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -81,7 +81,10 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	unsafeParams := map[string]interface{}{}
 	if resp.StatusCode >= http.StatusTemporaryRedirect &&
 		resp.StatusCode < http.StatusBadRequest {
-		unsafeParams["location"] = resp.Header.Get("Location")
+		location, err := resp.Location()
+		if err == nil {
+			unsafeParams["location"] = location.String()
+		}
 	}
 	wSafeParams := werror.SafeParams(safeParams)
 	wUnsafeParams := werror.UnsafeParams(unsafeParams)

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -65,7 +65,7 @@ func TestErrorDecoderMiddlewares(t *testing.T) {
 				assert.True(t, ok)
 				assert.Equal(t, 307, code)
 				location, ok := httpclient.LocationFromError(err)
-				assert.True(t, ok)
+				assert.False(t, ok)
 				assert.Equal(t, "", location)
 			},
 		},


### PR DESCRIPTION
## Before this PR
The `RequestRetrier` interprets the returned `Location` header for 307/308 requests from the returned witchcraft error. The Location header may contain a URI+path or just a relative path that should be used instead of path used in the original request. We previously we handle the relative path case in the `RequestRetrier`.

## After this PR
Use the `resp.Location()` stlib function to always get the full URI path we should retry on the next request. 

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Parse full qualified redirect URI in error handler middleware.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/348)
<!-- Reviewable:end -->
