### PR TITLE
improvement: Refactor req retrier/URI selection into new URISelector interface.

### DIFF
--- a/changelog/@unreleased/pr-349.v2.yml
+++ b/changelog/@unreleased/pr-349.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refactor req retrier/URI selection into new URISelector interface.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/349

--- a/conjure-go-client/httpclient/internal/interface.go
+++ b/conjure-go-client/httpclient/internal/interface.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+)
+
+// URISelector is middleware implemented on a CGR client to determine available/prefered URIs to use when building
+// requests.
+type URISelector interface {
+	// Select takes a list of URIs and returns all or a subset of the the passed in URIs ordered by preference of
+	// use.
+	Select([]string, http.Header) ([]string, error)
+	// RoundTrip implements CGR middleware
+	RoundTrip(*http.Request, http.RoundTripper) (*http.Response, error)
+}


### PR DESCRIPTION
## Before this PR
The components of the request retrier in CGR were tightly coupled and hard to reason about. Due to how requests are retried currently, we are unable to preserve server state across requests very easily.

## After this PR
The URISelector interface allows for implementations of client side load balancing algorithms.  For example, least used connection, server size error handling, rendezvous routing, zone aware routing, strict client side sharing, ect. Multiple URISelectors can be chained together in order to compound the client balancing that occurs. 

==COMMIT_MSG==
Refactor req retrier/URI selection into new URISelector interface.
==COMMIT_MSG==

Feature branch replacement of: https://github.com/palantir/conjure-go-runtime/pull/341

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/349)
<!-- Reviewable:end -->
