### PR TITLE
improvement: Implement round robin scorer as URISelector interface

### DIFF
--- a/changelog/@unreleased/pr-351.v2.yml
+++ b/changelog/@unreleased/pr-351.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Implement round robin scorer as URISelector interface
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/351

--- a/conjure-go-client/httpclient/internal/rr_selector.go
+++ b/conjure-go-client/httpclient/internal/rr_selector.go
@@ -29,7 +29,8 @@ type roundRobinSelector struct {
 }
 
 // NewRoundRobinURISelector returns a URI scorer that uses a round robin algorithm for selecting URIs when scoring
-// using a rand.Rand seeded by the nanoClock function. The middleware no-ops on each request.
+// using a rand.Rand seeded by the nanoClock function. The middleware no-ops on each request. This selector will always
+// return one URI.
 func NewRoundRobinURISelector(nanoClock func() int64) URISelector {
 	return &roundRobinSelector{
 		source:   rand.NewSource(nanoClock()),

--- a/conjure-go-client/httpclient/internal/rr_selector.go
+++ b/conjure-go-client/httpclient/internal/rr_selector.go
@@ -18,6 +18,8 @@ import (
 	"math/rand"
 	"net/http"
 	"sync"
+
+	werror "github.com/palantir/witchcraft-go-error"
 )
 
 type roundRobinSelector struct {
@@ -42,6 +44,9 @@ func NewRoundRobinURISelector(nanoClock func() int64) URISelector {
 func (s *roundRobinSelector) Select(uris []string, _ http.Header) ([]string, error) {
 	s.Lock()
 	defer s.Unlock()
+	if len(uris) == 0 {
+		return nil, werror.Error("no valid uris provided to round robin uri-selector")
+	}
 
 	s.updateURIs(uris)
 	s.offset = (s.offset + 1) % len(uris)

--- a/conjure-go-client/httpclient/internal/rr_selector.go
+++ b/conjure-go-client/httpclient/internal/rr_selector.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"sync"
+)
+
+type roundRobinSelector struct {
+	sync.Mutex
+	nanoClock func() int64
+
+	offset int
+}
+
+// NewRoundRobinURISelector returns a URI scorer that uses a round robin algorithm for selecting URIs when scoring
+// using a rand.Rand seeded by the nanoClock function. The middleware no-ops on each request.
+func NewRoundRobinURISelector(nanoClock func() int64) URISelector {
+	return &roundRobinSelector{
+		nanoClock: nanoClock,
+	}
+}
+
+// Select implements Selector interface
+func (s *roundRobinSelector) Select(uris []string, _ http.Header) ([]string, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.offset = (s.offset + 1) % len(uris)
+
+	return []string{uris[s.offset]}, nil
+}
+
+func (s *roundRobinSelector) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+	return next.RoundTrip(req)
+}

--- a/conjure-go-client/httpclient/internal/rr_selector_test.go
+++ b/conjure-go-client/httpclient/internal/rr_selector_test.go
@@ -19,27 +19,35 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoundRobinSelector_Select(t *testing.T) {
-	uris := []string{"uri1", "uri2", "uri3", "uri4", "uri5"}
 	scorer := NewRoundRobinURISelector(func() int64 { return time.Now().UnixNano() })
 
-	const iterations = 100
-	observed := make(map[string]int, iterations)
-	for i := 0; i < iterations; i++ {
-		uri, err := scorer.Select(uris, nil)
-		assert.NoError(t, err)
-		assert.Len(t, uri, 1)
-		observed[uri[0]] = observed[uri[0]] + 1
-	}
+	t.Run("round robins across valid connections", func(t *testing.T) {
+		uris := []string{"uri1", "uri2", "uri3", "uri4", "uri5"}
+		const iterations = 100
+		observed := make(map[string]int, iterations)
+		for i := 0; i < iterations; i++ {
+			uri, err := scorer.Select(uris, nil)
+			assert.NoError(t, err)
+			assert.Len(t, uri, 1)
+			observed[uri[0]] = observed[uri[0]] + 1
+		}
 
-	occurences := make([]int, 0, len(observed))
-	for _, count := range observed {
-		occurences = append(occurences, count)
-	}
+		occurences := make([]int, 0, len(observed))
+		for _, count := range observed {
+			occurences = append(occurences, count)
+		}
 
-	for _, v := range occurences {
-		assert.Equal(t, occurences[0], v)
-	}
+		for _, v := range occurences {
+			assert.Equal(t, occurences[0], v)
+		}
+	})
+
+	t.Run("erorrs with empty set of provided uris", func(t *testing.T) {
+		_, err := scorer.Select([]string{}, nil)
+		require.Error(t, err)
+	})
 }

--- a/conjure-go-client/httpclient/internal/rr_selector_test.go
+++ b/conjure-go-client/httpclient/internal/rr_selector_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundRobinSelector_Select(t *testing.T) {
+	uris := []string{"uri1", "uri2", "uri3", "uri4", "uri5"}
+	scorer := NewRoundRobinURISelector(func() int64 { return time.Now().UnixNano() })
+
+	const iterations = 100
+	observed := make(map[string]int, iterations)
+	for i := 0; i < iterations; i++ {
+		uri, err := scorer.Select(uris, nil)
+		assert.NoError(t, err)
+		assert.Len(t, uri, 1)
+		observed[uri[0]] = observed[uri[0]] + 1
+	}
+
+	occurences := make([]int, 0, len(observed))
+	for _, count := range observed {
+		occurences = append(occurences, count)
+	}
+
+	for _, v := range occurences {
+		assert.Equal(t, occurences[0], v)
+	}
+}


### PR DESCRIPTION
## Before this PR
Referencing the new URIScorer interface from https://github.com/palantir/conjure-go-runtime/pull/349, we add a implementation of the URIScorer for the round robin URI scoring algorithm. Round robin as of recently was the default algo for selecting URIs. It's implementation was subtle within the request retrier seen here:
https://github.com/palantir/conjure-go-runtime/blob/5af5fa96537ed2ae5e3dba9f7791a7fbf80699a5/conjure-go-client/httpclient/internal/request_retrier.go#L156

## After this PR
==COMMIT_MSG==
Implement round robin scorer as URISelector interface
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/351)
<!-- Reviewable:end -->
