### PR TITLE
improvement: Implement server URI selector.

### DIFF
--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -22,10 +22,6 @@ import (
 	"github.com/palantir/pkg/retry"
 )
 
-const (
-	meshSchemePrefix = "mesh-"
-)
-
 // RequestRetrier manages URIs for an HTTP client, providing an API which determines whether requests should be retries
 // and supplying the correct URL for the client to retry.
 // In the case of servers in a service-mesh, requests will never be retried and the mesh URI will only be returned on the

--- a/conjure-go-client/httpclient/internal/server_scorer.go
+++ b/conjure-go-client/httpclient/internal/server_scorer.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultResurrectDuration is the amount of time after which
+	// we resurrect failed URIs
+	defaultResurrectDuration = time.Second * 60
+	meshSchemePrefix         = "mesh-"
+)
+
+type serverScorer struct {
+	sync.RWMutex
+
+	failedURIs map[string]struct{}
+}
+
+// NewServerSelector returns a URISelector that keeps returns URIs for server which are not returning server side
+// errors. It is used as middleware to track server side request failures to future requests from hitting known bad
+// servers.
+func NewServerSelector() URISelector {
+	return &serverScorer{failedURIs: make(map[string]struct{})}
+}
+
+// select implements URISelector
+func (s *serverScorer) Select(uris []string, _ http.Header) ([]string, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	availableURIs := make([]string, 0, len(uris))
+	for _, uri := range uris {
+		if _, ok := s.failedURIs[uri]; ok {
+			continue
+		}
+		availableURIs = append(availableURIs, uri)
+	}
+	// if all connections are "failed", then return them all
+	if len(availableURIs) == 0 {
+		return uris, nil
+	}
+	return availableURIs, nil
+}
+
+// RoundTrip implements URISelector
+func (s *serverScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+	resp, err := next.RoundTrip(req)
+	errCode, ok := StatusCodeFromError(err)
+	// fall back to the status code from the response
+	if !ok && resp != nil {
+		errCode = resp.StatusCode
+	}
+
+	if isThrottle, ressurectAfter := isThrottleResponse(resp, errCode); isThrottle {
+		s.markBackoffURI(req, ressurectAfter)
+	} else if isUnavailableResponse(resp, errCode) {
+		// 503: go to next node
+		s.markBackoffURI(req, defaultResurrectDuration)
+	} else if resp == nil {
+		// if we get a nil response, we can assume there is a problem with host and can move on to the next.
+		s.markBackoffURI(req, defaultResurrectDuration)
+	}
+
+	return resp, err
+}
+
+func (s *serverScorer) markBackoffURI(req *http.Request, dur time.Duration) {
+	// if duration is equal to zero, then use defaultResurrectDuration
+	if dur == 0 {
+		dur = defaultResurrectDuration
+	}
+	reqURL := getBaseURI(req.URL)
+	s.Lock()
+	defer s.Unlock()
+
+	s.failedURIs[reqURL] = struct{}{}
+
+	time.AfterFunc(dur, func() {
+		s.Lock()
+		defer s.Unlock()
+		delete(s.failedURIs, reqURL)
+	})
+}

--- a/conjure-go-client/httpclient/internal/server_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/server_scorer_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestRetrier_GetNextURIs(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		resp       *http.Response
+		chosenURI  string
+		beforeURIs []string
+		afterURIs  []string
+	}{
+		{
+			name:       "preserves chosen URI if response doesn't contain a handled status code",
+			resp:       &http.Response{},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain0.example.com", "https://domain1.example.com"},
+		},
+		{
+			name:       "remove chosen URI if response is nil",
+			resp:       nil,
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain1.example.com"},
+		},
+		{
+			name:       "removes chosen URI if response return code is 503",
+			resp:       &http.Response{StatusCode: http.StatusServiceUnavailable},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain1.example.com"},
+		},
+		{
+			name:       "preserves chosen URI if response return code is 503 but it's a single URI",
+			resp:       &http.Response{StatusCode: http.StatusServiceUnavailable},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com"},
+			afterURIs:  []string{"https://domain0.example.com"},
+		},
+		{
+			name:       "removes chosen URI if response return code is 429",
+			resp:       &http.Response{StatusCode: http.StatusTooManyRequests},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain1.example.com"},
+		},
+		{
+			name:       "preserves chosen URI if response return code is 429 but it's a single URI",
+			resp:       &http.Response{StatusCode: http.StatusTooManyRequests},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com"},
+			afterURIs:  []string{"https://domain0.example.com"},
+		},
+		{
+			name:       "preserves chosen URI on permanent redirects",
+			resp:       &http.Response{StatusCode: StatusCodeRetryOther},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain0.example.com", "https://domain1.example.com"},
+		},
+		{
+			name:       "preserves chosen URI on temporary redirects",
+			resp:       &http.Response{StatusCode: StatusCodeRetryOther},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain0.example.com", "https://domain1.example.com"},
+		},
+		{
+			name:       "preserves chosen URI on 400 responses",
+			resp:       &http.Response{StatusCode: http.StatusBadRequest},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain0.example.com", "https://domain1.example.com"},
+		},
+		{
+			name:       "preserves chosen URI on 404 responses",
+			resp:       &http.Response{StatusCode: http.StatusNotFound},
+			chosenURI:  "https://domain0.example.com",
+			beforeURIs: []string{"https://domain0.example.com", "https://domain1.example.com"},
+			afterURIs:  []string{"https://domain0.example.com", "https://domain1.example.com"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewServerSelector()
+			req, err := http.NewRequest("GET", tc.chosenURI, nil)
+			assert.NoError(t, err)
+
+			resp, err := s.RoundTrip(req, newMockRoundTripper(tc.resp))
+			assert.Equal(t, tc.resp, resp)
+			assert.NoError(t, err)
+
+			uris, err := s.Select(tc.beforeURIs, nil)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.afterURIs, uris)
+		})
+	}
+}
+
+func newMockRoundTripper(resp *http.Response) http.RoundTripper {
+	return &mockRoundTripper{resp: resp}
+}
+
+type mockRoundTripper struct {
+	resp *http.Response
+}
+
+func (m mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.resp, nil
+}


### PR DESCRIPTION
## Before this PR
The server side error handling is all currently handled by the Request retrier. Referencing the new URIScorer interface from https://github.com/palantir/conjure-go-runtime/pull/349, we add an implementation of the URIScorer that that handles server side errors.

## After this PR
This PR introduced URISelector middleware that tracks server side errors and appropriately removes servers which are returning 5xx errors from the list of returned URIs. 

==COMMIT_MSG==
Implement server URI selector.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/352)
<!-- Reviewable:end -->
