### PR TITLE
fix: Do not write error response to server after status has been written by handler

### DIFF
--- a/changelog/@unreleased/pr-372.v2.yml
+++ b/changelog/@unreleased/pr-372.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Do not write error response to server after status has been written
+    by handler
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/372


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/372)
<!-- Reviewable:end -->
