### PR TITLE
Improve observability when draining and closing response body

### DIFF
--- a/changelog/@unreleased/pr-380.v2.yml
+++ b/changelog/@unreleased/pr-380.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve observability when draining and closing response body
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/380

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -185,7 +185,7 @@ func (c *clientImpl) doOnce(
 	// unless this is exactly the scenario where the caller has opted into being responsible for draining and closing
 	// the response body, be sure to do so here.
 	if !(respErr == nil && b.bodyMiddleware.rawOutput) {
-		internal.DrainBody(resp)
+		internal.DrainBody(ctx, resp)
 	}
 
 	return resp, unwrapURLError(ctx, respErr)

--- a/conjure-go-client/httpclient/internal/body.go
+++ b/conjure-go-client/httpclient/internal/body.go
@@ -32,13 +32,13 @@ func DrainBody(ctx context.Context, resp *http.Response) {
 			svc1log.FromContext(ctx).Warn("Failed to drain entire response body",
 				svc1log.SafeParam("bytes", bytes),
 				svc1log.Stacktrace(err))
-		} else {
+		} else if bytes > 0 {
 			svc1log.FromContext(ctx).Info("Drained remaining response body",
 				svc1log.SafeParam("bytes", bytes))
 		}
 
 		if err := resp.Body.Close(); err != nil {
-			svc1log.FromContext(ctx).Warn("Failed to close reponse body",
+			svc1log.FromContext(ctx).Warn("Failed to close response body",
 				svc1log.Stacktrace(err))
 		}
 	}

--- a/conjure-go-client/httpclient/internal/body.go
+++ b/conjure-go-client/httpclient/internal/body.go
@@ -15,18 +15,31 @@
 package internal
 
 import (
+	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
+
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // DrainBody reads then closes a response's body if it is non-nil.
 // This function should be deferred before a response reference is
 // discarded.
-func DrainBody(resp *http.Response) {
+func DrainBody(ctx context.Context, resp *http.Response) {
 	// drain and close treated as best-effort
 	if resp != nil && resp.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
-		_ = resp.Body.Close()
+		if bytes, err := io.Copy(io.Discard, resp.Body); err != nil {
+			svc1log.FromContext(ctx).Warn("Failed to drain entire response body",
+				svc1log.SafeParam("bytes", bytes),
+				svc1log.Stacktrace(err))
+		} else {
+			svc1log.FromContext(ctx).Info("Drained remaining response body",
+				svc1log.SafeParam("bytes", bytes))
+		}
+
+		if err := resp.Body.Close(); err != nil {
+			svc1log.FromContext(ctx).Warn("Failed to close reponse body",
+				svc1log.Stacktrace(err))
+		}
 	}
 }

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -49,7 +49,7 @@ func (e errorDecoderMiddleware) RoundTrip(req *http.Request, next http.RoundTrip
 		return nil, err
 	}
 	if e.errorDecoder.Handles(resp) {
-		defer internal.DrainBody(resp)
+		defer internal.DrainBody(req.Context(), resp)
 		return nil, e.errorDecoder.DecodeError(resp)
 	}
 	return resp, nil

--- a/conjure-go-contract/codecs/binary.go
+++ b/conjure-go-contract/codecs/binary.go
@@ -44,8 +44,8 @@ func (codecBinary) Decode(r io.Reader, v interface{}) error {
 	if closer, ok := r.(io.ReadCloser); ok {
 		defer func() { _ = closer.Close() }()
 	}
-	if _, err := io.Copy(w, r); err != nil {
-		return werror.Convert(err)
+	if bytes, err := io.Copy(w, r); err != nil {
+		return werror.Wrap(err, "Failed to copy all bytes while decoding: "+err.Error(), werror.SafeParam("bytesCopied", bytes))
 	}
 	return nil
 }
@@ -66,8 +66,8 @@ func (codecBinary) Encode(w io.Writer, v interface{}) error {
 	if closer, ok := r.(io.ReadCloser); ok {
 		defer func() { _ = closer.Close() }()
 	}
-	if _, err := io.Copy(w, r); err != nil {
-		return werror.Convert(err)
+	if bytes, err := io.Copy(w, r); err != nil {
+		return werror.Wrap(err, "Failed to copy all bytes while encoding: "+err.Error(), werror.SafeParam("bytesCopied", bytes))
 	}
 	return nil
 }

--- a/conjure-go-contract/codecs/binary.go
+++ b/conjure-go-contract/codecs/binary.go
@@ -45,7 +45,7 @@ func (codecBinary) Decode(r io.Reader, v interface{}) error {
 		defer func() { _ = closer.Close() }()
 	}
 	if bytes, err := io.Copy(w, r); err != nil {
-		return werror.Wrap(err, "Failed to copy all bytes while decoding: "+err.Error(), werror.SafeParam("bytesCopied", bytes))
+		return werror.Wrap(err, "Failed to copy all bytes while decoding", werror.SafeParam("bytesCopied", bytes))
 	}
 	return nil
 }
@@ -67,7 +67,7 @@ func (codecBinary) Encode(w io.Writer, v interface{}) error {
 		defer func() { _ = closer.Close() }()
 	}
 	if bytes, err := io.Copy(w, r); err != nil {
-		return werror.Wrap(err, "Failed to copy all bytes while encoding: "+err.Error(), werror.SafeParam("bytesCopied", bytes))
+		return werror.Wrap(err, "Failed to copy all bytes while encoding", werror.SafeParam("bytesCopied", bytes))
 	}
 	return nil
 }


### PR DESCRIPTION
## Before this PR
Any errors while draining and closing response body are ignored.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Improve observability when draining and closing response body
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/380)
<!-- Reviewable:end -->
