### PR TITLE
Add metric tag family for too many requests http errors

### DIFF
--- a/changelog/@unreleased/pr-402.v2.yml
+++ b/changelog/@unreleased/pr-402.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add metric tag family for too many requests http errors
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/402

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -50,13 +50,14 @@ var (
 	MetricTagConnectionNew    = metrics.MustNewTag("reused", "false")
 	MetricTagConnectionReused = metrics.MustNewTag("reused", "true")
 
-	metricTagFamily1xx     = metrics.MustNewTag(metricTagFamily, "1xx")
-	metricTagFamily2xx     = metrics.MustNewTag(metricTagFamily, "2xx")
-	metricTagFamily3xx     = metrics.MustNewTag(metricTagFamily, "3xx")
-	metricTagFamily4xx     = metrics.MustNewTag(metricTagFamily, "4xx")
-	metricTagFamily5xx     = metrics.MustNewTag(metricTagFamily, "5xx")
-	metricTagFamilyOther   = metrics.MustNewTag(metricTagFamily, "other")
-	metricTagFamilyTimeout = metrics.MustNewTag(metricTagFamily, "timeout")
+	metricTagFamily1xx             = metrics.MustNewTag(metricTagFamily, "1xx")
+	metricTagFamily2xx             = metrics.MustNewTag(metricTagFamily, "2xx")
+	metricTagFamily3xx             = metrics.MustNewTag(metricTagFamily, "3xx")
+	metricTagFamily4xx             = metrics.MustNewTag(metricTagFamily, "4xx")
+	metricTagFamily5xx             = metrics.MustNewTag(metricTagFamily, "5xx")
+	metricTagFamilyOther           = metrics.MustNewTag(metricTagFamily, "other")
+	metricTagFamilyTimeout         = metrics.MustNewTag(metricTagFamily, "timeout")
+	metricTagFamilyTooManyRequests = metrics.MustNewTag(metricTagFamily, "too-many-requests")
 )
 
 // A TagsProvider returns metrics tags based on an http round trip.
@@ -146,6 +147,8 @@ func tagStatusFamily(_ *http.Request, resp *http.Response, respErr error) metric
 	switch {
 	case isTimeoutError(respErr):
 		return metrics.Tags{metricTagFamilyTimeout}
+	case resp.StatusCode == 429:
+		return metrics.Tags{metricTagFamilyTooManyRequests}
 	case resp == nil, resp.StatusCode < 100, resp.StatusCode > 599:
 		return metrics.Tags{metricTagFamilyOther}
 	case resp.StatusCode < 200:

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -147,8 +147,6 @@ func tagStatusFamily(_ *http.Request, resp *http.Response, respErr error) metric
 	switch {
 	case isTimeoutError(respErr):
 		return metrics.Tags{metricTagFamilyTimeout}
-	case resp.StatusCode == 429:
-		return metrics.Tags{metricTagFamilyTooManyRequests}
 	case resp == nil, resp.StatusCode < 100, resp.StatusCode > 599:
 		return metrics.Tags{metricTagFamilyOther}
 	case resp.StatusCode < 200:
@@ -157,6 +155,8 @@ func tagStatusFamily(_ *http.Request, resp *http.Response, respErr error) metric
 		return metrics.Tags{metricTagFamily2xx}
 	case resp.StatusCode < 400:
 		return metrics.Tags{metricTagFamily3xx}
+	case resp.StatusCode == 429:
+		return metrics.Tags{metricTagFamilyTooManyRequests}
 	case resp.StatusCode < 500:
 		return metrics.Tags{metricTagFamily4xx}
 	case resp.StatusCode < 600:

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -155,6 +155,8 @@ func tagStatusFamily(_ *http.Request, resp *http.Response, respErr error) metric
 		return metrics.Tags{metricTagFamily2xx}
 	case resp.StatusCode < 400:
 		return metrics.Tags{metricTagFamily3xx}
+	case resp.StatusCode == 408:
+		return metrics.Tags{metricTagFamilyTimeout}
 	case resp.StatusCode == 429:
 		return metrics.Tags{metricTagFamilyTooManyRequests}
 	case resp.StatusCode < 500:


### PR DESCRIPTION
## Before this PR
We need a way to disambiguate throttling limits errors from other 4xx errors (e.g. for Azure APIs).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add metric tag family for too many requests http errors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/402)
<!-- Reviewable:end -->
