### PR TITLE
log draining response at debug

### DIFF
--- a/changelog/@unreleased/pr-403.v2.yml
+++ b/changelog/@unreleased/pr-403.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: log draining response at debug
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/403

--- a/conjure-go-client/httpclient/internal/body.go
+++ b/conjure-go-client/httpclient/internal/body.go
@@ -33,7 +33,7 @@ func DrainBody(ctx context.Context, resp *http.Response) {
 				svc1log.SafeParam("bytes", bytes),
 				svc1log.Stacktrace(err))
 		} else if bytes > 0 {
-			svc1log.FromContext(ctx).Info("Drained remaining response body",
+			svc1log.FromContext(ctx).Debug("Drained remaining response body",
 				svc1log.SafeParam("bytes", bytes))
 		}
 


### PR DESCRIPTION
## Before this PR
Excessive `INFO` messages for `Drained remaining response body`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
log draining response at debug
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/403)
<!-- Reviewable:end -->
