### PR TITLE
improvement: Add support for live-reloadable basic auth from config.

### DIFF
--- a/changelog/@unreleased/pr-418.v2.yml
+++ b/changelog/@unreleased/pr-418.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add support for live-reloadable basic auth from config.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/418

--- a/conjure-go-client/httpclient/authn.go
+++ b/conjure-go-client/httpclient/authn.go
@@ -16,6 +16,7 @@ package httpclient
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 
@@ -61,16 +62,24 @@ func newAuthTokenMiddlewareFromRefreshable(token refreshable.StringPtr) Middlewa
 	}
 }
 
+// BasicAuthProvider accepts a context and returns either:
+//
+// (1) a nonempty BasicAuth and a nil error, or
+//
+// (2) an empty BasicAuth and a non-nil error.
+type BasicAuthProvider func(context.Context) (BasicAuth, error)
+
 // basicAuthMiddleware wraps a refreshing BasicAuth pointer and injects basic auth credentials if the pointer is not nil
 type basicAuthMiddleware struct {
-	basicAuth refreshingclient.RefreshableBasicAuthPtr
+	provider BasicAuthProvider
 }
 
 func (b *basicAuthMiddleware) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-	if auth := b.basicAuth.CurrentBasicAuthPtr(); auth != nil {
-		setBasicAuth(req.Header, auth.User, auth.Password)
+	basicAuth, err := b.provider(req.Context())
+	if err != nil {
+		return nil, err
 	}
-
+	setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
 	return next.RoundTrip(req)
 }
 
@@ -79,6 +88,16 @@ func newBasicAuthMiddlewareFromRefreshable(auth refreshingclient.RefreshableBasi
 		Disabled: refreshable.NewBool(auth.MapBasicAuthPtr(func(auth *refreshingclient.BasicAuth) interface{} {
 			return auth == nil
 		})),
-		Delegate: &basicAuthMiddleware{basicAuth: auth},
+		Delegate: &basicAuthMiddleware{provider: func(ctx context.Context) (BasicAuth, error) {
+			if b := auth.CurrentBasicAuthPtr(); b != nil {
+				return BasicAuth{User: b.User, Password: b.Password}, nil
+			}
+			return BasicAuth{}, nil
+		}},
 	}
+}
+
+func setBasicAuth(h http.Header, username, password string) {
+	basicAuthBytes := []byte(username + ":" + password)
+	h.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(basicAuthBytes))
 }

--- a/conjure-go-client/httpclient/authn_test.go
+++ b/conjure-go-client/httpclient/authn_test.go
@@ -50,3 +50,33 @@ func TestRoundTripperWithToken(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.True(t, wrappedRTInvoked)
 }
+
+func TestRoundTripperWithBasicAuth(t *testing.T) {
+	var wrappedRTInvoked bool
+	expected := httpclient.BasicAuth{
+		User:     "user",
+		Password: "password",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		wrappedRTInvoked = true
+		user, pass, ok := req.BasicAuth()
+		assert.True(t, ok)
+		assert.Equal(t, expected.User, user)
+		assert.Equal(t, expected.Password, pass)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := httpclient.NewClient(
+		httpclient.WithHTTPTimeout(time.Minute),
+		httpclient.WithBasicAuth(expected.User, expected.Password),
+		httpclient.WithBaseURLs([]string{server.URL}))
+	require.NoError(t, err)
+
+	resp, err := client.Do(context.Background(), httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, wrappedRTInvoked)
+
+}

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -272,7 +272,10 @@ func newClientBuilderFromRefreshableConfig(ctx context.Context, config Refreshab
 	b.HTTP.Timeout = validParams.Timeout()
 	b.HTTP.DisableMetrics = validParams.DisableMetrics()
 	b.HTTP.MetricsTagProviders = append(b.HTTP.MetricsTagProviders, refreshableMetricsTagsProvider{validParams.MetricsTags()})
-	b.HTTP.Middlewares = append(b.HTTP.Middlewares, newAuthTokenMiddlewareFromRefreshable(validParams.APIToken()))
+	b.HTTP.Middlewares = append(b.HTTP.Middlewares,
+		newAuthTokenMiddlewareFromRefreshable(validParams.APIToken()),
+		newBasicAuthMiddlewareFromRefreshable(validParams.BasicAuth()))
+
 	b.URIs = validParams.URIs()
 	b.MaxAttempts = validParams.MaxAttempts()
 	b.RetryParams = validParams.Retry()

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -55,7 +55,7 @@ type ClientConfig struct {
 	// is not, the content of the file will be used as the APIToken.
 	APITokenFile *string `json:"api-token-file,omitempty" yaml:"api-token-file,omitempty"`
 	// BasicAuth is a user/password combination which, if provided, will be used as the credentials in the
-	// Authorization header
+	// Authorization header. APIToken and APITokenFile will take precedent over BasicAuth if specified
 	BasicAuth *BasicAuth `json:"basic-auth,omitempty" yaml:"basic-auth,omitempty"`
 	// DisableHTTP2, if true, will prevent the client from modifying the *tls.Config object to support H2 connections.
 	DisableHTTP2 *bool `json:"disable-http2,omitempty" yaml:"disable-http2,omitempty"`

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -54,6 +54,9 @@ type ClientConfig struct {
 	// APITokenFile is an on-disk location containing a Bearer token. If APITokenFile is provided and APIToken
 	// is not, the content of the file will be used as the APIToken.
 	APITokenFile *string `json:"api-token-file,omitempty" yaml:"api-token-file,omitempty"`
+	// BasicAuth is a user/password combination which, if provided, will be used as the credentials in the
+	// Authorization header
+	BasicAuth *BasicAuth `json:"basic-auth,omitempty" yaml:"basic-auth,omitempty"`
 	// DisableHTTP2, if true, will prevent the client from modifying the *tls.Config object to support H2 connections.
 	DisableHTTP2 *bool `json:"disable-http2,omitempty" yaml:"disable-http2,omitempty"`
 	// ProxyFromEnvironment enables reading HTTP proxy information from environment variables.
@@ -108,6 +111,14 @@ type ClientConfig struct {
 	Security SecurityConfig `json:"security,omitempty" yaml:"security,omitempty"`
 }
 
+// BasicAuth represents the configuration for HTTP Basic Authorization
+type BasicAuth struct {
+	// User is a string representing the user
+	User string `json:"user,omitempty" yaml:"user,omitempty"`
+	// Password is a string representing the password
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
 type MetricsConfig struct {
 	// Enabled can be used to disable metrics with an explicit 'false'. Metrics are enabled if this is unset.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
@@ -152,6 +163,9 @@ func MergeClientConfig(conf, defaults ClientConfig) ClientConfig {
 	}
 	if conf.APITokenFile == nil {
 		conf.APITokenFile = defaults.APITokenFile
+	}
+	if conf.BasicAuth == nil {
+		conf.BasicAuth = defaults.BasicAuth
 	}
 	if conf.MaxNumRetries == nil {
 		conf.MaxNumRetries = defaults.MaxNumRetries
@@ -248,6 +262,8 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 			return nil, werror.Wrap(err, "failed to read api-token-file", werror.SafeParam("file", *c.APITokenFile))
 		}
 		params = append(params, WithAuthToken(string(bytes.TrimSpace(token))))
+	} else if c.BasicAuth != nil && c.BasicAuth.User != "" && c.BasicAuth.Password != "" {
+		params = append(params, WithBasicAuth(c.BasicAuth.User, c.BasicAuth.Password))
 	}
 
 	// Disable HTTP2 (http2 is enabled by default)
@@ -381,6 +397,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		}
 	}
 
+	var basicAuth *refreshingclient.BasicAuth
 	var apiToken *string
 	if config.APIToken != nil {
 		apiToken = config.APIToken
@@ -392,6 +409,11 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		}
 		tokenStr := string(token)
 		apiToken = &tokenStr
+	} else if config.BasicAuth != nil && config.BasicAuth.User != "" && config.BasicAuth.Password != "" {
+		basicAuth = &refreshingclient.BasicAuth{
+			User:     config.BasicAuth.User,
+			Password: config.BasicAuth.Password,
+		}
 	}
 
 	disableMetrics := config.Metrics.Enabled != nil && !*config.Metrics.Enabled
@@ -441,6 +463,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 
 	return refreshingclient.ValidatedClientParams{
 		APIToken:       apiToken,
+		BasicAuth:      basicAuth,
 		Dialer:         dialer,
 		DisableMetrics: disableMetrics,
 		MaxAttempts:    maxAttempts,

--- a/conjure-go-client/httpclient/config_test.go
+++ b/conjure-go-client/httpclient/config_test.go
@@ -121,6 +121,27 @@ clients:
 				},
 			},
 		},
+		{
+			Name: "basic-auth configuration",
+			ServicesConfigYAML: `
+clients:
+  services:
+    my-service:
+      basic-auth:
+        user: user
+        password: password
+`,
+			ExpectedConfig: ServicesConfig{
+				Services: map[string]ClientConfig{
+					"my-service": {
+						BasicAuth: &BasicAuth{
+							User:     "user",
+							Password: "password",
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			var actual struct {

--- a/conjure-go-client/httpclient/internal/refreshingclient/types.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/types.go
@@ -26,6 +26,7 @@ import (
 // Values are generally known to be "valid" to minimize downstream error handling.
 type ValidatedClientParams struct {
 	APIToken       *string
+	BasicAuth      *BasicAuth
 	Dialer         DialerParams
 	DisableMetrics bool
 	MaxAttempts    *int
@@ -34,4 +35,10 @@ type ValidatedClientParams struct {
 	Timeout        time.Duration
 	Transport      TransportParams
 	URIs           []string
+}
+
+// BasicAuth represents the configuration for HTTP Basic Authorization
+type BasicAuth struct {
+	User     string
+	Password string
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/zz_generated_refreshables.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/zz_generated_refreshables.go
@@ -14,6 +14,7 @@ type RefreshableValidatedClientParams interface {
 	SubscribeToValidatedClientParams(func(ValidatedClientParams)) (unsubscribe func())
 
 	APIToken() refreshable.StringPtr
+	BasicAuth() RefreshableBasicAuthPtr
 	Dialer() RefreshableDialerParams
 	DisableMetrics() refreshable.Bool
 	MaxAttempts() refreshable.IntPtr
@@ -51,6 +52,12 @@ func (r RefreshingValidatedClientParams) SubscribeToValidatedClientParams(consum
 func (r RefreshingValidatedClientParams) APIToken() refreshable.StringPtr {
 	return refreshable.NewStringPtr(r.MapValidatedClientParams(func(i ValidatedClientParams) interface{} {
 		return i.APIToken
+	}))
+}
+
+func (r RefreshingValidatedClientParams) BasicAuth() RefreshableBasicAuthPtr {
+	return NewRefreshingBasicAuthPtr(r.MapValidatedClientParams(func(i ValidatedClientParams) interface{} {
+		return i.BasicAuth
 	}))
 }
 
@@ -99,6 +106,98 @@ func (r RefreshingValidatedClientParams) Transport() RefreshableTransportParams 
 func (r RefreshingValidatedClientParams) URIs() refreshable.StringSlice {
 	return refreshable.NewStringSlice(r.MapValidatedClientParams(func(i ValidatedClientParams) interface{} {
 		return i.URIs
+	}))
+}
+
+type RefreshableBasicAuthPtr interface {
+	refreshable.Refreshable
+	CurrentBasicAuthPtr() *BasicAuth
+	MapBasicAuthPtr(func(*BasicAuth) interface{}) refreshable.Refreshable
+	SubscribeToBasicAuthPtr(func(*BasicAuth)) (unsubscribe func())
+
+	User() refreshable.String
+	Password() refreshable.String
+}
+
+type RefreshingBasicAuthPtr struct {
+	refreshable.Refreshable
+}
+
+func NewRefreshingBasicAuthPtr(in refreshable.Refreshable) RefreshingBasicAuthPtr {
+	return RefreshingBasicAuthPtr{Refreshable: in}
+}
+
+func (r RefreshingBasicAuthPtr) CurrentBasicAuthPtr() *BasicAuth {
+	return r.Current().(*BasicAuth)
+}
+
+func (r RefreshingBasicAuthPtr) MapBasicAuthPtr(mapFn func(*BasicAuth) interface{}) refreshable.Refreshable {
+	return r.Map(func(i interface{}) interface{} {
+		return mapFn(i.(*BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuthPtr) SubscribeToBasicAuthPtr(consumer func(*BasicAuth)) (unsubscribe func()) {
+	return r.Subscribe(func(i interface{}) {
+		consumer(i.(*BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuthPtr) User() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuthPtr(func(i *BasicAuth) interface{} {
+		return i.User
+	}))
+}
+
+func (r RefreshingBasicAuthPtr) Password() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuthPtr(func(i *BasicAuth) interface{} {
+		return i.Password
+	}))
+}
+
+type RefreshableBasicAuth interface {
+	refreshable.Refreshable
+	CurrentBasicAuth() BasicAuth
+	MapBasicAuth(func(BasicAuth) interface{}) refreshable.Refreshable
+	SubscribeToBasicAuth(func(BasicAuth)) (unsubscribe func())
+
+	User() refreshable.String
+	Password() refreshable.String
+}
+
+type RefreshingBasicAuth struct {
+	refreshable.Refreshable
+}
+
+func NewRefreshingBasicAuth(in refreshable.Refreshable) RefreshingBasicAuth {
+	return RefreshingBasicAuth{Refreshable: in}
+}
+
+func (r RefreshingBasicAuth) CurrentBasicAuth() BasicAuth {
+	return r.Current().(BasicAuth)
+}
+
+func (r RefreshingBasicAuth) MapBasicAuth(mapFn func(BasicAuth) interface{}) refreshable.Refreshable {
+	return r.Map(func(i interface{}) interface{} {
+		return mapFn(i.(BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuth) SubscribeToBasicAuth(consumer func(BasicAuth)) (unsubscribe func()) {
+	return r.Subscribe(func(i interface{}) {
+		consumer(i.(BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuth) User() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuth(func(i BasicAuth) interface{} {
+		return i.User
+	}))
+}
+
+func (r RefreshingBasicAuth) Password() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuth(func(i BasicAuth) interface{} {
+		return i.Password
 	}))
 }
 

--- a/conjure-go-client/httpclient/zz_generated_refreshables.go
+++ b/conjure-go-client/httpclient/zz_generated_refreshables.go
@@ -60,6 +60,7 @@ type RefreshableClientConfig interface {
 	URIs() refreshable.StringSlice
 	APIToken() refreshable.StringPtr
 	APITokenFile() refreshable.StringPtr
+	BasicAuth() RefreshableBasicAuthPtr
 	DisableHTTP2() refreshable.BoolPtr
 	ProxyFromEnvironment() refreshable.BoolPtr
 	ProxyURL() refreshable.StringPtr
@@ -125,6 +126,12 @@ func (r RefreshingClientConfig) APIToken() refreshable.StringPtr {
 func (r RefreshingClientConfig) APITokenFile() refreshable.StringPtr {
 	return refreshable.NewStringPtr(r.MapClientConfig(func(i ClientConfig) interface{} {
 		return i.APITokenFile
+	}))
+}
+
+func (r RefreshingClientConfig) BasicAuth() RefreshableBasicAuthPtr {
+	return NewRefreshingBasicAuthPtr(r.MapClientConfig(func(i ClientConfig) interface{} {
+		return i.BasicAuth
 	}))
 }
 
@@ -233,6 +240,98 @@ func (r RefreshingClientConfig) Metrics() RefreshableMetricsConfig {
 func (r RefreshingClientConfig) Security() RefreshableSecurityConfig {
 	return NewRefreshingSecurityConfig(r.MapClientConfig(func(i ClientConfig) interface{} {
 		return i.Security
+	}))
+}
+
+type RefreshableBasicAuthPtr interface {
+	refreshable.Refreshable
+	CurrentBasicAuthPtr() *BasicAuth
+	MapBasicAuthPtr(func(*BasicAuth) interface{}) refreshable.Refreshable
+	SubscribeToBasicAuthPtr(func(*BasicAuth)) (unsubscribe func())
+
+	User() refreshable.String
+	Password() refreshable.String
+}
+
+type RefreshingBasicAuthPtr struct {
+	refreshable.Refreshable
+}
+
+func NewRefreshingBasicAuthPtr(in refreshable.Refreshable) RefreshingBasicAuthPtr {
+	return RefreshingBasicAuthPtr{Refreshable: in}
+}
+
+func (r RefreshingBasicAuthPtr) CurrentBasicAuthPtr() *BasicAuth {
+	return r.Current().(*BasicAuth)
+}
+
+func (r RefreshingBasicAuthPtr) MapBasicAuthPtr(mapFn func(*BasicAuth) interface{}) refreshable.Refreshable {
+	return r.Map(func(i interface{}) interface{} {
+		return mapFn(i.(*BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuthPtr) SubscribeToBasicAuthPtr(consumer func(*BasicAuth)) (unsubscribe func()) {
+	return r.Subscribe(func(i interface{}) {
+		consumer(i.(*BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuthPtr) User() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuthPtr(func(i *BasicAuth) interface{} {
+		return i.User
+	}))
+}
+
+func (r RefreshingBasicAuthPtr) Password() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuthPtr(func(i *BasicAuth) interface{} {
+		return i.Password
+	}))
+}
+
+type RefreshableBasicAuth interface {
+	refreshable.Refreshable
+	CurrentBasicAuth() BasicAuth
+	MapBasicAuth(func(BasicAuth) interface{}) refreshable.Refreshable
+	SubscribeToBasicAuth(func(BasicAuth)) (unsubscribe func())
+
+	User() refreshable.String
+	Password() refreshable.String
+}
+
+type RefreshingBasicAuth struct {
+	refreshable.Refreshable
+}
+
+func NewRefreshingBasicAuth(in refreshable.Refreshable) RefreshingBasicAuth {
+	return RefreshingBasicAuth{Refreshable: in}
+}
+
+func (r RefreshingBasicAuth) CurrentBasicAuth() BasicAuth {
+	return r.Current().(BasicAuth)
+}
+
+func (r RefreshingBasicAuth) MapBasicAuth(mapFn func(BasicAuth) interface{}) refreshable.Refreshable {
+	return r.Map(func(i interface{}) interface{} {
+		return mapFn(i.(BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuth) SubscribeToBasicAuth(consumer func(BasicAuth)) (unsubscribe func()) {
+	return r.Subscribe(func(i interface{}) {
+		consumer(i.(BasicAuth))
+	})
+}
+
+func (r RefreshingBasicAuth) User() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuth(func(i BasicAuth) interface{} {
+		return i.User
+	}))
+}
+
+func (r RefreshingBasicAuth) Password() refreshable.String {
+	return refreshable.NewString(r.MapBasicAuth(func(i BasicAuth) interface{} {
+		return i.Password
 	}))
 }
 


### PR DESCRIPTION
## Before this PR
In order to user `BasicAuth` clients in code needed to add the [`WithBasicAuth`](https://pkg.go.dev/github.com/palantir/conjure-go-runtime/v2@v2.48.0/conjure-go-client/httpclient#WithBasicAuth) `ClientParam`. 

## After this PR
Allow for users to specify basic auth in [config](https://pkg.go.dev/github.com/palantir/conjure-go-runtime/v2@v2.48.0/conjure-go-client/httpclient#ClientConfig). Also ensure this basic auth config is refreshablable via the refreshing client. The `api-token` and `api-token-file` client configurations take precedent if they are defined before basic-auth is configured on the client. 

==COMMIT_MSG==
Add support for live-reloadable basic auth from config.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/418)
<!-- Reviewable:end -->
