### PR TITLE
fix: Docstrings with correct httpclient default param values.

### DIFF
--- a/changelog/@unreleased/pr-473.v2.yml
+++ b/changelog/@unreleased/pr-473.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Docstrings with correct httpclient default param values.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/473

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -369,7 +369,7 @@ func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 }
 
 // WithDialTimeout sets the timeout on the Dialer.
-// If unset, the client defaults to 9 seconds.
+// If unset, the client defaults to 90 seconds.
 func WithDialTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.DialerParams = refreshingclient.ConfigureDialer(b.DialerParams, func(p refreshingclient.DialerParams) refreshingclient.DialerParams {

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -266,7 +266,7 @@ func WithHTTP2PingTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 }
 
 // WithMaxIdleConns sets the number of reusable TCP connections the client
-// will maintain. If unset, the client defaults to 32.
+// will maintain. If unset, the client defaults to 200.
 func WithMaxIdleConns(conns int) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
@@ -278,7 +278,7 @@ func WithMaxIdleConns(conns int) ClientOrHTTPClientParam {
 }
 
 // WithMaxIdleConnsPerHost sets the number of reusable TCP connections the client
-// will maintain per destination. If unset, the client defaults to 32.
+// will maintain per destination. If unset, the client defaults to 100.
 func WithMaxIdleConnsPerHost(conns int) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
@@ -369,7 +369,7 @@ func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 }
 
 // WithDialTimeout sets the timeout on the Dialer.
-// If unset, the client defaults to 30 seconds.
+// If unset, the client defaults to 9 seconds.
 func WithDialTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.DialerParams = refreshingclient.ConfigureDialer(b.DialerParams, func(p refreshingclient.DialerParams) refreshingclient.DialerParams {

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -98,10 +98,10 @@ type ClientConfig struct {
 	HTTP2PingTimeout *time.Duration `json:"http2-ping-timeout,omitempty" yaml:"http2-ping-timeout,omitempty"`
 
 	// MaxIdleConns sets the number of reusable TCP connections the client will maintain.
-	// If unset, the client defaults to 32.
+	// If unset, the client defaults to 200.
 	MaxIdleConns *int `json:"max-idle-conns,omitempty" yaml:"max-idle-conns,omitempty"`
 	// MaxIdleConnsPerHost sets the number of reusable TCP connections the client will maintain per destination.
-	// If unset, the client defaults to 32.
+	// If unset, the client defaults to 100.
 	MaxIdleConnsPerHost *int `json:"max-idle-conns-per-host,omitempty" yaml:"max-idle-conns-per-host,omitempty"`
 
 	// Metrics allows disabling metric emission or adding additional static tags to the client metrics.


### PR DESCRIPTION
## Before this PR
The docstrings on the the [godoc](https://pkg.go.dev/github.com/palantir/conjure-go-runtime/v2@v2.55.0/conjure-go-client/httpclient) page were incorrect. The actual default values here are seen here:
https://github.com/palantir/conjure-go-runtime/blob/develop/conjure-go-client/httpclient/client_builder.go#L34-L47


## After this PR
==COMMIT_MSG==
Docstrings with correct httpclient default param values.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

