### PR TITLE
fix: Properly configure a random scoring client with param.

### DIFF
--- a/changelog/@unreleased/pr-480.v2.yml
+++ b/changelog/@unreleased/pr-480.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Properly configure a random scoring client with param.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/480

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -549,7 +549,7 @@ func WithBalancedURIScoring() ClientParam {
 func WithRandomURIScoring() ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
 		b.URIScorerBuilder = func(uris []string) internal.URIScoringMiddleware {
-			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 {
+			return internal.NewRandomURIScoringMiddleware(uris, func() int64 {
 				return time.Now().UnixNano()
 			})
 		}


### PR DESCRIPTION
## Before this PR
If a client wanted to use the RandomScorer URI middleware, we'd always configure the BalancedURI scorer. The builder Param initialized the incorrect scorer ever since this PR:
https://github.com/palantir/conjure-go-runtime/commit/17d1b0c796eabc386d18675303846d352346dbeb

## After this PR
==COMMIT_MSG==
Properly configure a random scoring client with param.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

