### PR TITLE
Add request host override option

### DIFF
--- a/changelog/@unreleased/pr-495.v2.yml
+++ b/changelog/@unreleased/pr-495.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add request host override option
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/495

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -158,6 +158,14 @@ func WithUserAgent(userAgent string) ClientOrHTTPClientParam {
 	return WithSetHeader("User-Agent", userAgent)
 }
 
+// WithOverrideRequestHost overrides the request Host from the default URL.Host
+func WithOverrideRequestHost(host string) ClientOrHTTPClientParam {
+	return WithMiddleware(MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+		req.Host = host
+		return next.RoundTrip(req)
+	}))
+}
+
 // WithMetrics enables the "client.response" metric. See MetricsMiddleware for details.
 // The serviceName will appear as the "service-name" tag.
 func WithMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {


### PR DESCRIPTION
Allows overriding the request host from the default URL.Host

This gives clients the ability to override the request Host seen by the server (regardless of whether the server is HTTP1/2), for example to get correct virtual host routing behavior when configuring the client to connect directly to an IP address.

==COMMIT_MSG==
Add request host override option
==COMMIT_MSG==
