### PR TITLE
fix: Report duration of `client.response` metric in microseconds

### DIFF
--- a/changelog/@unreleased/pr-515.v2.yml
+++ b/changelog/@unreleased/pr-515.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Report duration of `client.response` metric in microseconds.
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/515

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	assertTimeout = time.Second * 5
+	assertTimeout = time.Second * 10
 )
 
 var (

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -49,7 +49,7 @@ func TestClose(t *testing.T) {
 	require.NoError(t, err)
 
 	// check for bad goroutine before timeout is over
-	time.Sleep(100 * time.Millisecond) // leave some time for the goroutine to reasonably exit
+	time.Sleep(500 * time.Millisecond) // leave some time for the goroutine to reasonably exit
 	buf := bytes.NewBuffer(nil)
 	require.NoError(t, pprof.Lookup("goroutine").WriteTo(buf, 1))
 	s := buf.String()
@@ -80,7 +80,7 @@ func TestCloseOnError(t *testing.T) {
 	require.Error(t, err)
 
 	// check for bad goroutine before timeout is over
-	time.Sleep(100 * time.Millisecond) // leave some time for the goroutine to reasonably exit
+	time.Sleep(500 * time.Millisecond) // leave some time for the goroutine to reasonably exit
 	buf := bytes.NewBuffer(nil)
 	require.NoError(t, pprof.Lookup("goroutine").WriteTo(buf, 1))
 	s := buf.String()


### PR DESCRIPTION
Similar to https://github.com/palantir/witchcraft-go-server/pull/652

## Before this PR
`client.response` metric was reported with resolution in milliseconds, even though the convention with the Java implementation of Conjure is to report it in microseconds. This results in response latency being reported with values that are 1000x faster than they actually are.

## After this PR
==COMMIT_MSG==
Report duration of `client.response` metric in microseconds.
==COMMIT_MSG==

You can also check the reasoning by running the following test locally:

```go
func TestTimer_Update(t *testing.T) {
	timerWithConversion := metrics.NewRootMetricsRegistry().Timer("with-conversion")
	timerWithConversion.Update(time.Second / time.Microsecond)
	// The value is incorrectly reported as 1,000 microseconds
	assert.Equal(t, int64(1_000), timerWithConversion.Max())

	timerWithoutConversion := metrics.NewRootMetricsRegistry().Timer("without-conversion")
	timerWithoutConversion.Update(time.Second)
	// The value is correctly reported as 1,000,000 microseconds
	assert.Equal(t, int64(1_000_000), timerWithoutConversion.Max())
}
```

## Possible downsides?
This might cause some confusion as the value will be reported correctly now. As a result, if looking at a longer time-frame, a user might think that the endpoint was responding much faster in the past, but got 1000x slower after this problem was fixed.