### PR TITLE
fix: Fix memory leak with ever increasing slice of tls tags

### DIFF
--- a/changelog/@unreleased/pr-535.v2.yml
+++ b/changelog/@unreleased/pr-535.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix memory leak with ever increasing slice of tls tags
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/535

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -238,11 +238,11 @@ func deepCombine(tags [][]metrics.Tag) []metrics.Tag {
 	for _, tagList := range tags {
 		size += len(tagList)
 	}
-	result := make([]metrics.Tag, 0, size)
+	combinedTags := make([]metrics.Tag, 0, size)
 	for _, tagList := range tags {
-		result = append(result, tagList...)
+		combinedTags = append(combinedTags, tagList...)
 	}
-	return result
+	return combinedTags
 }
 
 func isTimeoutError(respErr error) bool {


### PR DESCRIPTION
## Summary
There was a memory leak in the TLS metrics: A `tags` slice was instantiated when the connection was initialized and is re-used for the entire lifecycle of the connection. The function `TLSHandshakeDone` is called every time the TLS handshake finishes and appends some values to the tags. This works if there is only one handshake per connection.

If the connection is re-used, the function `TLSHandshakeDone` is called multiple times and, each time, the same tag values are appended over and over again. This causes new metric IDs to be created, which causes the metrics registry to create a new entry for each handshake instead of using the existing entry. When the metrics are emitted, a bunch of metrics with a single value are emitted instead of metrics with aggregated values.

This PR fixes this by deep copying the `tags` slice before appending new values to it.

## Testing
Reproed the issue without the fix, applied the fix and then confirmed the issue was solved.

## Changelog
==COMMIT_MSG==
Fix memory leak with ever increasing slice of tls tags
==COMMIT_MSG==