### PR TITLE
✨ feature: new error type Service Unavailable

### DIFF
--- a/changelog/@unreleased/pr-543.v2.yml
+++ b/changelog/@unreleased/pr-543.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Adding new ServiceUnavailable error code with status code 503 StatusServiceUnavailable
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/543

--- a/conjure-go-contract/errors/error_code.go
+++ b/conjure-go-contract/errors/error_code.go
@@ -60,6 +60,8 @@ const (
 	CustomClient
 	// CustomServer has status code 500 InternalServerError.
 	CustomServer
+	// ServiceUnavailable has status code 503 StatusServiceUnavailable.
+	ServiceUnavailable
 )
 
 // StatusCode returns HTTP status code associated with this error code.
@@ -87,6 +89,8 @@ func (ec ErrorCode) StatusCode() int {
 		return http.StatusBadRequest
 	case CustomServer:
 		return http.StatusInternalServerError
+	case ServiceUnavailable:
+		return http.StatusServiceUnavailable
 	}
 	return http.StatusInternalServerError
 }
@@ -118,6 +122,8 @@ func (ec ErrorCode) String() string {
 		return "CUSTOM_CLIENT"
 	case CustomServer:
 		return "CUSTOM_SERVER"
+	case ServiceUnavailable:
+		return "SERVICE_UNAVAILABLE"
 	}
 	return fmt.Sprintf("<invalid error code: %d>", ec)
 }
@@ -152,6 +158,8 @@ func (ec *ErrorCode) UnmarshalText(data []byte) error {
 		*ec = CustomClient
 	case "CUSTOM_SERVER":
 		*ec = CustomServer
+	case "SERVICE_UNAVAILABLE":
+		*ec = ServiceUnavailable
 	default:
 		return fmt.Errorf(`errors: unknown error code string`)
 	}

--- a/conjure-go-contract/errors/error_code_test.go
+++ b/conjure-go-contract/errors/error_code_test.go
@@ -39,6 +39,7 @@ func TestErrorCode_String(t *testing.T) {
 		errors.Timeout:               "TIMEOUT",
 		errors.CustomClient:          "CUSTOM_CLIENT",
 		errors.CustomServer:          "CUSTOM_SERVER",
+		errors.ServiceUnavailable:    "SERVICE_UNAVAILABLE",
 		errors.ErrorCode(0):          "<invalid error code: 0>",
 		errors.ErrorCode(200):        "<invalid error code: 200>",
 	} {
@@ -58,6 +59,7 @@ var validErrorCodes = []errors.ErrorCode{
 	errors.Timeout,
 	errors.CustomClient,
 	errors.CustomServer,
+	errors.ServiceUnavailable,
 }
 
 func TestErrorCode_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
# Summary
- Adding a new ServiceUnavailable error code with status code 503 StatusServiceUnavailable. This is needed for redirection behavior.

==COMMIT_MSG==
Adding new ServiceUnavailable error code with status code 503 StatusServiceUnavailable
==COMMIT_MSG==
