### PR TITLE
improvement: Make TLSConfig refreshable

### DIFF
--- a/changelog/@unreleased/pr-545.v2.yml
+++ b/changelog/@unreleased/pr-545.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make TLSConfig refreshable
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/545

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -352,7 +352,7 @@ func WithProxyURL(proxyURLString string) ClientOrHTTPClientParam {
 	})
 }
 
-// WithTLSConfig is the same as .
+// WithTLSConfig is the same as WithRefreshableTLSConfig, but provides a static config.
 func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		if conf == nil {

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -352,15 +352,23 @@ func WithProxyURL(proxyURLString string) ClientOrHTTPClientParam {
 	})
 }
 
-// WithTLSConfig sets the SSL/TLS configuration for the HTTP client's Transport using a copy of the provided config.
-// The palantir/pkg/tlsconfig package is recommended to build a tls.Config from sane defaults.
+// WithTLSConfig is the same as .
 func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		if conf == nil {
 			b.TLSConfig = nil
 		} else {
-			b.TLSConfig = conf.Clone()
+			b.TLSConfig = refreshable.NewDefaultRefreshable(conf.Clone())
 		}
+		return nil
+	})
+}
+
+// WithRefreshableTLSConfig sets the SSL/TLS configuration for the HTTP client's Transport using a copy of the provided config.
+// The palantir/pkg/tlsconfig package is recommended to build a tls.Config from sane defaults.
+func WithRefreshableTLSConfig(refreshingTLSConfig refreshable.Refreshable) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TLSConfig = refreshingTLSConfig
 		return nil
 	})
 }
@@ -370,7 +378,11 @@ func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		if b.TLSConfig != nil {
-			b.TLSConfig.InsecureSkipVerify = true
+			b.TLSConfig = b.TLSConfig.Map(func(confI interface{}) interface{} {
+				conf := confI.(*tls.Config).Clone()
+				conf.InsecureSkipVerify = true
+				return conf
+			})
 		}
 		return nil
 	})

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -41,14 +41,32 @@ type TransportParams struct {
 }
 
 func NewRefreshableTransport(ctx context.Context, p RefreshableTransportParams, tlsConfig refreshable.Refreshable, dialer ContextDialer) http.RoundTripper {
-	return &RefreshableTransport{
-		Refreshable: p.MapTransportParams(func(p TransportParams) interface{} {
-			var curTLSConfig *tls.Config = nil
-			if tlsConfig != nil {
-				curTLSConfig = tlsConfig.Current().(*tls.Config)
+	curTLSConfig := func() *tls.Config {
+		if tlsConfig == nil {
+			return nil
+		}
+		return tlsConfig.Current().(*tls.Config)
+	}
+
+	transport := refreshable.NewDefaultRefreshable(newTransport(ctx, p.CurrentTransportParams(), curTLSConfig(), dialer))
+
+	p.SubscribeToTransportParams(func(params TransportParams) {
+		if err := transport.Update(newTransport(ctx, params, curTLSConfig(), dialer)); err != nil {
+			svc1log.FromContext(ctx).Error("Failed to update HTTP transport with transport params", svc1log.Stacktrace(err))
+		}
+	})
+
+	if tlsConfig != nil {
+		tlsConfig.Subscribe(func(tlsConfI interface{}) {
+			tlsConf := tlsConfI.(*tls.Config)
+			if err := transport.Update(newTransport(ctx, p.CurrentTransportParams(), tlsConf, dialer)); err != nil {
+				svc1log.FromContext(ctx).Error("Failed to update HTTP transport with tls config", svc1log.Stacktrace(err))
 			}
-			return newTransport(ctx, p, curTLSConfig, dialer)
-		}),
+		})
+	}
+
+	return &RefreshableTransport{
+		Refreshable: transport,
 	}
 }
 

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -40,10 +40,14 @@ type TransportParams struct {
 	HTTP2PingTimeout      time.Duration
 }
 
-func NewRefreshableTransport(ctx context.Context, p RefreshableTransportParams, tlsConfig *tls.Config, dialer ContextDialer) http.RoundTripper {
+func NewRefreshableTransport(ctx context.Context, p RefreshableTransportParams, tlsConfig refreshable.Refreshable, dialer ContextDialer) http.RoundTripper {
 	return &RefreshableTransport{
 		Refreshable: p.MapTransportParams(func(p TransportParams) interface{} {
-			return newTransport(ctx, p, tlsConfig, dialer)
+			var curTLSConfig *tls.Config = nil
+			if tlsConfig != nil {
+				curTLSConfig = tlsConfig.Current().(*tls.Config)
+			}
+			return newTransport(ctx, p, curTLSConfig, dialer)
 		}),
 	}
 }


### PR DESCRIPTION
This should allow updating the TLS config whenever there's a change to security files such as certs and CAs.