### PR TITLE
fix: WithBasicAuth implements ClientOrHTTPClientParam

### DIFF
--- a/changelog/@unreleased/pr-592.v2.yml
+++ b/changelog/@unreleased/pr-592.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: WithBasicAuth implements ClientOrHTTPClientParam
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/592

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -541,7 +541,7 @@ func WithErrorDecoder(errorDecoder ErrorDecoder) ClientParam {
 
 // WithBasicAuth sets the request's Authorization header to use HTTP Basic Authentication with the provided username and
 // password.
-func WithBasicAuth(user, password string) ClientParam {
+func WithBasicAuth(user, password string) ClientOrHTTPClientParam {
 	return WithMiddleware(&basicAuthMiddleware{provider: func(ctx context.Context) (BasicAuth, error) {
 		return BasicAuth{User: user, Password: password}, nil
 	}})


### PR DESCRIPTION
This allows using WithBasicAuth for a base *http.Client

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/592)
<!-- Reviewable:end -->
