### PR TITLE
improvement: Add snappy-framed compression codec

### DIFF
--- a/changelog/@unreleased/pr-665.v2.yml
+++ b/changelog/@unreleased/pr-665.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add snappy-framed compression codec
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/665

--- a/conjure-go-contract/codecs/plain.go
+++ b/conjure-go-contract/codecs/plain.go
@@ -73,6 +73,8 @@ func (codecPlain) Marshal(v interface{}) ([]byte, error) {
 	switch t := v.(type) {
 	case string:
 		return []byte(t), nil
+	case []byte:
+		return t, nil
 	case encoding.TextMarshaler:
 		return t.MarshalText()
 	default:

--- a/conjure-go-contract/codecs/snappy_framed.go
+++ b/conjure-go-contract/codecs/snappy_framed.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/golang/snappy"
+)
+
+var _ Codec = codecSNAPPYFRAMED{}
+
+// SnappyFramed wraps an existing Codec and uses snappy with framing for
+// compression and decompression using github.com/golang/snappy.
+// The Content-Type of the encoded data is expected to be the following:
+//
+// Ref: https://github.com/google/snappy/blob/main/framing_format.txt
+func SnappyFramed(codec Codec) Codec {
+	return &codecSNAPPYFRAMED{contentCodec: codec}
+}
+
+type codecSNAPPYFRAMED struct {
+	contentCodec Codec
+}
+
+func (c codecSNAPPYFRAMED) Accept() string {
+	return c.contentCodec.Accept()
+}
+
+func (c codecSNAPPYFRAMED) Decode(r io.Reader, v interface{}) (err error) {
+	return c.contentCodec.Decode(snappy.NewReader(r), v)
+}
+
+func (c codecSNAPPYFRAMED) Unmarshal(data []byte, v interface{}) error {
+	return c.Decode(bytes.NewBuffer(data), v)
+}
+
+func (c codecSNAPPYFRAMED) ContentType() string {
+	return c.contentCodec.ContentType()
+}
+
+func (c codecSNAPPYFRAMED) Encode(w io.Writer, v interface{}) (err error) {
+	snappyWriter := snappy.NewBufferedWriter(w)
+	defer func() {
+		if closeErr := snappyWriter.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	return c.contentCodec.Encode(snappyWriter, v)
+}
+
+func (c codecSNAPPYFRAMED) Marshal(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := c.Encode(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/conjure-go-contract/codecs/snappy_framed_test.go
+++ b/conjure-go-contract/codecs/snappy_framed_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnappyFramedCompression(t *testing.T) {
+	// create a compressible string
+	input := strings.Join([]string{
+		strings.Repeat("a", 10),
+		strings.Repeat("b", 10),
+		strings.Repeat("a", 10),
+		strings.Repeat("c", 10),
+		strings.Repeat("a", 10),
+	}, "")
+	snappyEncoder := SnappyFramed(Plain)
+
+	t.Run("Encode/Decode", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := snappyEncoder.Encode(&buf, input)
+		require.NoError(t, err)
+
+		// assert encoded message compressed
+		encoded := buf.String()
+		assert.Less(t, len(encoded), len(input))
+
+		var actual string
+		err = snappyEncoder.Decode(strings.NewReader(encoded), &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, input, actual)
+	})
+	t.Run("Marshal/Unmarshal", func(t *testing.T) {
+		encoded, err := snappyEncoder.Marshal([]byte(input))
+		require.NoError(t, err)
+
+		// assert encoded message compressed
+		assert.Less(t, len(encoded), len(input))
+
+		var actual string
+		err = snappyEncoder.Unmarshal(encoded, &actual)
+		require.NoError(t, err)
+
+		require.Equal(t, input, actual)
+	})
+}


### PR DESCRIPTION
## Before this PR
Similar to snappy compression, but framed. Snappy-framed is a different wire format and requires a unique codec.

## After this PR
==COMMIT_MSG==
Add snappy-framed compression codec
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

