### PR TITLE
improvement: Add WithBaseURL param to avoid struct literals in WithBaseURLs

### DIFF
--- a/changelog/@unreleased/pr-697.v2.yml
+++ b/changelog/@unreleased/pr-697.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add WithBaseURL param to avoid struct literals in WithBaseURLs
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/697

--- a/conjure-go-client/httpclient/authn_test.go
+++ b/conjure-go-client/httpclient/authn_test.go
@@ -42,7 +42,7 @@ func TestRoundTripperWithToken(t *testing.T) {
 	client, err := httpclient.NewClient(
 		httpclient.WithHTTPTimeout(time.Minute),
 		httpclient.WithAuthTokenProvider(tokenProvider),
-		httpclient.WithBaseURLs([]string{server.URL}))
+		httpclient.WithBaseURL(server.URL))
 	require.NoError(t, err)
 
 	resp, err := client.Do(context.Background(), httpclient.WithRequestMethod(http.MethodGet))
@@ -71,7 +71,7 @@ func TestRoundTripperWithBasicAuth(t *testing.T) {
 	client, err := httpclient.NewClient(
 		httpclient.WithHTTPTimeout(time.Minute),
 		httpclient.WithBasicAuth(expected.User, expected.Password),
-		httpclient.WithBaseURLs([]string{server.URL}))
+		httpclient.WithBaseURL(server.URL))
 	require.NoError(t, err)
 
 	resp, err := client.Do(context.Background(), httpclient.WithRequestMethod(http.MethodGet))
@@ -106,7 +106,7 @@ func TestRoundTripperWithBasicAuthProvider(t *testing.T) {
 				Password: "password",
 			}, nil
 		}),
-		httpclient.WithBaseURLs([]string{server.URL}))
+		httpclient.WithBaseURL(server.URL))
 	require.NoError(t, err)
 
 	resp, err := client.Do(context.Background(), httpclient.WithRequestMethod(http.MethodGet))

--- a/conjure-go-client/httpclient/body_handler_test.go
+++ b/conjure-go-client/httpclient/body_handler_test.go
@@ -48,7 +48,7 @@ func TestJSONBody(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithUserAgent("TestNewRequest"),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 	)
 	require.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestRawBody(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithUserAgent("TestNewRequest"),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 	)
 	require.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestRawRequestRetry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{server.URL}))
+	client, err := httpclient.NewClient(httpclient.WithBaseURL(server.URL))
 	assert.NoError(t, err)
 
 	_, err = client.Do(
@@ -154,7 +154,7 @@ func TestRedirectWithBodyAndBytesBuffer(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithUserAgent("TestNewRequest"),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 		httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
 	)
 	require.NoError(t, err)

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -47,7 +47,7 @@ func TestWrapTransport(t *testing.T) {
 		httpclient.WithMiddleware(middleware(1)),
 		httpclient.WithMiddleware(middleware(2)),
 		httpclient.WithMiddleware(middleware(3)),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 	)
 	require.NoError(t, err)
 

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -450,6 +450,11 @@ func WithKeepAlive(keepAlive time.Duration) ClientOrHTTPClientParam {
 	})
 }
 
+// WithBaseURL is a variadic-argument alias for WithBaseURLs. Any previous base URLs will be overwritten.
+func WithBaseURL(urls ...string) ClientParam {
+	return WithBaseURLs(urls)
+}
+
 // WithBaseURLs sets the base URLs for every request. This is meant to be used in conjunction with WithPath.
 func WithBaseURLs(urls []string) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -145,8 +145,7 @@ func TestBuilder(t *testing.T) {
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			// Must provide URLs for client creation
-			urls := WithBaseURLs([]string{"https://localhost"})
-			client, err := NewClient(urls, test.Param)
+			client, err := NewClient(WithBaseURL("https://localhost"), test.Param)
 			require.NoError(t, err)
 			test.Test(t, client.(*clientImpl))
 		})

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -57,7 +57,7 @@ func TestCanReadBodyWithBufferPool(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 	)
 	require.NoError(t, err)
 
@@ -89,7 +89,7 @@ func TestCanUseRelocationURI(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 	)
 	assert.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestCanUseSimpleRelocationURI(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 	)
 	assert.NoError(t, err)
 
@@ -169,7 +169,7 @@ func TestMiddlewareCanReadBody(t *testing.T) {
 	t.Run("NoByteBufferPool", func(t *testing.T) {
 		client, err := httpclient.NewClient(
 			withMiddleware,
-			httpclient.WithBaseURLs([]string{server.URL}),
+			httpclient.WithBaseURL(server.URL),
 		)
 		require.NoError(t, err)
 		resp, err := client.Do(context.Background(), httpclient.WithRequestBody(unencodedBody, codecs.Plain), httpclient.WithRequestMethod("GET"))
@@ -180,7 +180,7 @@ func TestMiddlewareCanReadBody(t *testing.T) {
 		client, err := httpclient.NewClient(
 			httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
 			withMiddleware,
-			httpclient.WithBaseURLs([]string{server.URL}),
+			httpclient.WithBaseURL(server.URL),
 		)
 		require.NoError(t, err)
 		resp, err := client.Do(context.Background(), httpclient.WithRequestBody(unencodedBody, codecs.Plain), httpclient.WithRequestMethod("GET"))
@@ -258,7 +258,7 @@ func TestTimeouts(t *testing.T) {
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			clientParams := []httpclient.ClientParam{
-				httpclient.WithBaseURLs([]string{timeoutServer.URL}),
+				httpclient.WithBaseURL(timeoutServer.URL),
 				httpclient.WithMaxRetries(0),
 			}
 			if tt.ClientTimeout > 0 {
@@ -317,7 +317,7 @@ func BenchmarkAllocWithBytesBufferPool(b *testing.B) {
 	}
 	b.Run("NoByteBufferPool", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server.URL}),
+			httpclient.WithBaseURL(server.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
@@ -325,7 +325,7 @@ func BenchmarkAllocWithBytesBufferPool(b *testing.B) {
 	b.Run("WithByteBufferPool", func(b *testing.B) {
 		client, err := httpclient.NewClient(
 			httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
-			httpclient.WithBaseURLs([]string{server.URL}),
+			httpclient.WithBaseURL(server.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
@@ -376,42 +376,42 @@ func BenchmarkUnavailableURIs(b *testing.B) {
 	}
 	b.Run("OneAvailableServer", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server1.URL}),
+			httpclient.WithBaseURL(server1.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("FourAvailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server1.URL, server2.URL, server3.URL, server4.URL}),
+			httpclient.WithBaseURL(server1.URL, server2.URL, server3.URL, server4.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfFourUnavailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server1.URL, server2.URL, server3.URL, unavailableServer.URL}),
+			httpclient.WithBaseURL(server1.URL, server2.URL, server3.URL, unavailableServer.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfThreeUnavailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server1.URL, server2.URL, unavailableServer.URL}),
+			httpclient.WithBaseURL(server1.URL, server2.URL, unavailableServer.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfTwoUnavailableServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server1.URL, unavailableServer.URL}),
+			httpclient.WithBaseURL(server1.URL, unavailableServer.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)
 	})
 	b.Run("OneOutOfTwoUnstartedServers", func(b *testing.B) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{server1.URL, unstartedServer.URL}),
+			httpclient.WithBaseURL(server1.URL, unstartedServer.URL),
 		)
 		require.NoError(b, err)
 		runBench(b, client)

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -38,7 +38,7 @@ func TestClose(t *testing.T) {
 		_, _ = fmt.Fprintln(rw, "test")
 	}))
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithBaseURL(ts.URL),
 		httpclient.WithHTTPTimeout(5*time.Second),
 	)
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestCloseOnError(t *testing.T) {
 	before := runtime.NumGoroutine()
 	// create test server and client with an HTTP Timeout of 5s
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithBaseURL(ts.URL),
 		httpclient.WithHTTPTimeout(5*time.Second),
 	)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestCloseOnEmptyResponse(t *testing.T) {
 	before := runtime.NumGoroutine()
 	// create test server and client with an HTTP Timeout of 5s
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithBaseURL(ts.URL),
 		httpclient.WithHTTPTimeout(5*time.Second),
 	)
 	require.NoError(t, err)
@@ -138,14 +138,14 @@ func TestStreamingResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{ts.URL}),
+		httpclient.WithBaseURL(ts.URL),
 	)
 	require.NoError(t, err)
 	ctx := context.Background()
 	resp, err := client.Get(ctx, httpclient.WithPath("/"), httpclient.WithRawResponseBody())
 	require.NoError(t, err)
 	close(finishResponseChan)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, firstLine+"\n"+secondLine+"\n", string(b))
 }

--- a/conjure-go-client/httpclient/error_decoder_test.go
+++ b/conjure-go-client/httpclient/error_decoder_test.go
@@ -45,7 +45,7 @@ func TestErrorDecoder(t *testing.T) {
 	defer ts.Close()
 	t.Run("ClientDefault", func(t *testing.T) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{ts.URL}),
+			httpclient.WithBaseURL(ts.URL),
 		)
 		require.NoError(t, err)
 		resp, err := client.Get(context.Background())
@@ -57,7 +57,7 @@ func TestErrorDecoder(t *testing.T) {
 	})
 	t.Run("ClientNoop", func(t *testing.T) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{ts.URL}),
+			httpclient.WithBaseURL(ts.URL),
 			httpclient.WithDisableRestErrors(),
 		)
 		require.NoError(t, err)
@@ -68,7 +68,7 @@ func TestErrorDecoder(t *testing.T) {
 	})
 	t.Run("ClientCustom", func(t *testing.T) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{ts.URL}),
+			httpclient.WithBaseURL(ts.URL),
 			httpclient.WithErrorDecoder(&customErrorDecoder{
 				statusCode: statusCode,
 				message:    clientDecoderMsg,
@@ -81,7 +81,7 @@ func TestErrorDecoder(t *testing.T) {
 	})
 	t.Run("RequestCustom", func(t *testing.T) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{ts.URL}),
+			httpclient.WithBaseURL(ts.URL),
 			httpclient.WithErrorDecoder(&customErrorDecoder{
 				statusCode: statusCode,
 				message:    clientDecoderMsg,
@@ -101,7 +101,7 @@ func TestErrorDecoder(t *testing.T) {
 	})
 	t.Run("FallbackToClient", func(t *testing.T) {
 		client, err := httpclient.NewClient(
-			httpclient.WithBaseURLs([]string{ts.URL}),
+			httpclient.WithBaseURL(ts.URL),
 			httpclient.WithErrorDecoder(&customErrorDecoder{
 				statusCode: statusCode,
 				message:    clientDecoderMsg,

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -43,7 +43,7 @@ func TestFailover503(t *testing.T) {
 	s2 := httptest.NewServer(handler)
 	s3 := httptest.NewServer(handler)
 
-	cli, err := NewClient(WithBaseURLs([]string{s1.URL, s2.URL, s3.URL}))
+	cli, err := NewClient(WithBaseURL(s1.URL, s2.URL, s3.URL))
 	require.NoError(t, err)
 
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
@@ -71,7 +71,7 @@ func TestFailover429(t *testing.T) {
 	s3 := httptest.NewServer(handler)
 
 	backoff := 5 * time.Millisecond
-	cli, err := NewClient(WithBaseURLs([]string{s1.URL, s2.URL, s3.URL}), WithInitialBackoff(backoff), WithMaxBackoff(backoff))
+	cli, err := NewClient(WithBaseURL(s1.URL, s2.URL, s3.URL), WithInitialBackoff(backoff), WithMaxBackoff(backoff))
 	require.NoError(t, err)
 
 	timer := time.NewTimer(backoff)
@@ -96,7 +96,7 @@ func TestFailover200(t *testing.T) {
 	s1 := httptest.NewServer(handler)
 	s2 := httptest.NewServer(handler)
 	s3 := httptest.NewServer(handler)
-	cli, err := NewClient(WithBaseURLs([]string{s1.URL, s2.URL, s3.URL}))
+	cli, err := NewClient(WithBaseURL(s1.URL, s2.URL, s3.URL))
 	require.NoError(t, err)
 
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
@@ -114,7 +114,7 @@ func TestFailoverEverythingDown(t *testing.T) {
 	s1 := httptest.NewServer(handler)
 	s2 := httptest.NewServer(handler)
 	s3 := httptest.NewServer(handler)
-	cli, err := NewClient(WithBaseURLs([]string{s1.URL, s2.URL, s3.URL}), WithMaxRetries(5))
+	cli, err := NewClient(WithBaseURL(s1.URL, s2.URL, s3.URL), WithMaxRetries(5))
 	require.NoError(t, err)
 
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
@@ -133,7 +133,7 @@ func TestBackoffSingleURL(t *testing.T) {
 		}
 	})
 	s1 := httptest.NewServer(handler)
-	cli, err := NewClient(WithBaseURLs([]string{s1.URL}), WithMaxRetries(4))
+	cli, err := NewClient(WithBaseURL(s1.URL), WithMaxRetries(4))
 	require.NoError(t, err)
 
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
@@ -161,7 +161,7 @@ func TestFailoverOtherURL(t *testing.T) {
 		rw.WriteHeader(http.StatusPermanentRedirect)
 	}))
 
-	cli, err := NewClient(WithBaseURLs([]string{s2.URL, s3.URL}))
+	cli, err := NewClient(WithBaseURL(s2.URL, s3.URL))
 	require.NoError(t, err)
 
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
@@ -218,7 +218,7 @@ func TestSleep(t *testing.T) {
 
 	s1 := httptest.NewServer(handler)
 	s2 := httptest.NewServer(handler)
-	cli, err := NewClient(WithBaseURLs([]string{s1.URL, s2.URL}))
+	cli, err := NewClient(WithBaseURL(s1.URL, s2.URL))
 	require.NoError(t, err)
 
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
@@ -237,7 +237,7 @@ func TestRoundRobin(t *testing.T) {
 	s0 := httptest.NewServer(getHandler(0))
 	s1 := httptest.NewServer(getHandler(1))
 	s2 := httptest.NewServer(getHandler(2))
-	cli, err := NewClient(WithBaseURLs([]string{s0.URL, s1.URL, s2.URL}), WithMaxRetries(5))
+	cli, err := NewClient(WithBaseURL(s0.URL, s1.URL, s2.URL), WithMaxRetries(5))
 	require.NoError(t, err)
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
 	assert.Error(t, err)
@@ -255,7 +255,7 @@ func TestFailover_ConnectionRefused(t *testing.T) {
 	s1 := httptest.NewServer(http.NotFoundHandler())
 	defer s1.Close()
 
-	cli, err := NewClient(WithBaseURLs([]string{url1, url2, url1, url2, s1.URL}), WithDisableRestErrors())
+	cli, err := NewClient(WithBaseURL(url1, url2, url1, url2, s1.URL), WithDisableRestErrors())
 	require.NoError(t, err)
 
 	_, err = cli.Get(context.Background())
@@ -273,7 +273,7 @@ func TestFailover_NoHost(t *testing.T) {
 	s1 := httptest.NewServer(http.NotFoundHandler())
 	defer s1.Close()
 
-	cli, err := NewClient(WithBaseURLs([]string{url1, url2, url1, url2, s1.URL}), WithDisableRestErrors())
+	cli, err := NewClient(WithBaseURL(url1, url2, url1, url2, s1.URL), WithDisableRestErrors())
 	require.NoError(t, err)
 
 	_, err = cli.Get(context.Background())

--- a/conjure-go-client/httpclient/http2_client_test.go
+++ b/conjure-go-client/httpclient/http2_client_test.go
@@ -71,7 +71,7 @@ func testProxy(t *testing.T, readIdleTimeout, pingTimeout time.Duration, expecte
 	go proxy.serve(t, stopCh, false)
 
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{"https://" + proxy.ln.Addr().String()}),
+		httpclient.WithBaseURL("https://"+proxy.ln.Addr().String()),
 		httpclient.WithHTTP2ReadIdleTimeout(readIdleTimeout),
 		httpclient.WithHTTP2PingTimeout(pingTimeout),
 		httpclient.WithTLSInsecureSkipVerify(),

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -123,7 +123,7 @@ func TestRoundTripperWithMetrics(t *testing.T) {
 			httpclient.WithHTTPTimeout(5*time.Second),
 			httpclient.WithServiceName("my-service"),
 			httpclient.WithMetrics(tagsProviders...),
-			httpclient.WithBaseURLs([]string{serverURLstr}))
+			httpclient.WithBaseURL(serverURLstr))
 		require.NoError(t, err)
 
 		rpcMethodName, expectedMethodNameTag := getRpcNameAndExpectedTag()
@@ -212,17 +212,17 @@ func TestMetricsMiddleware_HTTPClient(t *testing.T) {
 }
 
 func TestMetricsMiddleware_ClientTimeout(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(time.Second)
 		w.WriteHeader(200)
 	}))
-	defer srv.Close()
+	defer server.Close()
 
 	rootRegistry := metrics.NewRootMetricsRegistry()
 	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
 
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{srv.URL}),
+		httpclient.WithBaseURL(server.URL),
 		httpclient.WithTLSInsecureSkipVerify(),
 		httpclient.WithServiceName("test-service"),
 		httpclient.WithHTTPTimeout(time.Millisecond),
@@ -251,10 +251,10 @@ func TestMetricsMiddleware_ClientTimeout(t *testing.T) {
 }
 
 func TestMetricsMiddleware_ContextCanceled(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
 	}))
-	defer srv.Close()
+	defer server.Close()
 
 	rootRegistry := metrics.NewRootMetricsRegistry()
 	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
@@ -262,7 +262,7 @@ func TestMetricsMiddleware_ContextCanceled(t *testing.T) {
 	cancel()
 
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{srv.URL}),
+		httpclient.WithBaseURL(server.URL),
 		httpclient.WithTLSInsecureSkipVerify(),
 		httpclient.WithServiceName("test-service"),
 		httpclient.WithMetrics())
@@ -383,15 +383,15 @@ func TestMetricsMiddleware_InFlightRequests(t *testing.T) {
 	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
 	serviceNameTag := metrics.MustNewTag("service-name", "test-service")
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		clientMetric := rootRegistry.Counter(httpclient.MetricRequestInFlight, serviceNameTag).Count()
 		assert.Equal(t, int64(1), clientMetric, "%s should be nonzero during a request", httpclient.MetricRequestInFlight)
 		w.WriteHeader(200)
 	}))
-	defer srv.Close()
+	defer server.Close()
 
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{srv.URL}),
+		httpclient.WithBaseURL(server.URL),
 		httpclient.WithServiceName("test-service"),
 		httpclient.WithMetrics())
 	require.NoError(t, err)

--- a/conjure-go-client/httpclient/recovery_test.go
+++ b/conjure-go-client/httpclient/recovery_test.go
@@ -33,7 +33,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 	defer server.Close()
 
 	client, err := httpclient.NewClient(
-		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithBaseURL(server.URL),
 		httpclient.WithMiddleware(panicMiddleware{err: helloErr}),
 	)
 	require.NoError(t, err)

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -211,7 +211,7 @@ func TestErrorDecoderMiddlewares(t *testing.T) {
 			tsURL, err := url.Parse(ts.URL)
 			require.NoError(t, err)
 
-			client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{ts.URL}), httpclient.WithNoProxy(), tc.decoderParam)
+			client, err := httpclient.NewClient(httpclient.WithBaseURL(ts.URL), httpclient.WithNoProxy(), tc.decoderParam)
 			require.NoError(t, err)
 
 			_, err = client.Get(ctx, httpclient.WithPath("/path"))

--- a/conjure-go-client/httpclient/trace_test.go
+++ b/conjure-go-client/httpclient/trace_test.go
@@ -88,7 +88,7 @@ func TestTracing(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{server.URL}))
+			client, err := httpclient.NewClient(httpclient.WithBaseURL(server.URL))
 			require.NoError(t, err)
 
 			resp, err := client.Do(ctx, testCase.requestParams...)


### PR DESCRIPTION
This is just syntactic sugar for when urls are enumerated by the caller anyway

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/697)
<!-- Reviewable:end -->
