### PR TITLE
fix: NewClientFromRefreshableConfig respects SecurityConfig

### DIFF
--- a/changelog/@unreleased/pr-701.v2.yml
+++ b/changelog/@unreleased/pr-701.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: NewClientFromRefreshableConfig respects SecurityConfig
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/701

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -27,7 +27,6 @@ import (
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/refreshable"
-	"github.com/palantir/pkg/tlsconfig"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 
@@ -215,7 +214,6 @@ func NewHTTPClientFromRefreshableConfig(ctx context.Context, config RefreshableC
 }
 
 func newClientBuilder() *clientBuilder {
-	defaultTLSConfig, _ := tlsconfig.NewClientConfig()
 	return &clientBuilder{
 		HTTP: &httpClientBuilder{
 			ServiceName: refreshable.NewString(refreshable.NewDefaultRefreshable("")),
@@ -225,7 +223,6 @@ func newClientBuilder() *clientBuilder {
 				KeepAlive:     defaultKeepAlive,
 				SocksProxyURL: nil,
 			})),
-			TLSConfig: defaultTLSConfig,
 			TransportParams: refreshingclient.NewRefreshingTransportParams(refreshable.NewDefaultRefreshable(refreshingclient.TransportParams{
 				MaxIdleConns:          defaultMaxIdleConns,
 				MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost,

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -360,6 +360,23 @@ func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 	})
 }
 
+func withSecurityConfig(conf SecurityConfig) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLS.CertFile = conf.CertFile
+			p.TLS.KeyFile = conf.KeyFile
+			p.TLS.CAFiles = conf.CAFiles
+			if conf.InsecureSkipVerify != nil {
+				p.TLS.InsecureSkipVerify = *conf.InsecureSkipVerify
+			} else {
+				p.TLS.InsecureSkipVerify = false
+			}
+			return p
+		})
+		return nil
+	})
+}
+
 // WithTLSInsecureSkipVerify sets the InsecureSkipVerify field for the HTTP client's tls config.
 // This option should only be used in clients that have way to establish trust with servers.
 // If WithTLSConfig is used, the config's InsecureSkipVerify is set to true.

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -360,6 +360,8 @@ func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 	})
 }
 
+// withSecurityConfig sets the builder's TransportParams.TLS to match the provided SecurityConfig.
+// This param is used by configToParams() but is not exported because users should use WithConfig().
 func withSecurityConfig(conf SecurityConfig) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -360,25 +360,6 @@ func WithTLSConfig(conf *tls.Config) ClientOrHTTPClientParam {
 	})
 }
 
-// withSecurityConfig sets the builder's TransportParams.TLS to match the provided SecurityConfig.
-// This param is used by configToParams() but is not exported because users should use WithConfig().
-func withSecurityConfig(conf SecurityConfig) ClientOrHTTPClientParam {
-	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
-		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
-			p.TLS.CertFile = conf.CertFile
-			p.TLS.KeyFile = conf.KeyFile
-			p.TLS.CAFiles = conf.CAFiles
-			if conf.InsecureSkipVerify != nil {
-				p.TLS.InsecureSkipVerify = *conf.InsecureSkipVerify
-			} else {
-				p.TLS.InsecureSkipVerify = false
-			}
-			return p
-		})
-		return nil
-	})
-}
-
 // WithTLSInsecureSkipVerify sets the InsecureSkipVerify field for the HTTP client's tls config.
 // This option should only be used in clients that have way to establish trust with servers.
 // If WithTLSConfig is used, the config's InsecureSkipVerify is set to true.

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -125,6 +125,9 @@ func TestBuilder(t *testing.T) {
 			Param: WithTLSConfig(nil),
 			Test: func(t *testing.T, client *clientImpl) {
 				// No-op: passing nil should not cause panic
+
+				transport, _ := unwrapTransport(client.client.CurrentHTTPClient().Transport)
+				assert.NotNil(t, transport.TLSClientConfig)
 			},
 		},
 		{
@@ -137,6 +140,18 @@ func TestBuilder(t *testing.T) {
 		{
 			Name:  "TLSInsecureSkipVerify",
 			Param: WithTLSInsecureSkipVerify(),
+			Test: func(t *testing.T, client *clientImpl) {
+				transport, _ := unwrapTransport(client.client.CurrentHTTPClient().Transport)
+				assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+			},
+		},
+		{
+			Name: "TLSConfig from config",
+			Param: WithConfig(ClientConfig{
+				Security: SecurityConfig{
+					InsecureSkipVerify: &[]bool{true}[0],
+				},
+			}),
 			Test: func(t *testing.T, client *clientImpl) {
 				transport, _ := unwrapTransport(client.client.CurrentHTTPClient().Transport)
 				assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -365,16 +365,7 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 	}
 
 	// Security (TLS) Config
-
-	if tlsConfig, err := refreshingclient.NewTLSConfig(context.TODO(), refreshingclient.TLSParams{
-		CAFiles:  c.Security.CAFiles,
-		CertFile: c.Security.CertFile,
-		KeyFile:  c.Security.KeyFile,
-	}); err != nil {
-		return nil, err
-	} else if tlsConfig != nil {
-		params = append(params, WithTLSConfig(tlsConfig))
-	}
+	params = append(params, withSecurityConfig(c.Security))
 
 	return params, nil
 }
@@ -402,6 +393,12 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		HTTP2ReadIdleTimeout:  derefPtr(config.HTTP2ReadIdleTimeout, defaultHTTP2ReadIdleTimeout),
 		ProxyFromEnvironment:  derefPtr(config.ProxyFromEnvironment, true),
 		TLSHandshakeTimeout:   derefPtr(config.TLSHandshakeTimeout, defaultTLSHandshakeTimeout),
+		TLS: refreshingclient.TLSParams{
+			CAFiles:            config.Security.CAFiles,
+			CertFile:           config.Security.CertFile,
+			KeyFile:            config.Security.KeyFile,
+			InsecureSkipVerify: derefPtr(config.Security.InsecureSkipVerify, false),
+		},
 	}
 
 	if config.ProxyURL != nil {

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -365,7 +365,16 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 	}
 
 	// Security (TLS) Config
-	params = append(params, withSecurityConfig(c.Security))
+	if tlsConfig, err := refreshingclient.NewTLSConfig(context.TODO(), refreshingclient.TLSParams{
+		CAFiles:            c.Security.CAFiles,
+		CertFile:           c.Security.CertFile,
+		KeyFile:            c.Security.KeyFile,
+		InsecureSkipVerify: derefPtr(c.Security.InsecureSkipVerify, false),
+	}); err != nil {
+		return nil, err
+	} else if tlsConfig != nil {
+		params = append(params, WithTLSConfig(tlsConfig))
+	}
 
 	return params, nil
 }

--- a/conjure-go-client/httpclient/config_refreshable_test.go
+++ b/conjure-go-client/httpclient/config_refreshable_test.go
@@ -260,6 +260,24 @@ func TestRefreshableClientConfig(t *testing.T) {
 		initialConfig.Default.ProxyFromEnvironment = nil
 		updateRefreshableBytes(initialConfig)
 	})
+
+	t.Run("tls updates, transport updates", func(t *testing.T) {
+		oldClient := currentHTTPClient()
+		oldTransport, _ := unwrapTransport(oldClient.Transport)
+
+		assert.Equal(t, false, oldTransport.TLSClientConfig.InsecureSkipVerify)
+
+		initialConfig.Default.Security.InsecureSkipVerify = &[]bool{true}[0]
+		updateRefreshableBytes(initialConfig)
+
+		newClient := currentHTTPClient()
+		newTransport, _ := unwrapTransport(newClient.Transport)
+
+		assert.Equal(t, true, newTransport.TLSClientConfig.InsecureSkipVerify)
+
+		initialConfig.Default.Security.InsecureSkipVerify = nil
+		updateRefreshableBytes(initialConfig)
+	})
 }
 
 func newDurationPtr(dur time.Duration) *time.Duration {

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -69,7 +69,7 @@ func NewRefreshableTLSConfig(ctx context.Context, params RefreshableTLSParams) (
 	return RefreshableTLSConfig{r: r}, nil
 }
 
-// GetTLSConfig returns the the most recent valid *tls.Config.
+// GetTLSConfig returns the most recent valid *tls.Config.
 // If the last refreshable update resulted in an error, that error is logged and
 // the previous value is returned.
 func (r RefreshableTLSConfig) GetTLSConfig(ctx context.Context) *tls.Config {


### PR DESCRIPTION
Fixes regression from #689, which now depends on the builder's `b.TLSConfig` being nil in case we should construct a refreshable provider.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/701)
<!-- Reviewable:end -->
