### PR TITLE
fix: requestBodyFunc handles functions returning nil readers; add RetrieveReaderFromRequestBody

### DIFF
--- a/changelog/@unreleased/pr-719.v2.yml
+++ b/changelog/@unreleased/pr-719.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: RequestBodyFunc handles functions returning nil readers; add RetrieveReaderFromRequestBody
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/719


### PR DESCRIPTION
Fixes failures like this conjure-go test failure: https://app.circleci.com/pipelines/github/palantir/conjure-go/1963/workflows/9d9e8d4a-91e2-4ced-8e6d-dcbef1aca645/jobs/7973/steps

```
=== RUN   TestBytes/BinaryOptionalAlias_empty
    binary_test.go:112: 
                Error Trace:    /home/circleci/go/src/github.com/palantir/conjure-go/integration_test/testgenerated/binary/binary_test.go:112
                Error:          Received unexpected error:
                                http: Request.ContentLength=-1 with nil Body
                                httpclient request failed map[requestHost:127.0.0.1:33297 requestMethod:Post]
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/719)
<!-- Reviewable:end -->
