### PR TITLE
fix: codecs.codecSNAPPY.Marshal uses configured contentCodec

### DIFF
--- a/changelog/@unreleased/pr-723.v2.yml
+++ b/changelog/@unreleased/pr-723.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Codecs.codecSNAPPY.Marshal uses configured contentCodec
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/723

--- a/conjure-go-contract/codecs/snappy.go
+++ b/conjure-go-contract/codecs/snappy.go
@@ -18,7 +18,6 @@ import (
 	"io"
 
 	"github.com/golang/snappy"
-	werror "github.com/palantir/witchcraft-go-error"
 )
 
 var _ Codec = codecSNAPPY{}
@@ -68,20 +67,16 @@ func (c codecSNAPPY) Encode(w io.Writer, v interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	encoded, err := c.Marshal(data)
-	if err != nil {
-		return err
-	}
+	encoded := snappy.Encode(nil, data)
 	_, err = w.Write(encoded)
 	return err
 }
 
 func (c codecSNAPPY) Marshal(v interface{}) ([]byte, error) {
-	data, ok := v.([]byte)
-	if !ok {
-		return nil, werror.Error("failed to compress data from type which is not of type []byte")
+	data, err := c.contentCodec.Marshal(v)
+	if err != nil {
+		return nil, err
 	}
-	d := snappy.Encode(nil, data)
-	return d, nil
+	encoded := snappy.Encode(nil, data)
+	return encoded, nil
 }

--- a/conjure-go-contract/codecs/snappy_test.go
+++ b/conjure-go-contract/codecs/snappy_test.go
@@ -50,7 +50,7 @@ func TestSnappyCompression(t *testing.T) {
 		require.Equal(t, input, actual)
 	})
 	t.Run("Marshal/Unmarshal", func(t *testing.T) {
-		encoded, err := snappyEncoder.Marshal([]byte(input))
+		encoded, err := snappyEncoder.Marshal(input)
 		require.NoError(t, err)
 
 		// assert encoded message compressed


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/723)
<!-- Reviewable:end -->
