### PR TITLE
fix: codecs.GZIP checks error before defer func

### DIFF
--- a/changelog/@unreleased/pr-730.v2.yml
+++ b/changelog/@unreleased/pr-730.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Codecs.GZIP checks error before defer func
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/730

--- a/conjure-go-contract/codecs/gzip.go
+++ b/conjure-go-contract/codecs/gzip.go
@@ -38,14 +38,14 @@ func (c codecGZIP) Accept() string {
 
 func (c codecGZIP) Decode(r io.Reader, v interface{}) (err error) {
 	gzipReader, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %w", err)
+	}
 	defer func() {
 		if closeErr := gzipReader.Close(); err == nil && closeErr != nil {
 			err = closeErr
 		}
 	}()
-	if err != nil {
-		return fmt.Errorf("failed to create gzip reader: %s", err.Error())
-	}
 	return c.contentCodec.Decode(gzipReader, v)
 }
 


### PR DESCRIPTION
If gzip.NewReader fails, we should not attempt to close the nil return value

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/730)
<!-- Reviewable:end -->
