### PR TITLE
Revert "feature: Update config, not params, during builder phase"

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/bytesbuffers"
+	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"
 )
@@ -54,6 +55,7 @@ var (
 type clientBuilder struct {
 	HTTP *httpClientBuilder
 
+	URIs             refreshable.StringSlice
 	URIScorerBuilder func([]string) internal.URIScoringMiddleware
 
 	// If false, NewClient() will return an error when URIs.Current() is empty.
@@ -63,15 +65,19 @@ type clientBuilder struct {
 	ErrorDecoder ErrorDecoder
 
 	BytesBufferPool bytesbuffers.Pool
+	MaxAttempts     refreshable.IntPtr
+	RetryParams     refreshingclient.RefreshableRetryParams
 }
 
 type httpClientBuilder struct {
-	// A set of functions that modify the ClientConfig before it is used to build the client.
-	// Populated by client params and applied using Map on the underlying refreshable config.
-	ConfigOverride []func(c *ClientConfig)
+	ServiceName     refreshable.String
+	Timeout         refreshable.Duration
+	DialerParams    refreshingclient.RefreshableDialerParams
+	TLSConfig       *tls.Config // If unset, config in TransportParams will be used.
+	TransportParams refreshingclient.RefreshableTransportParams
+	Middlewares     []Middleware
 
-	TLSConfig           *tls.Config // Optionally set by WithTLSConfig(). If unset, config.Security is used.
-	Middlewares         []Middleware
+	DisableMetrics      refreshable.Bool
 	MetricsTagProviders []TagsProvider
 
 	// These middleware options are not refreshed anywhere because they are not in ClientConfig,
@@ -81,69 +87,57 @@ type httpClientBuilder struct {
 	DisableTraceHeaders bool
 }
 
-func (b *httpClientBuilder) Build(ctx context.Context, config RefreshableClientConfig, reloadErrorSubmitter func(error), params ...HTTPClientParam) (RefreshableHTTPClient, refreshingclient.RefreshableValidatedClientParams, error) {
+func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam) (RefreshableHTTPClient, error) {
 	for _, p := range params {
 		if p == nil {
 			continue
 		}
 		if err := p.applyHTTPClient(b); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	finalConfig := newRefreshingClientConfigWithConfigOverrides(config, b.ConfigOverride...)
-
-	validParams, err := newRefreshingValidatedClientParams(ctx, finalConfig, reloadErrorSubmitter)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Build the transport with a refreshable dialer and tls config.
-	// Each component attempts to rebuild as infrequently as possible.
-	serviceName := validParams.ServiceName()
-	transportParams := validParams.Transport()
-	metricsTagProviders := append(b.MetricsTagProviders, refreshableTagsProvider{validParams.MetricsTags()})
 
 	var tlsProvider refreshingclient.TLSProvider
 	if b.TLSConfig != nil {
 		tlsProvider = refreshingclient.NewStaticTLSConfigProvider(b.TLSConfig)
 	} else {
-		refreshableProvider, err := refreshingclient.NewRefreshableTLSConfig(ctx, transportParams.TLS())
+		refreshableProvider, err := refreshingclient.NewRefreshableTLSConfig(ctx, b.TransportParams.TLS())
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		tlsProvider = refreshableProvider
 	}
 
-	dialer := refreshingclient.NewRefreshableDialer(ctx, validParams.Dialer())
-	transport := refreshingclient.NewRefreshableTransport(ctx, transportParams, tlsProvider, dialer)
-	transport = wrapTransport(transport, newMetricsMiddleware(serviceName, metricsTagProviders, validParams.DisableMetrics()))
-	transport = wrapTransport(transport, newTraceMiddleware(serviceName, b.DisableRequestSpan, b.DisableTraceHeaders))
+	dialer := refreshingclient.NewRefreshableDialer(ctx, b.DialerParams)
+	transport := refreshingclient.NewRefreshableTransport(ctx, b.TransportParams, tlsProvider, dialer)
+	transport = wrapTransport(transport, newMetricsMiddleware(b.ServiceName, b.MetricsTagProviders, b.DisableMetrics))
+	transport = wrapTransport(transport, newTraceMiddleware(b.ServiceName, b.DisableRequestSpan, b.DisableTraceHeaders))
 	if !b.DisableRecovery {
 		transport = wrapTransport(transport, recoveryMiddleware{})
 	}
 	transport = wrapTransport(transport, b.Middlewares...)
 
-	client := refreshingclient.NewRefreshableHTTPClient(transport, validParams.Timeout())
-	return client, validParams, nil
+	return refreshingclient.NewRefreshableHTTPClient(transport, b.Timeout), nil
 }
 
 // NewClient returns a configured client ready for use.
 // We apply "sane defaults" before applying the provided params.
 func NewClient(params ...ClientParam) (Client, error) {
-	return NewClientFromRefreshableConfig(context.TODO(), nil, params...)
+	b := newClientBuilder()
+	return newClient(context.TODO(), b, params...)
 }
 
 // NewClientFromRefreshableConfig returns a configured client ready for use.
 // We apply "sane defaults" before applying the provided params.
 func NewClientFromRefreshableConfig(ctx context.Context, config RefreshableClientConfig, params ...ClientParam) (Client, error) {
-	b := &clientBuilder{
-		HTTP:         &httpClientBuilder{},
-		ErrorDecoder: restErrorDecoder{},
+	b := newClientBuilder()
+	if err := newClientBuilderFromRefreshableConfig(ctx, config, b, nil); err != nil {
+		return nil, err
 	}
-	return newClient(ctx, config, b, nil, params...)
+	return newClient(ctx, b, params...)
 }
 
-func newClient(ctx context.Context, config RefreshableClientConfig, b *clientBuilder, reloadErrorSubmitter func(error), params ...ClientParam) (Client, error) {
+func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (Client, error) {
 	for _, p := range params {
 		if p == nil {
 			continue
@@ -151,6 +145,12 @@ func newClient(ctx context.Context, config RefreshableClientConfig, b *clientBui
 		if err := p.apply(b); err != nil {
 			return nil, err
 		}
+	}
+	if b.URIs == nil {
+		return nil, werror.ErrorWithContextParams(ctx, "httpclient URLs must be set in configuration or by constructor param", werror.SafeParam("serviceName", b.HTTP.ServiceName.CurrentString()))
+	}
+	if !b.AllowEmptyURIs && len(b.URIs.CurrentStringSlice()) == 0 {
+		return nil, werror.WrapWithContextParams(ctx, ErrEmptyURIs, "", werror.SafeParam("serviceName", b.HTTP.ServiceName.CurrentString()))
 	}
 
 	var edm Middleware
@@ -161,40 +161,27 @@ func newClient(ctx context.Context, config RefreshableClientConfig, b *clientBui
 	middleware := b.HTTP.Middlewares
 	b.HTTP.Middlewares = nil
 
-	httpClient, validParams, err := b.HTTP.Build(ctx, config, reloadErrorSubmitter)
+	httpClient, err := b.HTTP.Build(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if !b.AllowEmptyURIs {
-		// Validate that the URIs are not empty.
-		if curr := validParams.CurrentValidatedClientParams(); len(curr.URIs) == 0 {
-			return nil, werror.ErrorWithContextParams(ctx, "httpclient URIs must be set in configuration or by constructor param",
-				werror.SafeParam("serviceName", curr.ServiceName))
-		}
 	}
 
 	var recovery Middleware
 	if !b.HTTP.DisableRecovery {
 		recovery = recoveryMiddleware{}
 	}
-	uriScorer := internal.NewRefreshableURIScoringMiddleware(validParams.URIs(), func(uris []string) internal.URIScoringMiddleware {
+	uriScorer := internal.NewRefreshableURIScoringMiddleware(b.URIs, func(uris []string) internal.URIScoringMiddleware {
 		if b.URIScorerBuilder == nil {
 			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 { return time.Now().UnixNano() })
 		}
 		return b.URIScorerBuilder(uris)
 	})
-
-	middleware = append(middleware,
-		newAuthTokenMiddlewareFromRefreshable(validParams.APIToken()),
-		newBasicAuthMiddlewareFromRefreshable(validParams.BasicAuth()))
-
 	return &clientImpl{
-		serviceName:            validParams.ServiceName(),
+		serviceName:            b.HTTP.ServiceName,
 		client:                 httpClient,
 		uriScorer:              uriScorer,
-		maxAttempts:            validParams.MaxAttempts(),
-		backoffOptions:         validParams.Retry(),
+		maxAttempts:            b.MaxAttempts,
+		backoffOptions:         b.RetryParams,
 		middlewares:            middleware,
 		errorDecoderMiddleware: edm,
 		recoveryMiddleware:     recovery,
@@ -205,7 +192,8 @@ func newClient(ctx context.Context, config RefreshableClientConfig, b *clientBui
 // NewHTTPClient returns a configured http client ready for use.
 // We apply "sane defaults" before applying the provided params.
 func NewHTTPClient(params ...HTTPClientParam) (*http.Client, error) {
-	provider, err := NewHTTPClientFromRefreshableConfig(context.TODO(), nil, params...)
+	b := newClientBuilder()
+	provider, err := b.HTTP.Build(context.TODO(), params...)
 	if err != nil {
 		return nil, err
 	}
@@ -217,16 +205,57 @@ type RefreshableHTTPClient = refreshingclient.RefreshableHTTPClient
 
 // NewHTTPClientFromRefreshableConfig returns a configured http client ready for use.
 // We apply "sane defaults" before applying the provided params.
-//
-// The RefreshableClientConfig is not accepted as a client param because there must be exactly one
-// subscription used to build the ValidatedClientParams in Build().
 func NewHTTPClientFromRefreshableConfig(ctx context.Context, config RefreshableClientConfig, params ...HTTPClientParam) (RefreshableHTTPClient, error) {
-	client, _, err := new(httpClientBuilder).Build(ctx, config, nil, params...)
-	return client, err
+	b := newClientBuilder()
+	if err := newClientBuilderFromRefreshableConfig(ctx, config, b, nil); err != nil {
+		return nil, err
+	}
+	return b.HTTP.Build(ctx, params...)
 }
 
-// Map the final config to a set of validated client params used to build the dialer, retrier, tls config, and transport.
-func newRefreshingValidatedClientParams(ctx context.Context, config RefreshableClientConfig, reloadErrorSubmitter func(error)) (refreshingclient.RefreshableValidatedClientParams, error) {
+func newClientBuilder() *clientBuilder {
+	return &clientBuilder{
+		HTTP: &httpClientBuilder{
+			ServiceName: refreshable.NewString(refreshable.NewDefaultRefreshable("")),
+			Timeout:     refreshable.NewDuration(refreshable.NewDefaultRefreshable(defaultHTTPTimeout)),
+			DialerParams: refreshingclient.NewRefreshingDialerParams(refreshable.NewDefaultRefreshable(refreshingclient.DialerParams{
+				DialTimeout:   defaultDialTimeout,
+				KeepAlive:     defaultKeepAlive,
+				SocksProxyURL: nil,
+			})),
+			TransportParams: refreshingclient.NewRefreshingTransportParams(refreshable.NewDefaultRefreshable(refreshingclient.TransportParams{
+				MaxIdleConns:          defaultMaxIdleConns,
+				MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost,
+				DisableHTTP2:          false,
+				DisableKeepAlives:     false,
+				IdleConnTimeout:       defaultIdleConnTimeout,
+				ExpectContinueTimeout: defaultExpectContinueTimeout,
+				ResponseHeaderTimeout: 0,
+				TLSHandshakeTimeout:   defaultTLSHandshakeTimeout,
+				HTTPProxyURL:          nil,
+				ProxyFromEnvironment:  true,
+				HTTP2ReadIdleTimeout:  defaultHTTP2ReadIdleTimeout,
+				HTTP2PingTimeout:      defaultHTTP2PingTimeout,
+			})),
+			Middlewares:         nil,
+			DisableMetrics:      refreshable.NewBool(refreshable.NewDefaultRefreshable(false)),
+			MetricsTagProviders: nil,
+			DisableRecovery:     false,
+			DisableRequestSpan:  false,
+			DisableTraceHeaders: false,
+		},
+		URIs:            nil,
+		BytesBufferPool: nil,
+		ErrorDecoder:    restErrorDecoder{},
+		MaxAttempts:     nil,
+		RetryParams: refreshingclient.NewRefreshingRetryParams(refreshable.NewDefaultRefreshable(refreshingclient.RetryParams{
+			InitialBackoff: defaultInitialBackoff,
+			MaxBackoff:     defaultMaxBackoff,
+		})),
+	}
+}
+
+func newClientBuilderFromRefreshableConfig(ctx context.Context, config RefreshableClientConfig, b *clientBuilder, reloadErrorSubmitter func(error)) error {
 	refreshingParams, err := refreshable.NewMapValidatingRefreshable(config, func(i interface{}) (interface{}, error) {
 		p, err := newValidatedClientParamsFromConfig(ctx, i.(ClientConfig))
 		if reloadErrorSubmitter != nil {
@@ -235,21 +264,25 @@ func newRefreshingValidatedClientParams(ctx context.Context, config RefreshableC
 		return p, err
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 	validParams := refreshingclient.NewRefreshingValidatedClientParams(refreshingParams)
-	return validParams, nil
-}
 
-func newRefreshingClientConfigWithConfigOverrides(config RefreshableClientConfig, configOverride ...func(c *ClientConfig)) RefreshableClientConfig {
-	// Build the final config refreshable by applying the overrides.
-	if config == nil {
-		config = NewRefreshingClientConfig(refreshable.NewDefaultRefreshable(ClientConfig{}))
-	}
-	return NewRefreshingClientConfig(config.MapClientConfig(func(c ClientConfig) interface{} {
-		for _, o := range configOverride {
-			o(&c)
-		}
-		return c
-	}))
+	b.HTTP.ServiceName = validParams.ServiceName()
+	b.HTTP.DialerParams = validParams.Dialer()
+	b.HTTP.TransportParams = validParams.Transport()
+	b.HTTP.Timeout = validParams.Timeout()
+	b.HTTP.DisableMetrics = validParams.DisableMetrics()
+	b.HTTP.MetricsTagProviders = append(b.HTTP.MetricsTagProviders,
+		TagsProviderFunc(func(*http.Request, *http.Response, error) metrics.Tags {
+			return validParams.CurrentValidatedClientParams().MetricsTags
+		}))
+	b.HTTP.Middlewares = append(b.HTTP.Middlewares,
+		newAuthTokenMiddlewareFromRefreshable(validParams.APIToken()),
+		newBasicAuthMiddlewareFromRefreshable(validParams.BasicAuth()))
+
+	b.URIs = validParams.URIs()
+	b.MaxAttempts = validParams.MaxAttempts()
+	b.RetryParams = validParams.Retry()
+	return nil
 }

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -22,18 +22,17 @@ import (
 	"time"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 
-// ClientParam is an interface that seals optional parameters used by NewClient and its variants.
+// ClientParam is a param that can be used to build
 type ClientParam interface {
 	apply(builder *clientBuilder) error
 }
 
-// HTTPClientParam is an interface that seals optional parameters used by NewHTTPClient and its variants.
-// These params (generally) operate on the http.Transport and do not modify the http.Request itself.
 type HTTPClientParam interface {
 	applyHTTPClient(builder *httpClientBuilder) error
 }
@@ -72,36 +71,44 @@ func (f clientOrHTTPClientParamFunc) applyHTTPClient(b *httpClientBuilder) error
 	return f(b)
 }
 
-// configOverrideClientParamFunc constructs a ClientOrHTTPClientParam that modifies a ClientConfig pointer.
-// If provided to NewClient or NewHTTPClient, these parameters will be applied to the ClientConfig before the client is built
-// and will override any values set in the refreshable configuration.
-func configOverrideClientParamFunc(override func(c *ClientConfig)) clientOrHTTPClientParamFunc {
-	return func(b *httpClientBuilder) error {
-		b.ConfigOverride = append(b.ConfigOverride, override)
+func WithConfig(c ClientConfig) ClientParam {
+	return clientParamFunc(func(b *clientBuilder) error {
+		params, err := configToParams(c)
+		if err != nil {
+			return err
+		}
+		for _, p := range params {
+			if err := p.apply(b); err != nil {
+				return err
+			}
+		}
 		return nil
-	}
-}
-
-// WithConfig merges all the values from the provided config into the final config used by the client.
-// These masked values take precedence over those from a refreshable configuration used as the basis
-// for NewClient or NewHTTPClient.
-func WithConfig(in ClientConfig) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		*c = MergeClientConfig(in, *c)
 	})
 }
 
-// WithConfigForHTTPClient merges all the values from the provided config into the final config used by the http.Client.
-//
-// Deprecated: Use WithConfig instead.
-func WithConfigForHTTPClient(in ClientConfig) HTTPClientParam {
-	return WithConfig(in)
+func WithConfigForHTTPClient(c ClientConfig) HTTPClientParam {
+	return httpClientParamFunc(func(b *httpClientBuilder) error {
+		params, err := configToParams(c)
+		if err != nil {
+			return err
+		}
+		for _, p := range params {
+			httpClientParam, ok := p.(HTTPClientParam)
+			if !ok {
+				return werror.Error("param from config was not a http client builder param")
+			}
+			if err := httpClientParam.applyHTTPClient(b); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
-// WithServiceName sets the service name for the client, used in telemetry.
 func WithServiceName(serviceName string) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ServiceName = serviceName
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.ServiceName = refreshable.NewString(refreshable.NewDefaultRefreshable(serviceName))
+		return nil
 	})
 }
 
@@ -115,8 +122,6 @@ func WithMiddleware(h Middleware) ClientOrHTTPClientParam {
 	})
 }
 
-// WithAddHeader adds the key-value pair to the request headers.
-// If the key is already set, the value is appended.
 func WithAddHeader(key, value string) ClientOrHTTPClientParam {
 	return WithMiddleware(MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
 		req.Header.Add(key, value)
@@ -124,8 +129,6 @@ func WithAddHeader(key, value string) ClientOrHTTPClientParam {
 	}))
 }
 
-// WithSetHeader sets the key-value pair to the request headers.
-// If the key is already set, the value is overwritten.
 func WithSetHeader(key, value string) ClientOrHTTPClientParam {
 	return WithMiddleware(MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
 		req.Header.Set(key, value)
@@ -162,9 +165,7 @@ func WithOverrideRequestHost(host string) ClientOrHTTPClientParam {
 // The serviceName will appear as the "service-name" tag.
 func WithMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
-		b.ConfigOverride = append(b.ConfigOverride, func(c *ClientConfig) {
-			c.Metrics.Enabled = newPtr(true)
-		})
+		b.DisableMetrics = refreshable.NewBool(refreshable.NewDefaultRefreshable(false))
 		b.MetricsTagProviders = append(b.MetricsTagProviders, tagProviders...)
 		return nil
 	})
@@ -217,17 +218,21 @@ func WithDisableTraceHeaderPropagation() ClientOrHTTPClientParam {
 // WithHTTPTimeout sets the timeout on the http client.
 // If unset, the client defaults to 1 minute.
 func WithHTTPTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ReadTimeout = &timeout
-		c.WriteTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.Timeout = refreshable.NewDuration(refreshable.NewDefaultRefreshable(timeout))
+		return nil
 	})
 }
 
 // WithDisableHTTP2 skips the default behavior of configuring
 // the transport with http2.ConfigureTransport.
 func WithDisableHTTP2() ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.DisableHTTP2 = newPtr(true)
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.DisableHTTP2 = true
+			return p
+		})
+		return nil
 	})
 }
 
@@ -240,8 +245,12 @@ func WithDisableHTTP2() ClientOrHTTPClientParam {
 // The amount of time to wait for the ping response can be configured by the WithHTTP2PingTimeout param.
 // If unset, the client defaults to 30 seconds, if HTTP2 is enabled.
 func WithHTTP2ReadIdleTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.HTTP2ReadIdleTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.HTTP2ReadIdleTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
@@ -250,24 +259,36 @@ func WithHTTP2ReadIdleTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 // the ReadIdleTimeout is > 0 otherwise pings (health checks) are not enabled.
 // If unset, the client defaults to 15 seconds, if HTTP/2 is enabled and the ReadIdleTimeout is > 0.
 func WithHTTP2PingTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.HTTP2PingTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.HTTP2PingTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
 // WithMaxIdleConns sets the number of reusable TCP connections the client
 // will maintain. If unset, the client defaults to 200.
 func WithMaxIdleConns(conns int) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.MaxIdleConns = &conns
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.MaxIdleConns = conns
+			return p
+		})
+		return nil
 	})
 }
 
 // WithMaxIdleConnsPerHost sets the number of reusable TCP connections the client
 // will maintain per destination. If unset, the client defaults to 100.
 func WithMaxIdleConnsPerHost(conns int) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.MaxIdleConnsPerHost = &conns
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.MaxIdleConnsPerHost = conns
+			return p
+		})
+		return nil
 	})
 }
 
@@ -275,17 +296,29 @@ func WithMaxIdleConnsPerHost(conns int) ClientOrHTTPClientParam {
 // ignoring any proxy set in the process's environment.
 // If unset, the default is http.ProxyFromEnvironment.
 func WithNoProxy() ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ProxyURL = nil
-		c.ProxyFromEnvironment = newPtr(false)
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.DialerParams = refreshingclient.ConfigureDialer(b.DialerParams, func(p refreshingclient.DialerParams) refreshingclient.DialerParams {
+			p.SocksProxyURL = nil
+			return p
+		})
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.HTTPProxyURL = nil
+			p.ProxyFromEnvironment = false
+			return p
+		})
+		return nil
 	})
 }
 
 // WithProxyFromEnvironment can be used to set the HTTP(s) proxy to use
 // the Go standard library's http.ProxyFromEnvironment.
 func WithProxyFromEnvironment() ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ProxyFromEnvironment = newPtr(true)
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.ProxyFromEnvironment = true
+			return p
+		})
+		return nil
 	})
 }
 
@@ -298,13 +331,18 @@ func WithProxyURL(proxyURLString string) ClientOrHTTPClientParam {
 		}
 		switch proxyURL.Scheme {
 		case "http", "https":
+			b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+				p.HTTPProxyURL = proxyURL
+				return p
+			})
 		case "socks5", "socks5h":
+			b.DialerParams = refreshingclient.ConfigureDialer(b.DialerParams, func(p refreshingclient.DialerParams) refreshingclient.DialerParams {
+				p.SocksProxyURL = proxyURL
+				return p
+			})
 		default:
 			return werror.Error("unrecognized proxy scheme", werror.SafeParam("scheme", proxyURL.Scheme))
 		}
-		b.ConfigOverride = append(b.ConfigOverride, func(c *ClientConfig) {
-			c.ProxyURL = &proxyURLString
-		})
 		return nil
 	})
 }
@@ -330,8 +368,9 @@ func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 		if b.TLSConfig != nil {
 			b.TLSConfig.InsecureSkipVerify = true
 		}
-		b.ConfigOverride = append(b.ConfigOverride, func(c *ClientConfig) {
-			c.Security.InsecureSkipVerify = newPtr(true)
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLS.InsecureSkipVerify = true
+			return p
 		})
 		return nil
 	})
@@ -340,24 +379,36 @@ func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 // WithDialTimeout sets the timeout on the Dialer.
 // If unset, the client defaults to 90 seconds.
 func WithDialTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ConnectTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.DialerParams = refreshingclient.ConfigureDialer(b.DialerParams, func(p refreshingclient.DialerParams) refreshingclient.DialerParams {
+			p.DialTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
 // WithIdleConnTimeout sets the timeout for idle connections.
 // If unset, the client defaults to 90 seconds.
 func WithIdleConnTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.IdleConnTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.IdleConnTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
 // WithTLSHandshakeTimeout sets the timeout for TLS handshakes.
 // If unset, the client defaults to 10 seconds.
 func WithTLSHandshakeTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.TLSHandshakeTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLSHandshakeTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
@@ -365,8 +416,12 @@ func WithTLSHandshakeTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 // fully writing the request headers if the request has an "Expect: 100-continue" header.
 // If unset, the client defaults to 1 second.
 func WithExpectContinueTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ExpectContinueTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.ExpectContinueTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
@@ -374,25 +429,31 @@ func WithExpectContinueTimeout(timeout time.Duration) ClientOrHTTPClientParam {
 // the request (including its body, if any). This time does not include the time to read the response body. If unset,
 // the client defaults to having no response header timeout.
 func WithResponseHeaderTimeout(timeout time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.ResponseHeaderTimeout = &timeout
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.ResponseHeaderTimeout = timeout
+			return p
+		})
+		return nil
 	})
 }
 
 // WithKeepAlive sets the keep alive frequency on the Dialer.
 // If unset, the client defaults to 30 seconds.
 func WithKeepAlive(keepAlive time.Duration) ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.KeepAlive = &keepAlive
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.DialerParams = refreshingclient.ConfigureDialer(b.DialerParams, func(p refreshingclient.DialerParams) refreshingclient.DialerParams {
+			p.KeepAlive = keepAlive
+			return p
+		})
+		return nil
 	})
 }
 
 // WithBaseURLs sets the base URLs for every request. This is meant to be used in conjunction with WithPath.
 func WithBaseURLs(urls []string) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
-		b.HTTP.ConfigOverride = append(b.HTTP.ConfigOverride, func(c *ClientConfig) {
-			c.URIs = urls
-		})
+		b.URIs = refreshable.NewStringSlice(refreshable.NewDefaultRefreshable(urls))
 		return nil
 	})
 }
@@ -400,9 +461,7 @@ func WithBaseURLs(urls []string) ClientParam {
 // WithRefreshableBaseURLs sets the base URLs for every request. This is meant to be used in conjunction with WithPath.
 func WithRefreshableBaseURLs(urls refreshable.StringSlice) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
-		b.HTTP.ConfigOverride = append(b.HTTP.ConfigOverride, func(c *ClientConfig) {
-			c.URIs = urls.CurrentStringSlice()
-		})
+		b.URIs = urls
 		return nil
 	})
 }
@@ -421,8 +480,9 @@ func WithAllowCreateWithEmptyURIs() ClientParam {
 // Defaults to 2 seconds. <= 0 indicates no limit.
 func WithMaxBackoff(maxBackoff time.Duration) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
-		b.HTTP.ConfigOverride = append(b.HTTP.ConfigOverride, func(c *ClientConfig) {
-			c.MaxBackoff = &maxBackoff
+		b.RetryParams = refreshingclient.ConfigureRetry(b.RetryParams, func(p refreshingclient.RetryParams) refreshingclient.RetryParams {
+			p.MaxBackoff = maxBackoff
+			return p
 		})
 		return nil
 	})
@@ -431,8 +491,9 @@ func WithMaxBackoff(maxBackoff time.Duration) ClientParam {
 // WithInitialBackoff sets the initial backoff between retried calls to the same URI. Defaults to 250ms.
 func WithInitialBackoff(initialBackoff time.Duration) ClientParam {
 	return clientParamFunc(func(b *clientBuilder) error {
-		b.HTTP.ConfigOverride = append(b.HTTP.ConfigOverride, func(c *ClientConfig) {
-			c.InitialBackoff = &initialBackoff
+		b.RetryParams = refreshingclient.ConfigureRetry(b.RetryParams, func(p refreshingclient.RetryParams) refreshingclient.RetryParams {
+			p.InitialBackoff = initialBackoff
+			return p
 		})
 		return nil
 	})
@@ -443,16 +504,22 @@ func WithInitialBackoff(initialBackoff time.Duration) ClientParam {
 // If unset, the client defaults to 2 * size of URIs
 // TODO (#151): Rename to WithMaxAttempts and set maxAttempts directly using the argument provided to the function.
 func WithMaxRetries(maxTransportRetries int) ClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.MaxNumRetries = &maxTransportRetries
+	return clientParamFunc(func(b *clientBuilder) error {
+		attempts := maxTransportRetries + 1
+		b.MaxAttempts = refreshable.NewIntPtr(refreshable.NewDefaultRefreshable(&attempts))
+		return nil
 	})
 }
 
 // WithUnlimitedRetries sets an unlimited number of retries on transport errors for every request.
 // If set, this supersedes any retry limits set with WithMaxRetries.
 func WithUnlimitedRetries() ClientParam {
-	// hack: will have 1 added to create MaxAttempts of 0, which means unlimited retries.
-	return WithMaxRetries(-1)
+	return clientParamFunc(func(b *clientBuilder) error {
+		// max attempts of 0 indicates no limit
+		attempts := 0
+		b.MaxAttempts = refreshable.NewIntPtr(refreshable.NewDefaultRefreshable(&attempts))
+		return nil
+	})
 }
 
 // WithDisableRestErrors disables the middleware which sets Do()'s returned
@@ -466,8 +533,12 @@ func WithDisableRestErrors() ClientParam {
 
 // WithDisableKeepAlives disables keep alives on the http transport
 func WithDisableKeepAlives() ClientOrHTTPClientParam {
-	return configOverrideClientParamFunc(func(c *ClientConfig) {
-		c.KeepAlive = newPtr(time.Duration(0))
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshingclient.ConfigureTransport(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.DisableKeepAlives = true
+			return p
+		})
+		return nil
 	})
 }
 
@@ -540,5 +611,3 @@ func WithRandomURIScoring() ClientParam {
 		return nil
 	})
 }
-
-func newPtr[T any](t T) *T { return &t }

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestNoBaseURIs(t *testing.T) {
 	client, err := httpclient.NewClient()
-	require.EqualError(t, err, "httpclient URIs must be set in configuration or by constructor param")
+	require.EqualError(t, err, "httpclient URLs must be set in configuration or by constructor param")
 	require.Nil(t, client)
 }
 

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -15,9 +15,10 @@
 package httpclient
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
 	"net/url"
-	"os"
 	"slices"
 	"time"
 
@@ -256,6 +257,128 @@ func MergeClientConfig(conf, defaults ClientConfig) ClientConfig {
 	return conf
 }
 
+func configToParams(c ClientConfig) ([]ClientParam, error) {
+	var params []ClientParam
+
+	if len(c.URIs) > 0 {
+		params = append(params, WithBaseURLs(c.URIs))
+	}
+
+	if c.ServiceName != "" {
+		params = append(params, WithServiceName(c.ServiceName))
+	}
+
+	// Bearer Token
+
+	if c.APIToken != nil && *c.APIToken != "" {
+		params = append(params, WithAuthToken(*c.APIToken))
+	} else if c.APITokenFile != nil && *c.APITokenFile != "" {
+		token, err := ioutil.ReadFile(*c.APITokenFile)
+		if err != nil {
+			return nil, werror.Wrap(err, "failed to read api-token-file", werror.SafeParam("file", *c.APITokenFile))
+		}
+		params = append(params, WithAuthToken(string(bytes.TrimSpace(token))))
+	} else if c.BasicAuth != nil && c.BasicAuth.User != "" && c.BasicAuth.Password != "" {
+		params = append(params, WithBasicAuth(c.BasicAuth.User, c.BasicAuth.Password))
+	}
+
+	// Disable HTTP2 (http2 is enabled by default)
+	if c.DisableHTTP2 != nil && *c.DisableHTTP2 {
+		params = append(params, WithDisableHTTP2())
+	}
+
+	// Retries
+
+	if c.MaxNumRetries != nil {
+		params = append(params, WithMaxRetries(*c.MaxNumRetries))
+	}
+
+	// Backoff
+
+	if c.MaxBackoff != nil {
+		params = append(params, WithMaxBackoff(*c.MaxBackoff))
+	}
+
+	if c.InitialBackoff != nil {
+		params = append(params, WithInitialBackoff(*c.InitialBackoff))
+	}
+
+	// Metrics (default enabled)
+
+	if c.Metrics.Enabled == nil || (c.Metrics.Enabled != nil && *c.Metrics.Enabled) {
+		configuredTags, err := metrics.NewTags(c.Metrics.Tags)
+		if err != nil {
+			return nil, werror.Wrap(err, "invalid metrics configuration")
+		}
+		params = append(params, WithMetrics(StaticTagsProvider(configuredTags)))
+	}
+
+	// Proxy
+
+	if c.ProxyFromEnvironment != nil && *c.ProxyFromEnvironment {
+		params = append(params, WithProxyFromEnvironment())
+	}
+	if c.ProxyURL != nil {
+		params = append(params, WithProxyURL(*c.ProxyURL))
+	}
+
+	// Timeouts
+
+	if c.ConnectTimeout != nil && *c.ConnectTimeout != 0 {
+		params = append(params, WithDialTimeout(*c.ConnectTimeout))
+	}
+	if c.IdleConnTimeout != nil && *c.IdleConnTimeout != 0 {
+		params = append(params, WithIdleConnTimeout(*c.IdleConnTimeout))
+	}
+	if c.TLSHandshakeTimeout != nil && *c.TLSHandshakeTimeout != 0 {
+		params = append(params, WithTLSHandshakeTimeout(*c.TLSHandshakeTimeout))
+	}
+	if c.ExpectContinueTimeout != nil && *c.ExpectContinueTimeout != 0 {
+		params = append(params, WithExpectContinueTimeout(*c.ExpectContinueTimeout))
+	}
+	if c.ResponseHeaderTimeout != nil && *c.ResponseHeaderTimeout != 0 {
+		params = append(params, WithResponseHeaderTimeout(*c.ResponseHeaderTimeout))
+	}
+	if c.KeepAlive != nil && *c.KeepAlive != 0 {
+		params = append(params, WithKeepAlive(*c.KeepAlive))
+	}
+	if c.HTTP2ReadIdleTimeout != nil && *c.HTTP2ReadIdleTimeout >= 0 {
+		params = append(params, WithHTTP2ReadIdleTimeout(*c.HTTP2ReadIdleTimeout))
+	}
+	if c.HTTP2PingTimeout != nil && *c.HTTP2PingTimeout >= 0 {
+		params = append(params, WithHTTP2PingTimeout(*c.HTTP2PingTimeout))
+	}
+
+	// Connections
+
+	if c.MaxIdleConns != nil && *c.MaxIdleConns != 0 {
+		params = append(params, WithMaxIdleConns(*c.MaxIdleConns))
+	}
+	if c.MaxIdleConnsPerHost != nil && *c.MaxIdleConnsPerHost != 0 {
+		params = append(params, WithMaxIdleConnsPerHost(*c.MaxIdleConnsPerHost))
+	}
+
+	// N.B. we only have one timeout field (not based on method) so just take the max of read and write for now.
+	timeout := max(derefPtr(c.WriteTimeout, 0), derefPtr(c.ReadTimeout, 0))
+	if timeout != 0 {
+		params = append(params, WithHTTPTimeout(timeout))
+	}
+
+	// Security (TLS) Config
+	if tlsConfig, err := refreshingclient.NewTLSConfig(context.TODO(), refreshingclient.TLSParams{
+		CAFiles:            c.Security.CAFiles,
+		CertFile:           c.Security.CertFile,
+		KeyFile:            c.Security.KeyFile,
+		InsecureSkipVerify: derefPtr(c.Security.InsecureSkipVerify, false),
+	}); err != nil {
+		return nil, err
+	} else if tlsConfig != nil {
+		params = append(params, WithTLSConfig(tlsConfig))
+	}
+
+	return params, nil
+}
+
 func RefreshableClientConfigFromServiceConfig(servicesConfig RefreshableServicesConfig, serviceName string) RefreshableClientConfig {
 	return NewRefreshingClientConfig(servicesConfig.MapServicesConfig(func(servicesConfig ServicesConfig) interface{} {
 		return servicesConfig.ClientConfig(serviceName)
@@ -272,7 +395,6 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		MaxIdleConns:          derefPtr(config.MaxIdleConns, defaultMaxIdleConns),
 		MaxIdleConnsPerHost:   derefPtr(config.MaxIdleConnsPerHost, defaultMaxIdleConnsPerHost),
 		DisableHTTP2:          derefPtr(config.DisableHTTP2, false),
-		DisableKeepAlives:     derefPtr(config.KeepAlive, defaultKeepAlive) == 0,
 		IdleConnTimeout:       derefPtr(config.IdleConnTimeout, defaultIdleConnTimeout),
 		ExpectContinueTimeout: derefPtr(config.ExpectContinueTimeout, defaultExpectContinueTimeout),
 		ResponseHeaderTimeout: derefPtr(config.ResponseHeaderTimeout, 0),
@@ -309,7 +431,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		apiToken = config.APIToken
 	} else if config.APITokenFile != nil {
 		file := *config.APITokenFile
-		token, err := os.ReadFile(file)
+		token, err := ioutil.ReadFile(file)
 		if err != nil {
 			return refreshingclient.ValidatedClientParams{}, werror.WrapWithContextParams(ctx, err, "failed to read api-token-file", werror.SafeParam("file", file))
 		}
@@ -322,7 +444,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		}
 	}
 
-	disableMetrics := !derefPtr(config.Metrics.Enabled, true)
+	disableMetrics := config.Metrics.Enabled != nil && !*config.Metrics.Enabled
 
 	metricsTags, err := metrics.NewTags(config.Metrics.Tags)
 	if err != nil {
@@ -335,7 +457,8 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 	}
 	var maxAttempts *int
 	if config.MaxNumRetries != nil {
-		maxAttempts = newPtr(*config.MaxNumRetries + 1)
+		attempts := *config.MaxNumRetries + 1
+		maxAttempts = &attempts
 	}
 
 	timeout := defaultHTTPTimeout

--- a/conjure-go-client/httpclient/config_refreshable_test.go
+++ b/conjure-go-client/httpclient/config_refreshable_test.go
@@ -71,6 +71,7 @@ func TestRefreshableClientConfig(t *testing.T) {
 				assert.Equal(t, uint16(tls.VersionTLS12), tlsConfig.MinVersion, "unexpected tls min version")
 			}
 		}
+
 	}
 	t.Run("default static config", func(t *testing.T) {
 		client, err := NewClient(WithConfig(ClientConfig{ServiceName: serviceName, URIs: []string{"https://localhost"}}))
@@ -78,75 +79,8 @@ func TestRefreshableClientConfig(t *testing.T) {
 		testDefaultClient(t, client.(*clientImpl))
 	})
 
-	t.Run("refreshable config without uris fails", func(t *testing.T) {
-		initialConfig := ServicesConfig{
-			Default:  ClientConfig{},
-			Services: map[string]ClientConfig{},
-		}
-		initialConfigBytes, err := yaml.Marshal(initialConfig)
-		require.NoError(t, err)
-		refreshableConfigBytes := refreshable.NewDefaultRefreshable(initialConfigBytes)
-		updateRefreshableBytes := func(s ServicesConfig) {
-			b, err := yaml.Marshal(s)
-			if err != nil {
-				panic(err)
-			}
-			if err := refreshableConfigBytes.Update(b); err != nil {
-				panic(err)
-			}
-		}
-		refreshableServicesConfig := NewRefreshingServicesConfig(refreshableConfigBytes.Map(func(i interface{}) interface{} {
-			var c ServicesConfig
-			if err := yaml.Unmarshal(i.([]byte), &c); err != nil {
-				panic(err)
-			}
-			return c
-		}))
-		getClientURIs := func(client Client) []string {
-			return client.(*clientImpl).uriScorer.CurrentURIScoringMiddleware().GetURIsInOrderOfIncreasingScore()
-		}
-		refreshableClientConfig := RefreshableClientConfigFromServiceConfig(refreshableServicesConfig, serviceName)
-		client, err := NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig)
-		require.EqualError(t, err, "httpclient URIs must be set in configuration or by constructor param")
-		require.Nil(t, client)
-
-		client, err = NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig, WithBaseURLs([]string{"https://localhost"}))
-		require.NoError(t, err, "expected to successfully create client using WithBaseURL even when config has no URIs")
-		require.Equal(t, []string{"https://localhost"}, getClientURIs(client), "expected URIs to be set")
-
-		client, err = NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig, WithRefreshableBaseURLs(refreshable.NewStringSlice(refreshable.NewDefaultRefreshable([]string{"https://localhost"}))))
-		require.NoError(t, err, "expected to successfully create client using WithRefreshableBaseURLs even when config has no URIs")
-		require.Equal(t, []string{"https://localhost"}, getClientURIs(client), "expected URIs to be set")
-
-		t.Run("WithAllowCreateWithEmptyURIs", func(t *testing.T) {
-			client, err := NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig, WithAllowCreateWithEmptyURIs())
-			require.NoError(t, err, "expected to create a client from empty client config with WithAllowCreateWithEmptyURIs")
-
-			// Expect error making request
-			_, err = client.Get(context.Background())
-			require.EqualError(t, err, ErrEmptyURIs.Error())
-			// Update config
-			initialConfig.Services[serviceName] = ClientConfig{ServiceName: serviceName, URIs: []string{"https://localhost"}}
-			updateRefreshableBytes(initialConfig)
-
-			require.Equal(t, []string{"https://localhost"}, getClientURIs(client), "expected URIs to be set")
-		})
-
-		t.Run("WithBaseURL overrides invalid configured uris", func(t *testing.T) {
-			_, err := NewClient(
-				WithConfig(ClientConfig{URIs: []string{"invalid://localhost"}}),
-				WithBaseURLs([]string{"https://localhost"}))
-			require.NoError(t, err)
-
-			_, err = NewClientFromRefreshableConfig(
-				context.Background(),
-				NewRefreshingClientConfig(refreshable.NewDefaultRefreshable(ClientConfig{URIs: []string{"invalid://localhost"}})),
-				WithBaseURLs([]string{"https://localhost"}))
-			require.NoError(t, err)
-		})
-	})
-
 	// Build a refreshable client from the ground up -- start with an empty configuration, then add/mutate values.
+
 	initialConfig := ServicesConfig{
 		Default:  ClientConfig{},
 		Services: map[string]ClientConfig{},
@@ -170,6 +104,39 @@ func TestRefreshableClientConfig(t *testing.T) {
 		}
 		return c
 	}))
+
+	t.Run("refreshable config without uris fails", func(t *testing.T) {
+		getClientURIs := func(client Client) []string {
+			return client.(*clientImpl).uriScorer.CurrentURIScoringMiddleware().GetURIsInOrderOfIncreasingScore()
+		}
+		refreshableClientConfig := RefreshableClientConfigFromServiceConfig(refreshableServicesConfig, serviceName)
+		client, err := NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig)
+		require.EqualError(t, err, "httpclient URLs must not be empty")
+		require.Nil(t, client)
+
+		client, err = NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig, WithBaseURLs([]string{"https://localhost"}))
+		require.NoError(t, err, "expected to successfully create client using WithBaseURL even when config has no URIs")
+		require.Equal(t, []string{"https://localhost"}, getClientURIs(client), "expected URIs to be set")
+
+		client, err = NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig, WithRefreshableBaseURLs(refreshable.NewStringSlice(refreshable.NewDefaultRefreshable([]string{"https://localhost"}))))
+		require.NoError(t, err, "expected to successfully create client using WithRefreshableBaseURLs even when config has no URIs")
+		require.Equal(t, []string{"https://localhost"}, getClientURIs(client), "expected URIs to be set")
+
+		t.Run("WithAllowCreateWithEmptyURIs", func(t *testing.T) {
+			client, err := NewClientFromRefreshableConfig(context.Background(), refreshableClientConfig, WithAllowCreateWithEmptyURIs())
+			require.NoError(t, err, "expected to create a client from empty client config with WithAllowCreateWithEmptyURIs")
+
+			// Expect error making request
+			_, err = client.Get(context.Background())
+			require.EqualError(t, err, ErrEmptyURIs.Error())
+			// Update config
+			initialConfig.Services[serviceName] = ClientConfig{ServiceName: serviceName, URIs: []string{"https://localhost"}}
+			updateRefreshableBytes(initialConfig)
+
+			require.Equal(t, []string{"https://localhost"}, getClientURIs(client), "expected URIs to be set")
+		})
+	})
+
 	refreshableClientConfig := RefreshableClientConfigFromServiceConfig(refreshableServicesConfig, serviceName)
 	initialConfig.Services[serviceName] = ClientConfig{ServiceName: serviceName, URIs: []string{"https://localhost"}}
 	updateRefreshableBytes(initialConfig)
@@ -189,7 +156,7 @@ func TestRefreshableClientConfig(t *testing.T) {
 
 		t.Run("service config", func(t *testing.T) {
 			serviceCfg := initialConfig.Services[serviceName]
-			serviceCfg.WriteTimeout = newPtr(time.Second)
+			serviceCfg.WriteTimeout = newDurationPtr(time.Second)
 			initialConfig.Services[serviceName] = serviceCfg
 			updateRefreshableBytes(initialConfig)
 
@@ -201,7 +168,7 @@ func TestRefreshableClientConfig(t *testing.T) {
 			assert.Equal(t, oldMiddlewares, newMiddlewares, "expected middlewares to remain unchanged")
 		})
 		t.Run("default config", func(t *testing.T) {
-			initialConfig.Default.ReadTimeout = newPtr(time.Hour)
+			initialConfig.Default.ReadTimeout = newDurationPtr(time.Hour)
 			updateRefreshableBytes(initialConfig)
 
 			newClient := currentHTTPClient()
@@ -311,28 +278,8 @@ func TestRefreshableClientConfig(t *testing.T) {
 		initialConfig.Default.Security.InsecureSkipVerify = nil
 		updateRefreshableBytes(initialConfig)
 	})
+}
 
-	t.Run("update keep-alive, transport updates, tlsconfig doesn't", func(t *testing.T) {
-		oldClient := currentHTTPClient()
-		oldTransport, _ := unwrapTransport(oldClient.Transport)
-
-		assert.False(t, oldTransport.DisableKeepAlives)
-
-		c := initialConfig.Services[serviceName]
-		oldKeepAlive := c.KeepAlive
-		c.KeepAlive = newPtr(time.Duration(0))
-		initialConfig.Services[serviceName] = c
-		updateRefreshableBytes(initialConfig)
-
-		newClient := currentHTTPClient()
-		newTransport, _ := unwrapTransport(newClient.Transport)
-
-		assert.True(t, newTransport.DisableKeepAlives)
-
-		assert.Equal(t, oldTransport.TLSClientConfig, newTransport.TLSClientConfig)
-
-		c.KeepAlive = oldKeepAlive
-		initialConfig.Services[serviceName] = c
-		updateRefreshableBytes(initialConfig)
-	})
+func newDurationPtr(dur time.Duration) *time.Duration {
+	return &dur
 }

--- a/conjure-go-client/httpclient/config_test.go
+++ b/conjure-go-client/httpclient/config_test.go
@@ -81,7 +81,7 @@ func TestWithConfigForHTTPClientParam(t *testing.T) {
 			},
 		},
 	}
-	client, err := NewHTTPClient(WithConfig(conf.ClientConfig("my-service")))
+	client, err := NewHTTPClient(WithConfigForHTTPClient(conf.ClientConfig("my-service")))
 	require.NoError(t, err)
 	assert.Equal(t, 3*time.Second, client.Timeout)
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/dialer.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/dialer.go
@@ -58,6 +58,14 @@ func NewRefreshableDialer(ctx context.Context, p RefreshableDialerParams) Contex
 	}
 }
 
+// ConfigureDialer accepts a mapping function which will be applied to the params value as it is evaluated.
+// This can be used to layer/overwrite configuration before building the RefreshableDialer.
+func ConfigureDialer(r RefreshableDialerParams, mapFn func(p DialerParams) DialerParams) RefreshableDialerParams {
+	return NewRefreshingDialerParams(r.MapDialerParams(func(params DialerParams) interface{} {
+		return mapFn(params)
+	}))
+}
+
 type RefreshableDialer struct {
 	refreshable.Refreshable // contains ContextDialer
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -50,6 +50,14 @@ func NewRefreshableTransport(ctx context.Context, p RefreshableTransportParams, 
 	}
 }
 
+// ConfigureTransport accepts a mapping function which will be applied to the params value as it is evaluated.
+// This can be used to layer/overwrite configuration before building the RefreshableTransportParams.
+func ConfigureTransport(r RefreshableTransportParams, mapFn func(p TransportParams) TransportParams) RefreshableTransportParams {
+	return NewRefreshingTransportParams(r.MapTransportParams(func(params TransportParams) interface{} {
+		return mapFn(params)
+	}))
+}
+
 // RefreshableTransport implements http.RoundTripper backed by a refreshable *http.Transport.
 // The transport and internal dialer are each rebuilt when any of their respective parameters are updated.
 type RefreshableTransport struct {

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -23,7 +23,6 @@ import (
 	"net/http/httptrace"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -75,16 +74,8 @@ func (f TagsProviderFunc) Tags(req *http.Request, resp *http.Response, respErr e
 
 type StaticTagsProvider metrics.Tags
 
-func (s StaticTagsProvider) Tags(*http.Request, *http.Response, error) metrics.Tags {
+func (s StaticTagsProvider) Tags(_ *http.Request, _ *http.Response, _ error) metrics.Tags {
 	return metrics.Tags(s)
-}
-
-type refreshableTagsProvider struct {
-	refreshingclient.RefreshableTags
-}
-
-func (r refreshableTagsProvider) Tags(*http.Request, *http.Response, error) metrics.Tags {
-	return r.CurrentTags()
 }
 
 // MetricsMiddleware updates the "client.response" timer metric on every request.


### PR DESCRIPTION
Reverts palantir/conjure-go-runtime#694

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/736)
<!-- Reviewable:end -->
