### PR TITLE
feature: Add client.connection.dialer timer to measure DialContext()

### DIFF
--- a/changelog/@unreleased/pr-747.v2.yml
+++ b/changelog/@unreleased/pr-747.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add client.connection.dialer timer to measure DialContext()
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/747

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -108,7 +108,7 @@ func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam
 		tlsProvider = refreshableProvider
 	}
 
-	dialer := refreshingclient.NewRefreshableDialer(ctx, b.DialerParams)
+	dialer := newMetricsDialer(refreshingclient.NewRefreshableDialer(ctx, b.DialerParams), b.ServiceName, b.DisableMetrics)
 	transport := refreshingclient.NewRefreshableTransport(ctx, b.TransportParams, tlsProvider, dialer)
 	transport = wrapTransport(transport, newMetricsMiddleware(b.ServiceName, b.MetricsTagProviders, b.DisableMetrics))
 	transport = wrapTransport(transport, newTraceMiddleware(b.ServiceName, b.DisableRequestSpan, b.DisableTraceHeaders))

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptrace"
 	"time"
 
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -30,6 +31,7 @@ import (
 
 const (
 	MetricTagServiceName = "service-name"
+	metricClientDialer   = "client.connection.dialer"
 	metricClientResponse = "client.response"
 	metricTagFamily      = "family"
 	metricTagMethod      = "method"
@@ -76,6 +78,25 @@ type StaticTagsProvider metrics.Tags
 
 func (s StaticTagsProvider) Tags(_ *http.Request, _ *http.Response, _ error) metrics.Tags {
 	return metrics.Tags(s)
+}
+
+type metricsDialer struct {
+	Dialer      refreshingclient.ContextDialer
+	ServiceName refreshable.String
+	Disabled    refreshable.Bool
+}
+
+func newMetricsDialer(dialer refreshingclient.ContextDialer, serviceName refreshable.String, disabled refreshable.Bool) refreshingclient.ContextDialer {
+	return &metricsDialer{Dialer: dialer, ServiceName: serviceName, Disabled: disabled}
+}
+
+func (d *metricsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	defer func(startTime time.Time) {
+		serviceNameTag := metrics.NewTagWithFallbackValue(MetricTagServiceName, d.ServiceName.CurrentString(), "unknown")
+		metrics.FromContext(ctx).Timer(metricClientDialer, serviceNameTag).UpdateSince(startTime)
+	}(time.Now())
+
+	return d.Dialer.DialContext(ctx, network, address)
 }
 
 // MetricsMiddleware updates the "client.response" timer metric on every request.

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -91,10 +91,12 @@ func newMetricsDialer(dialer refreshingclient.ContextDialer, serviceName refresh
 }
 
 func (d *metricsDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	defer func(startTime time.Time) {
-		serviceNameTag := metrics.NewTagWithFallbackValue(MetricTagServiceName, d.ServiceName.CurrentString(), "unknown")
-		metrics.FromContext(ctx).Timer(metricClientDialer, serviceNameTag).UpdateSince(startTime)
-	}(time.Now())
+	if !d.Disabled.CurrentBool() {
+		defer func(startTime time.Time) {
+			serviceNameTag := metrics.NewTagWithFallbackValue(MetricTagServiceName, d.ServiceName.CurrentString(), "unknown")
+			metrics.FromContext(ctx).Timer(metricClientDialer, serviceNameTag).UpdateSince(startTime)
+		}(time.Now())
+	}
 
 	return d.Dialer.DialContext(ctx, network, address)
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/747)
<!-- Reviewable:end -->
