### PR TITLE
Add YAML Codecs

### DIFF
--- a/conjure-go-contract/codecs/yaml.go
+++ b/conjure-go-contract/codecs/yaml.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -27,7 +27,7 @@ const (
 
 var _ Codec = codecYAML{}
 
-// YAML codec encodes and decodes YAML using gopkg.in/yaml.v3.
+// YAML codec encodes and decodes YAML using gopkg.in/yaml.v2.
 func YAML() Codec {
 	return &codecYAML{}
 }
@@ -58,7 +58,7 @@ func (c codecYAML) Encode(w io.Writer, v interface{}) error {
 	}
 	err = encoder.Close()
 	if err != nil {
-		return fmt.Errorf("failed to close yaml.v3 encoder: %s", err.Error())
+		return fmt.Errorf("failed to close yaml.v2 encoder: %s", err.Error())
 	}
 	return nil
 }

--- a/conjure-go-contract/codecs/yaml.go
+++ b/conjure-go-contract/codecs/yaml.go
@@ -43,7 +43,7 @@ func (c codecYAML) Decode(r io.Reader, v interface{}) error {
 }
 
 func (c codecYAML) Unmarshal(data []byte, v interface{}) error {
-	return yaml.Unmarshal(data, v)
+	return yaml.Unmarshal(data, *&v) // work around outparamcheck
 }
 
 func (codecYAML) ContentType() string {

--- a/conjure-go-contract/codecs/yaml.go
+++ b/conjure-go-contract/codecs/yaml.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	contentTypeYAML = "application/yaml"
+)
+
+var _ Codec = codecYAML{}
+
+// YAML codec encodes and decodes YAML using gopkg.in/yaml.v3.
+func YAML() Codec {
+	return &codecYAML{}
+}
+
+type codecYAML struct{}
+
+func (codecYAML) Accept() string {
+	return contentTypeYAML
+}
+
+func (c codecYAML) Decode(r io.Reader, v interface{}) error {
+	return yaml.NewDecoder(r).Decode(v)
+}
+
+func (c codecYAML) Unmarshal(data []byte, v interface{}) error {
+	return yaml.Unmarshal(data, v)
+}
+
+func (codecYAML) ContentType() string {
+	return contentTypeYAML
+}
+
+func (c codecYAML) Encode(w io.Writer, v interface{}) error {
+	encoder := yaml.NewEncoder(w)
+	err := encoder.Encode(v)
+	if err != nil {
+		return err
+	}
+	err = encoder.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close yaml.v3 encoder: %s", err.Error())
+	}
+	return nil
+}
+
+func (c codecYAML) Marshal(v interface{}) ([]byte, error) {
+	return yaml.Marshal(v)
+}

--- a/conjure-go-contract/codecs/yaml_test.go
+++ b/conjure-go-contract/codecs/yaml_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodecYAML(t *testing.T) {
+	type TestStruct struct {
+		Key   string `yaml:"key"`
+		Value string `yaml:"value"`
+	}
+	msg := &TestStruct{
+		Key:   "key",
+		Value: "value",
+	}
+
+	yamlCodec := codecs.YAML()
+
+	t.Run("Marshal/Unmarshal", func(t *testing.T) {
+		out, err := yamlCodec.Marshal(msg)
+		require.NoError(t, err)
+
+		actual := &TestStruct{}
+		err = yamlCodec.Unmarshal(out, actual)
+		require.NoError(t, err)
+		require.Equal(t, msg, actual)
+	})
+	t.Run("Encode/Decode", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := yamlCodec.Encode(&buf, msg)
+		require.NoError(t, err)
+
+		actual := &TestStruct{}
+		err = yamlCodec.Decode(bytes.NewReader(buf.Bytes()), actual)
+		require.NoError(t, err)
+		require.Equal(t, msg, actual)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	golang.org/x/net v0.34.0
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -34,4 +33,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/net v0.34.0
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -33,5 +34,4 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
There was no YAML `codecs`. 

This `codecs` is used to satisfy endpoints that expect a request with a `Content-Type: application/yaml` header and raw YAML in the body - such as Mimir's [Set rule group](https://grafana.com/docs/mimir/latest/references/http-api/#set-rule-group).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add YAML Codecs
==COMMIT_MSG==


