### PR TITLE
improvement: Update client_params to give an WithoutMetrics option

### DIFF
--- a/changelog/@unreleased/pr-794.v2.yml
+++ b/changelog/@unreleased/pr-794.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update client_params to give an WithoutMetrics option
+  links:
+  - https://github.com/palantir/conjure-go-runtime/pull/794

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -183,6 +183,15 @@ func WithMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {
 	})
 }
 
+// WithoutMetrics disables the "client.response" metric.
+func WithoutMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.DisableMetrics = refreshable.NewBool(refreshable.NewDefaultRefreshable(true))
+		b.MetricsTagProviders = nil
+		return nil
+	})
+}
+
 // WithBytesBufferPool stores a bytes buffer pool on the client for use in encoding request bodies.
 // This prevents allocating a new byte buffer for every request.
 func WithBytesBufferPool(pool bytesbuffers.Pool) ClientParam {

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -184,6 +184,7 @@ func WithMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {
 }
 
 // WithoutMetrics disables the "client.response" metric.
+// Also clears any b.MetricsTagProviders that were set
 func WithoutMetrics() ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.DisableMetrics = refreshable.NewBool(refreshable.NewDefaultRefreshable(true))

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -184,7 +184,7 @@ func WithMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {
 }
 
 // WithoutMetrics disables the "client.response" metric.
-func WithoutMetrics(tagProviders ...TagsProvider) ClientOrHTTPClientParam {
+func WithoutMetrics() ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.DisableMetrics = refreshable.NewBool(refreshable.NewDefaultRefreshable(true))
 		b.MetricsTagProviders = nil


### PR DESCRIPTION
- Update client_params to give an WithoutMetrics option
- The default behavior sets it to true: https://github.com/palantir/conjure-go-runtime/blob/develop/conjure-go-client/httpclient/client_builder.go#L241
- This allows clients to turn of metrics while still using httpclient.NewClient