### PR TITLE
Remove all usages of the deprecated io/ioutil pkg

### DIFF
--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -44,7 +43,7 @@ func TestCanReadBodyWithBufferPool(t *testing.T) {
 	encodedBody, err := codecs.Plain.Marshal(unencodedBody)
 	require.NoError(t, err)
 	bodyIsCorrect := func(body io.ReadCloser) {
-		content, err := ioutil.ReadAll(body)
+		content, err := io.ReadAll(body)
 		require.NoError(t, err)
 		require.Equal(t, encodedBody, content)
 	}
@@ -143,7 +142,7 @@ func TestMiddlewareCanReadBody(t *testing.T) {
 	encodedBody, err := codecs.Plain.Marshal(unencodedBody)
 	require.NoError(t, err)
 	bodyIsCorrect := func(body io.ReadCloser) {
-		content, err := ioutil.ReadAll(body)
+		content, err := io.ReadAll(body)
 		require.NoError(t, err)
 		require.Equal(t, encodedBody, content)
 	}

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -145,7 +145,7 @@ func TestStreamingResponse(t *testing.T) {
 	resp, err := client.Get(ctx, httpclient.WithPath("/"), httpclient.WithRawResponseBody())
 	require.NoError(t, err)
 	close(finishResponseChan)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, firstLine+"\n"+secondLine+"\n", string(b))
 }

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -17,8 +17,8 @@ package httpclient
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"slices"
 	"time"
 
@@ -273,7 +273,7 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 	if c.APIToken != nil && *c.APIToken != "" {
 		params = append(params, WithAuthToken(*c.APIToken))
 	} else if c.APITokenFile != nil && *c.APITokenFile != "" {
-		token, err := ioutil.ReadFile(*c.APITokenFile)
+		token, err := os.ReadFile(*c.APITokenFile)
 		if err != nil {
 			return nil, werror.Wrap(err, "failed to read api-token-file", werror.SafeParam("file", *c.APITokenFile))
 		}
@@ -431,7 +431,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		apiToken = config.APIToken
 	} else if config.APITokenFile != nil {
 		file := *config.APITokenFile
-		token, err := ioutil.ReadFile(file)
+		token, err := os.ReadFile(file)
 		if err != nil {
 			return refreshingclient.ValidatedClientParams{}, werror.WrapWithContextParams(ctx, err, "failed to read api-token-file", werror.SafeParam("file", file))
 		}

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -15,7 +15,7 @@
 package httpclient
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -92,7 +92,7 @@ func (d restErrorDecoder) DecodeError(resp *http.Response) error {
 	wUnsafeParams := werror.UnsafeParams(unsafeParams)
 
 	// TODO(#98): If a byte buffer pool is configured, use it to avoid an allocation.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return werror.Wrap(err, "server returned an error and failed to read body", wSafeParams, wUnsafeParams)
 	}

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -17,7 +17,7 @@ package httpclient_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -237,7 +237,7 @@ func (bodyReadingErrorDecoder) Handles(resp *http.Response) bool {
 }
 
 func (bodyReadingErrorDecoder) DecodeError(resp *http.Response) error {
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error reading response body: %v", err)
 	}

--- a/conjure-go-contract/codecs/urlencoded.go
+++ b/conjure-go-contract/codecs/urlencoded.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -36,7 +35,7 @@ func (codecFormURLEncoded) Accept() string {
 }
 
 func (codecFormURLEncoded) Decode(r io.Reader, v interface{}) error {
-	query, err := ioutil.ReadAll(r)
+	query, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("failed to read all query bytes: %s", err.Error())
 	}

--- a/conjure-go-contract/errors/http_test.go
+++ b/conjure-go-contract/errors/http_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -54,7 +54,7 @@ func TestWriteErrorResponse_ValidateJSON(t *testing.T) {
 	response := recorder.Result()
 
 	assert.Equal(t, "application/json; charset=utf-8", response.Header.Get("Content-Type"))
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
 
 	var buffer bytes.Buffer

--- a/conjure-go-server/httpserver/handlers_test.go
+++ b/conjure-go-server/httpserver/handlers_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,7 +53,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			},
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "plaintext", string(body))
 			},
@@ -69,7 +69,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 				assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "a bad thing\n", string(body))
 			},
@@ -90,7 +90,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 				assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "a bad thing\n", string(body))
 			},
@@ -111,7 +111,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 				assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "{\"message\":\"a bad thing\"}\n", string(body))
 			},
@@ -135,7 +135,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				// the body, the headers are already sent. A solution would be encoding to a buffer, but this would come
 				// with a memory cost.
 				assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "json: error calling MarshalJSON for type httpserver.testJSONErrorMarshalFails: failed to marshal json\n", string(body))
 			},
@@ -156,7 +156,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 				assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				expected, err := conjure500Err.(json.Marshaler).MarshalJSON()
 				assert.NoError(t, err)
@@ -179,7 +179,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 				assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				expected, err := conjure404Err.(json.Marshaler).MarshalJSON()
 				assert.NoError(t, err)
@@ -202,7 +202,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 				assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				expected, err := conjure404Err.(json.Marshaler).MarshalJSON()
 				assert.NoError(t, err)
@@ -232,7 +232,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			},
 			verifyResp: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "ok", string(body))
 			},


### PR DESCRIPTION
## Before this PR
The [io/ioutil](https://pkg.go.dev/io/ioutil) has been deprecated since Go 1.16.

## After this PR
==COMMIT_MSG==
Remove all usages of the deprecated io/ioutil pkg
==COMMIT_MSG==

This should be a noop change and is safe to make since the go directive in our go.mod specifies 1.25.x which ensures other pkgs that depend on CGR must be at minimum 1.25

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

