### PR TITLE
Remove go 1.16 build tags

### DIFF
--- a/conjure-go-client/httpclient/http2_client_test.go
+++ b/conjure-go-client/httpclient/http2_client_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package httpclient_test
 
 import (


### PR DESCRIPTION
## Before this PR
These build tags were added in #189 but were never removed when the build tags were cleaned up (#690).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove go 1.16 build tags
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

