### PR TITLE
Break: Update module to V3

### DIFF
--- a/conjure-go-client/httpclient/authn.go
+++ b/conjure-go-client/httpclient/authn.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/refreshable"
 )
 

--- a/conjure-go-client/httpclient/authn_test.go
+++ b/conjure-go-client/httpclient/authn_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-client/httpclient/body_handler.go
+++ b/conjure-go-client/httpclient/body_handler.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/bytesbuffers"
 	werror "github.com/palantir/witchcraft-go-error"
 )

--- a/conjure-go-client/httpclient/body_handler_test.go
+++ b/conjure-go-client/httpclient/body_handler_test.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-client/httpclient/body_types.go
+++ b/conjure-go-client/httpclient/body_types.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 )
 
 // RequestBody is an interface that can be used to set the body of an http.Request.

--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/refreshable"

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	"github.com/palantir/pkg/refreshable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -21,8 +21,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-client/httpclient/close_test.go
+++ b/conjure-go-client/httpclient/close_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -22,7 +22,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
 	"github.com/palantir/pkg/metrics"
 	werror "github.com/palantir/witchcraft-go-error"
 )

--- a/conjure-go-client/httpclient/error_decoder_test.go
+++ b/conjure-go-client/httpclient/error_decoder_test.go
@@ -21,8 +21,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
 	"github.com/palantir/pkg/httpserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-client/httpclient/http2_client_test.go
+++ b/conjure-go-client/httpclient/http2_client_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-server/httpserver"
 	"github.com/stretchr/testify/require"
 )
 

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	"github.com/palantir/pkg/metrics"
 	"github.com/palantir/pkg/tlsconfig"
 	"github.com/stretchr/testify/assert"

--- a/conjure-go-client/httpclient/recovery_test.go
+++ b/conjure-go-client/httpclient/recovery_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-client/httpclient/request_params.go
+++ b/conjure-go-client/httpclient/request_params.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 

--- a/conjure-go-client/httpclient/response_error_decoder_middleware.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware.go
@@ -19,9 +19,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -23,8 +23,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/stretchr/testify/assert"

--- a/conjure-go-client/httpclient/trace_test.go
+++ b/conjure-go-client/httpclient/trace_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
 	"github.com/palantir/witchcraft-go-tracing/wtracing/propagation/b3"
 	"github.com/palantir/witchcraft-go-tracing/wzipkin"

--- a/conjure-go-contract/codecs/binary_test.go
+++ b/conjure-go-contract/codecs/binary_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/stretchr/testify/require"
 )
 

--- a/conjure-go-contract/codecs/plain_test.go
+++ b/conjure-go-contract/codecs/plain_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/uuid"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-contract/codecs/protobuf_test.go
+++ b/conjure-go-contract/codecs/protobuf_test.go
@@ -18,8 +18,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs/internal/gopb"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs/internal/gopb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )

--- a/conjure-go-contract/codecs/urlencoded_test.go
+++ b/conjure-go-contract/codecs/urlencoded_test.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/conjure-go-contract/codecs/yaml_test.go
+++ b/conjure-go-contract/codecs/yaml_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/stretchr/testify/require"
 )
 

--- a/conjure-go-contract/errors/error_code_test.go
+++ b/conjure-go-contract/errors/error_code_test.go
@@ -21,8 +21,8 @@ package errors_test
 import (
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conjure-go-contract/errors/error_type_registry.go
+++ b/conjure-go-contract/errors/error_type_registry.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 

--- a/conjure-go-contract/errors/error_type_test.go
+++ b/conjure-go-contract/errors/error_type_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/conjure-go-contract/errors/generic_error.go
+++ b/conjure-go-contract/errors/generic_error.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/uuid"
 	werror "github.com/palantir/witchcraft-go-error"
 	wparams "github.com/palantir/witchcraft-go-params"

--- a/conjure-go-contract/errors/generic_error_test.go
+++ b/conjure-go-contract/errors/generic_error_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-contract/errors/http.go
+++ b/conjure-go-contract/errors/http.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 )
 
 // WriteErrorResponse writes error to the response writer.

--- a/conjure-go-contract/errors/http_test.go
+++ b/conjure-go-contract/errors/http_test.go
@@ -22,7 +22,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-contract/errors/serializable_error_test.go
+++ b/conjure-go-contract/errors/serializable_error_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/palantir/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-contract/errors/unmarshal.go
+++ b/conjure-go-contract/errors/unmarshal.go
@@ -15,7 +15,7 @@
 package errors
 
 import (
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 

--- a/conjure-go-contract/errors/unmarshal_test.go
+++ b/conjure-go-contract/errors/unmarshal_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/palantir/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/conjure-go-contract/errors/wrap_test.go
+++ b/conjure-go-contract/errors/wrap_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/stretchr/testify/assert"

--- a/conjure-go-server/httpserver/handlers.go
+++ b/conjure-go-server/httpserver/handlers.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )

--- a/conjure-go-server/httpserver/handlers_test.go
+++ b/conjure-go-server/httpserver/handlers_test.go
@@ -24,8 +24,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
-	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/palantir/conjure-go-runtime/v2
+module github.com/palantir/conjure-go-runtime/v3
 
 go 1.25.0
 


### PR DESCRIPTION
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update module to V3
==COMMIT_MSG==

The last V2 release was just cut: ([v2.99.0](https://github.com/palantir/conjure-go-runtime/releases/tag/v2.99.0)). We're only going to support the V2 module for critical support/security issues where these releases will be cut from a separate branch.

Once this PR merges, all breaking changes will be added before we cut the v3.0.0 release.