### PR TITLE
Add 429 "TooManyRequests" error to default contract errors

### DIFF
--- a/conjure-go-contract/errors/error.go
+++ b/conjure-go-contract/errors/error.go
@@ -179,3 +179,18 @@ func WrapWithTimeout(cause error, parameters ...wparams.ParamStorer) Error {
 func IsTimeout(err error) bool {
 	return isErrorOfType(err, DefaultTimeout)
 }
+
+// NewTooManyRequests returns new error instance of default tooManyRequests type.
+func NewTooManyRequests(parameters ...wparams.ParamStorer) Error {
+	return newGenericError(nil, DefaultTooManyRequests, wparams.NewParamStorer(parameters...))
+}
+
+// WrapWithTooManyRequests returns new error instance of default tooManyRequests type wrapping an existing error.
+func WrapWithTooManyRequests(cause error, parameters ...wparams.ParamStorer) Error {
+	return newGenericError(cause, DefaultTooManyRequests, wparams.NewParamStorer(parameters...))
+}
+
+// IsTooManyRequests returns true if an error is an instance of default tooManyRequests type.
+func IsTooManyRequests(err error) bool {
+	return isErrorOfType(err, DefaultTooManyRequests)
+}

--- a/conjure-go-contract/errors/error_code.go
+++ b/conjure-go-contract/errors/error_code.go
@@ -60,6 +60,8 @@ const (
 	CustomClient
 	// CustomServer has status code 500 InternalServerError.
 	CustomServer
+	// TooManyRequests has status code 429 TooManyRequests.
+	TooManyRequests
 )
 
 // StatusCode returns HTTP status code associated with this error code.
@@ -87,6 +89,8 @@ func (ec ErrorCode) StatusCode() int {
 		return http.StatusBadRequest
 	case CustomServer:
 		return http.StatusInternalServerError
+	case TooManyRequests:
+		return http.StatusTooManyRequests
 	}
 	return http.StatusInternalServerError
 }
@@ -118,6 +122,8 @@ func (ec ErrorCode) String() string {
 		return "CUSTOM_CLIENT"
 	case CustomServer:
 		return "CUSTOM_SERVER"
+	case TooManyRequests:
+		return "TOO_MANY_REQUESTS"
 	}
 	return fmt.Sprintf("<invalid error code: %d>", ec)
 }
@@ -152,6 +158,8 @@ func (ec *ErrorCode) UnmarshalText(data []byte) error {
 		*ec = CustomClient
 	case "CUSTOM_SERVER":
 		*ec = CustomServer
+	case "TOO_MANY_REQUESTS":
+		*ec = TooManyRequests
 	default:
 		return fmt.Errorf(`errors: unknown error code string`)
 	}

--- a/conjure-go-contract/errors/error_code_test.go
+++ b/conjure-go-contract/errors/error_code_test.go
@@ -39,6 +39,7 @@ func TestErrorCode_String(t *testing.T) {
 		errors.Timeout:               "TIMEOUT",
 		errors.CustomClient:          "CUSTOM_CLIENT",
 		errors.CustomServer:          "CUSTOM_SERVER",
+		errors.TooManyRequests:       "TOO_MANY_REQUESTS",
 		errors.ErrorCode(0):          "<invalid error code: 0>",
 		errors.ErrorCode(200):        "<invalid error code: 200>",
 	} {
@@ -58,6 +59,7 @@ var validErrorCodes = []errors.ErrorCode{
 	errors.Timeout,
 	errors.CustomClient,
 	errors.CustomServer,
+	errors.TooManyRequests,
 }
 
 func TestErrorCode_MarshalJSON(t *testing.T) {

--- a/conjure-go-contract/errors/error_type.go
+++ b/conjure-go-contract/errors/error_type.go
@@ -34,6 +34,7 @@ var (
 	DefaultFailedPrecondition    = ErrorType{FailedPrecondition, errorNameFailedPrecondition}
 	DefaultInternal              = ErrorType{Internal, errorNameInternal}
 	DefaultTimeout               = ErrorType{Timeout, errorNameTimeout}
+	DefaultTooManyRequests       = ErrorType{TooManyRequests, errorNameTooManyRequests}
 )
 
 // ErrorType represents certain class of errors. Each error type is uniquely identified by an error name
@@ -120,6 +121,7 @@ const (
 	errorNameFailedPrecondition    = "Default:FailedPrecondition"
 	errorNameInternal              = "Default:Internal"
 	errorNameTimeout               = "Default:Timeout"
+	errorNameTooManyRequests       = "Default:TooManyRequests"
 )
 
 func verifyErrorNameString(name string) error {
@@ -137,6 +139,7 @@ func verifyErrorNameString(name string) error {
 		case errorNameFailedPrecondition:
 		case errorNameInternal:
 		case errorNameTimeout:
+		case errorNameTooManyRequests:
 		default:
 			return fmt.Errorf("errors: error name with default namespace cannot use custom cause")
 		}
@@ -157,6 +160,7 @@ func verifyErrorCodeErrorNameCombination(code ErrorCode, name string) error {
 		case DefaultFailedPrecondition:
 		case DefaultInternal:
 		case DefaultTimeout:
+		case DefaultTooManyRequests:
 		default:
 			return fmt.Errorf("errors: invalid combination of default error name and error code")
 		}

--- a/conjure-go-contract/errors/error_type_test.go
+++ b/conjure-go-contract/errors/error_type_test.go
@@ -56,6 +56,7 @@ var defaultErrorTypes = []errors.ErrorType{
 	errors.DefaultFailedPrecondition,
 	errors.DefaultInternal,
 	errors.DefaultTimeout,
+	errors.DefaultTooManyRequests,
 }
 
 func TestNewErrorType_ForDefaultErrorNames(t *testing.T) {

--- a/conjure-go-contract/errors/unmarshal_test.go
+++ b/conjure-go-contract/errors/unmarshal_test.go
@@ -98,6 +98,18 @@ func TestUnmarshalError(t *testing.T) {
 			},
 		},
 		{
+			name: "too many requests",
+			in: errors.SerializableError{
+				ErrorCode:       errors.TooManyRequests,
+				ErrorName:       "MyApplication:TooManyRequests",
+				ErrorInstanceID: uuid.NewUUID(),
+			},
+			verify: func(t *testing.T, actual errors.Error) {
+				assert.Equal(t, map[string]interface{}{"errorInstanceId": actual.InstanceID(), "errorName": actual.Name()}, actual.SafeParams())
+				assert.Equal(t, map[string]interface{}{}, actual.UnsafeParams())
+			},
+		},
+		{
 			name: "registered error type",
 			in: errors.SerializableError{
 				ErrorCode:       errors.CustomClient,


### PR DESCRIPTION
## Before this PR
`StatusTooManyRequests` 429 is a default error code available in errors, but it is not available as an error to generate via this conjure library, so users have to manually create a new error with code 429.

## After this PR
Add the boilerplate necessary to expose 429 TooManyRequests as an error that can be created with conjure

==COMMIT_MSG==
Add 429 "TooManyRequests" error to default contract errors
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

