### PR TITLE
improvement: Refactor to allow the process of creating refreshable Client CA Files

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -97,22 +97,22 @@ func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam
 		}
 	}
 
-	var tlsProvider refreshingclient.TLSProvider
+	var refreshableConfig refreshable.Refreshable[*tls.Config]
 	if b.TLSConfig != nil {
-		tlsProvider = refreshingclient.NewStaticTLSConfigProvider(b.TLSConfig)
+		refreshableConfig = refreshable.New(b.TLSConfig)
 	} else {
 		tlsParams := refreshable.View(b.TransportParams, func(t refreshingclient.TransportParams) refreshingclient.TLSParams {
 			return t.TLS
 		})
-		refreshableProvider, err := refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)
+		refreshableTLSConfig, err := refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)
 		if err != nil {
 			return nil, err
 		}
-		tlsProvider = refreshableProvider
+		refreshableConfig = refreshableTLSConfig
 	}
 
 	dialer := refreshingclient.NewRefreshableDialer(ctx, b.DialerParams)
-	transport := refreshingclient.NewRefreshableTransport(ctx, b.TransportParams, tlsProvider, dialer)
+	transport := refreshingclient.NewRefreshableTransport(ctx, b.TransportParams, refreshableConfig, dialer)
 	transport = wrapTransport(transport, newMetricsMiddleware(b.ServiceName, b.MetricsTagProviders, b.DisableMetrics))
 	transport = wrapTransport(transport, newTraceMiddleware(b.ServiceName, b.DisableRequestSpan, b.DisableTraceHeaders))
 	if !b.DisableRecovery {

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -97,9 +97,17 @@ func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam
 		}
 	}
 
-	var refreshableConfig refreshable.Refreshable[*tls.Config]
+	var refreshableConfig refreshable.Validated[*tls.Config]
 	if b.TLSConfig != nil {
-		refreshableConfig = refreshable.New(b.TLSConfig)
+		refreshableOfStaticTLSConfig := refreshable.New(b.TLSConfig)
+		validatedStaticTLSConfig, _, err := refreshable.Validate(refreshableOfStaticTLSConfig, func(cfg *tls.Config) error {
+			// No validation needed given validation is done when setting config
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		refreshableConfig = validatedStaticTLSConfig
 	} else {
 		tlsParams := refreshable.View(b.TransportParams, func(t refreshingclient.TransportParams) refreshingclient.TLSParams {
 			return t.TLS

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -88,7 +88,6 @@ func TestAddingCAFileIsCaptured(t *testing.T) {
 	caFile2 := filepath.Join(tmpDir, "ca2.pem")
 	createTestCACertFile(t, caFile1, 1, "Test CA")
 	createTestCACertFile(t, caFile2, 2, "Test CA 2")
-
 	// Track unique CA subjects captured during requests
 	capturedSubjects := make(map[string]struct{})
 	tlsCapturingMiddleware := httpclient.MiddlewareFunc(
@@ -104,7 +103,6 @@ func TestAddingCAFileIsCaptured(t *testing.T) {
 			return next.RoundTrip(req)
 		},
 	)
-
 	cfg := httpclient.ClientConfig{
 		ServiceName:   "baz",
 		MaxNumRetries: toPointer(0),
@@ -123,25 +121,18 @@ func TestAddingCAFileIsCaptured(t *testing.T) {
 	)
 	require.NoError(t, err)
 	_, err = scopedTokenClient.Delete(context.Background())
-	assert.ErrorContains(t, err, "test-service")
-	assert.Equal(t, capturedSubjects, map[string]struct{}{
-		"Test CA": {},
-	})
-
+	assert.Error(t, err)
+	assert.Eventually(t, func() bool {
+		return reflect.DeepEqual(map[string]struct{}{
+			"Test CA": {},
+		}, capturedSubjects)
+	}, time.Second*2, time.Millisecond*100)
 	// Update config to use both CA files
 	capturedSubjects = map[string]struct{}{}
 	cfg.Security.CAFiles = []string{caFile1, caFile2}
 	clientConfigRefreshable.Update(cfg)
 	_, err = scopedTokenClient.Delete(context.Background())
-	assert.ErrorContains(t, err, "test-service")
-	assert.Equal(t, map[string]struct{}{
-		"Test CA":   {},
-		"Test CA 2": {},
-	}, capturedSubjects)
-	// Append a file and see the newest CA
-	capturedSubjects = map[string]struct{}{}
-	_, err = scopedTokenClient.Delete(context.Background())
-	assert.ErrorContains(t, err, "test-service")
+	assert.Error(t, err)
 	assert.Eventually(t, func() bool {
 		return reflect.DeepEqual(map[string]struct{}{
 			"Test CA":   {},

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -16,9 +16,22 @@ package httpclient_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
+	"unsafe"
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
 	"github.com/palantir/pkg/refreshable/v2"
@@ -62,4 +75,203 @@ func TestNewHTTPClientWithoutURIs(t *testing.T) {
 	c, err := httpclient.NewHTTPClientFromRefreshableConfig(context.Background(), refreshable.New(cfg))
 	require.NoError(t, err)
 	require.NotNil(t, c.Current())
+}
+
+func toPointer[T any](timeArg T) *T {
+	return &timeArg
+}
+
+func TestAddingCAFileIsCaptured(t *testing.T) {
+	// Create a temp directory with CA certificate files
+	tmpDir := t.TempDir()
+	caFile1 := filepath.Join(tmpDir, "ca1.pem")
+	caFile2 := filepath.Join(tmpDir, "ca2.pem")
+	createTestCACertFile(t, caFile1, 1, "Test CA")
+	createTestCACertFile(t, caFile2, 2, "Test CA 2")
+
+	// Track unique CA subjects captured during requests
+	capturedSubjects := make(map[string]struct{})
+	tlsCapturingMiddleware := httpclient.MiddlewareFunc(
+		func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+			transport := unwrapTransport(next)
+			for _, subject := range transport.TLSClientConfig.RootCAs.Subjects() {
+				results := strings.Split(strings.TrimSpace(string(subject)), "\a")
+				last := results[len(results)-1]
+				results = strings.Split(last, "\t")
+				last = results[len(results)-1]
+				capturedSubjects[last] = struct{}{}
+			}
+			return next.RoundTrip(req)
+		},
+	)
+
+	cfg := httpclient.ClientConfig{
+		ServiceName:   "baz",
+		MaxNumRetries: toPointer(0),
+		URIs: []string{
+			"https://test-service",
+		},
+		Security: httpclient.SecurityConfig{
+			CAFiles: []string{caFile1},
+		},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	scopedTokenClient, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+		httpclient.WithMiddleware(tlsCapturingMiddleware),
+	)
+	require.NoError(t, err)
+	_, err = scopedTokenClient.Delete(context.Background())
+	assert.ErrorContains(t, err, "test-service")
+	assert.Equal(t, capturedSubjects, map[string]struct{}{
+		"Test CA": {},
+	})
+
+	// Update config to use both CA files
+	capturedSubjects = map[string]struct{}{}
+	cfg.Security.CAFiles = []string{caFile1, caFile2}
+	clientConfigRefreshable.Update(cfg)
+	_, err = scopedTokenClient.Delete(context.Background())
+	assert.ErrorContains(t, err, "test-service")
+	assert.Equal(t, map[string]struct{}{
+		"Test CA":   {},
+		"Test CA 2": {},
+	}, capturedSubjects)
+	// Append a file and see the newest CA
+	capturedSubjects = map[string]struct{}{}
+	_, err = scopedTokenClient.Delete(context.Background())
+	assert.ErrorContains(t, err, "test-service")
+	assert.Eventually(t, func() bool {
+		return reflect.DeepEqual(map[string]struct{}{
+			"Test CA":   {},
+			"Test CA 2": {},
+		}, capturedSubjects)
+	}, time.Second*2, time.Millisecond*100)
+}
+
+func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
+	t.Skip("skipping test until feature complete")
+	// Create a temp directory with CA certificate files
+	tmpDir := t.TempDir()
+	caFile1 := filepath.Join(tmpDir, "ca1.pem")
+	createTestCACertFile(t, caFile1, 1, "Test CA")
+
+	// Track unique CA subjects captured during requests
+	capturedSubjects := make(map[string]struct{})
+	tlsCapturingMiddleware := httpclient.MiddlewareFunc(
+		func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+			transport := unwrapTransport(next)
+			for _, subject := range transport.TLSClientConfig.RootCAs.Subjects() {
+				results := strings.Split(strings.TrimSpace(string(subject)), "\a")
+				last := results[len(results)-1]
+				results = strings.Split(last, "\t")
+				last = results[len(results)-1]
+				capturedSubjects[last] = struct{}{}
+			}
+			return next.RoundTrip(req)
+		},
+	)
+
+	cfg := httpclient.ClientConfig{
+		ServiceName: "baz",
+		URIs: []string{
+			"https://test-service",
+		},
+		MaxNumRetries: toPointer(0),
+		Security: httpclient.SecurityConfig{
+			CAFiles: []string{caFile1},
+		},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	scopedTokenClient, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+		httpclient.WithMiddleware(tlsCapturingMiddleware),
+	)
+	require.NoError(t, err)
+	_, err = scopedTokenClient.Delete(context.Background())
+	assert.ErrorContains(t, err, "test-service")
+	assert.Equal(t, capturedSubjects, map[string]struct{}{
+		"Test CA": {},
+	})
+	// Append a file and see the newest CA
+	capturedSubjects = map[string]struct{}{}
+	appendTestCACertFile(t, caFile1, 3, "Test CA 3")
+	// Ensure the underlying refreshable can sync
+	_, err = scopedTokenClient.Delete(context.Background())
+	assert.ErrorContains(t, err, "test-service")
+	assert.Eventually(t, func() bool {
+		return reflect.DeepEqual(map[string]struct{}{
+			"Test CA":   {},
+			"Test CA 3": {},
+		}, capturedSubjects)
+	}, time.Second*2, time.Millisecond*100)
+}
+
+// unwrapTransport traverses the RoundTripper chain to find the underlying *http.Transport.
+func unwrapTransport(rt http.RoundTripper) *http.Transport {
+	for rt != nil {
+		switch t := rt.(type) {
+		case *http.Transport:
+			return t
+		case interface{ Current() *http.Transport }:
+			// RefreshableTransport has a Current() method that returns the underlying transport
+			return t.Current()
+		default:
+			rt = getUnexportedBaseTransport(rt)
+		}
+	}
+	return nil
+}
+
+// getUnexportedBaseTransport uses unsafe reflection to access the unexported baseTransport
+// field from httpclient.wrappedClient middleware wrappers.
+func getUnexportedBaseTransport(rt http.RoundTripper) http.RoundTripper {
+	val := reflect.ValueOf(rt)
+	if val.Kind() == reflect.Pointer {
+		val = val.Elem()
+	}
+	if val.Kind() != reflect.Struct {
+		return nil
+	}
+	field := val.FieldByName("baseTransport")
+	if !field.IsValid() || !field.CanAddr() {
+		return nil
+	}
+	return *(*http.RoundTripper)(unsafe.Pointer(field.UnsafeAddr()))
+}
+
+func createTestCACertFile(t *testing.T, filePath string, serialNumber int64, orgName string) {
+	certPEM := generateTestCACertPEM(t, serialNumber, orgName)
+	err := os.WriteFile(filePath, certPEM, 0600)
+	require.NoError(t, err)
+}
+
+func appendTestCACertFile(t *testing.T, filePath string, serialNumber int64, orgName string) {
+	certPEM := generateTestCACertPEM(t, serialNumber, orgName)
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.Write(certPEM)
+	require.NoError(t, err)
+}
+
+func generateTestCACertPEM(t *testing.T, serialNumber int64, orgName string) []byte {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(serialNumber),
+		Subject: pkix.Name{
+			Organization: []string{orgName},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 }

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -252,7 +252,7 @@ func appendTestCACertFile(t *testing.T, filePath string, serialNumber int64, org
 	certPEM := generateTestCACertPEM(t, serialNumber, orgName)
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0600)
 	require.NoError(t, err)
-	defer f.Close()
+	defer assert.NoError(t, f.Close())
 	_, err = f.Write(certPEM)
 	require.NoError(t, err)
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -21,7 +21,6 @@ import (
 	"github.com/palantir/pkg/refreshable/v2"
 	"github.com/palantir/pkg/tlsconfig"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // TLSParams contains the parameters needed to build a *tls.Config.
@@ -33,25 +32,6 @@ type TLSParams struct {
 	InsecureSkipVerify bool
 }
 
-type TLSProvider interface {
-	GetTLSConfig(ctx context.Context) *tls.Config
-}
-
-// StaticTLSConfigProvider is a TLSProvider that always returns the same *tls.Config.
-type StaticTLSConfigProvider tls.Config
-
-func NewStaticTLSConfigProvider(tlsConfig *tls.Config) *StaticTLSConfigProvider {
-	return (*StaticTLSConfigProvider)(tlsConfig)
-}
-
-func (p *StaticTLSConfigProvider) GetTLSConfig(context.Context) *tls.Config {
-	return (*tls.Config)(p)
-}
-
-type RefreshableTLSConfig struct {
-	r refreshable.Validated[*tls.Config]
-}
-
 // NewRefreshableTLSConfig evaluates the provided TLSParams and returns a RefreshableTLSConfig that will update the
 // underlying *tls.Config when the TLSParams change.
 // IF the initial TLSParams are invalid, NewRefreshableTLSConfig will return an error.
@@ -59,24 +39,14 @@ type RefreshableTLSConfig struct {
 //
 // N.B. This subscription only fires when the paths are updated, not when the contents of the files are updated.
 // We could consider adding a file refreshable to watch the key and cert files.
-func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Refreshable[TLSParams]) (TLSProvider, error) {
+func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Refreshable[TLSParams]) (refreshable.Refreshable[*tls.Config], error) {
 	r, _, err := refreshable.MapWithError(params, func(p TLSParams) (*tls.Config, error) {
 		return NewTLSConfig(ctx, p)
 	})
 	if err != nil {
 		return nil, werror.WrapWithContextParams(ctx, err, "failed to build RefreshableTLSConfig")
 	}
-	return RefreshableTLSConfig{r: r}, nil
-}
-
-// GetTLSConfig returns the most recent valid *tls.Config.
-// If the last refreshable update resulted in an error, that error is logged and
-// the previous value is returned.
-func (r RefreshableTLSConfig) GetTLSConfig(ctx context.Context) *tls.Config {
-	if _, err := r.r.Validation(); err != nil {
-		svc1log.FromContext(ctx).Warn("Invalid TLS config. Using previous value.", svc1log.Stacktrace(err))
-	}
-	return r.r.Current()
+	return r, nil
 }
 
 // NewTLSConfig returns a *tls.Config built from the provided TLSParams.

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -39,7 +39,7 @@ type TLSParams struct {
 //
 // N.B. This subscription only fires when the paths are updated, not when the contents of the files are updated.
 // We could consider adding a file refreshable to watch the key and cert files.
-func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Refreshable[TLSParams]) (refreshable.Refreshable[*tls.Config], error) {
+func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Refreshable[TLSParams]) (refreshable.Validated[*tls.Config], error) {
 	r, _, err := refreshable.MapWithError(params, func(p TLSParams) (*tls.Config, error) {
 		return NewTLSConfig(ctx, p)
 	})

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -16,6 +16,7 @@ package refreshingclient
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/url"
 	"time"
@@ -42,9 +43,9 @@ type TransportParams struct {
 	TLS TLSParams
 }
 
-func NewRefreshableTransport(ctx context.Context, p refreshable.Refreshable[TransportParams], tlsProvider TLSProvider, dialer ContextDialer) http.RoundTripper {
-	mapped, _ := refreshable.Map(p, func(p TransportParams) *http.Transport {
-		return newTransport(ctx, p, tlsProvider, dialer)
+func NewRefreshableTransport(ctx context.Context, p refreshable.Refreshable[TransportParams], refreshableConfig refreshable.Refreshable[*tls.Config], dialer ContextDialer) http.RoundTripper {
+	mapped, _ := refreshable.Merge(p, refreshableConfig, func(p TransportParams, t *tls.Config) *http.Transport {
+		return newTransport(ctx, p, t, dialer)
 	})
 	return &RefreshableTransport{Refreshable: mapped}
 }
@@ -59,7 +60,7 @@ func (r *RefreshableTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return r.Current().RoundTrip(req)
 }
 
-func newTransport(ctx context.Context, p TransportParams, tlsProvider TLSProvider, dialer ContextDialer) *http.Transport {
+func newTransport(ctx context.Context, p TransportParams, tlsConfig *tls.Config, dialer ContextDialer) *http.Transport {
 	svc1log.FromContext(ctx).Debug("Reconstructing HTTP Transport")
 
 	var transportProxy func(*http.Request) (*url.URL, error)
@@ -69,7 +70,6 @@ func newTransport(ctx context.Context, p TransportParams, tlsProvider TLSProvide
 		transportProxy = http.ProxyFromEnvironment
 	}
 
-	tlsConfig := tlsProvider.GetTLSConfig(ctx)
 	transport := &http.Transport{
 		Proxy:                 transportProxy,
 		DialContext:           dialer.DialContext,

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -43,7 +43,7 @@ type TransportParams struct {
 	TLS TLSParams
 }
 
-func NewRefreshableTransport(ctx context.Context, p refreshable.Refreshable[TransportParams], refreshableConfig refreshable.Refreshable[*tls.Config], dialer ContextDialer) http.RoundTripper {
+func NewRefreshableTransport(ctx context.Context, p refreshable.Refreshable[TransportParams], refreshableConfig refreshable.Validated[*tls.Config], dialer ContextDialer) http.RoundTripper {
 	mapped, _ := refreshable.Merge(p, refreshableConfig, func(p TransportParams, t *tls.Config) *http.Transport {
 		return newTransport(ctx, p, t, dialer)
 	})


### PR DESCRIPTION
- Add a test for CA File additions, as well as a skipped test for the eventual desire to have updated CA files
- Remove the static `TLSProvider `, this is replaced with a `refreshable.Refreshable[*tls.Config]` which can then safely be merged into the already refreshable TransportParams
- Start of https://github.com/palantir/conjure-go-runtime/issues/221
- Pre commit to https://github.com/palantir/conjure-go-runtime/pull/858