### PR TITLE
fix: Update client with TLS file changes if the file on disk is updated

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -132,6 +132,9 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 		return toReturn
 	})
 	multiFileRefreshable := refreshable.NewMultiFileRefreshable(ctx, fileSlices)
+	if _, err := multiFileRefreshable.Validation(); err != nil {
+		return nil, werror.WrapWithContextParams(ctx, err, "failed to read CA files")
+	}
 	tlsParams, _ := refreshable.Merge(b.TransportParams, multiFileRefreshable, func(t1 refreshingclient.TransportParams, t2 map[string][]byte) refreshingclient.TLSParams {
 		var caBytes [][]byte
 		for _, caSlice := range t2 {

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -100,6 +100,8 @@ func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam
 	if err != nil {
 		return nil, err
 	}
+
+	// Create dialer and transport
 	dialer := refreshingclient.NewRefreshableDialer(ctx, b.DialerParams)
 	transport := refreshingclient.NewRefreshableTransport(ctx, b.TransportParams, refreshableConfig, dialer)
 	transport = wrapTransport(transport, newMetricsMiddleware(b.ServiceName, b.MetricsTagProviders, b.DisableMetrics))

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -124,8 +124,26 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 		}
 		return validatedStaticTLSConfig, nil
 	}
-	tlsParams := refreshable.View(b.TransportParams, func(t refreshingclient.TransportParams) refreshingclient.TLSParams {
-		return t.TLS
+	fileSlices, _ := refreshable.Map(b.TransportParams, func(t refreshingclient.TransportParams) map[string]struct{} {
+		toReturn := map[string]struct{}{}
+		for _, file := range t.TLS.CAFiles {
+			toReturn[file] = struct{}{}
+		}
+		return toReturn
+	})
+	multiFileRefreshable := refreshable.NewMultiFileRefreshable(ctx, fileSlices)
+	tlsParams, _ := refreshable.Merge(b.TransportParams, multiFileRefreshable, func(t1 refreshingclient.TransportParams, t2 map[string][]byte) refreshingclient.TLSParams {
+		var caBytes [][]byte
+		for _, caSlice := range t2 {
+			caBytes = append(caBytes, caSlice)
+		}
+		return refreshingclient.TLSParams{
+			CABytes:            caBytes,
+			CAFiles:            t1.TLS.CAFiles,
+			CertFile:           t1.TLS.CertFile,
+			KeyFile:            t1.TLS.KeyFile,
+			InsecureSkipVerify: t1.TLS.InsecureSkipVerify,
+		}
 	})
 	return refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)
 }

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -96,29 +96,10 @@ func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam
 			return nil, err
 		}
 	}
-
-	var refreshableConfig refreshable.Validated[*tls.Config]
-	if b.TLSConfig != nil {
-		refreshableOfStaticTLSConfig := refreshable.New(b.TLSConfig)
-		validatedStaticTLSConfig, _, err := refreshable.Validate(refreshableOfStaticTLSConfig, func(cfg *tls.Config) error {
-			// No validation needed given validation is done when setting config
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		refreshableConfig = validatedStaticTLSConfig
-	} else {
-		tlsParams := refreshable.View(b.TransportParams, func(t refreshingclient.TransportParams) refreshingclient.TLSParams {
-			return t.TLS
-		})
-		refreshableTLSConfig, err := refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)
-		if err != nil {
-			return nil, err
-		}
-		refreshableConfig = refreshableTLSConfig
+	refreshableConfig, err := b.getRefreshableTLSConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
-
 	dialer := refreshingclient.NewRefreshableDialer(ctx, b.DialerParams)
 	transport := refreshingclient.NewRefreshableTransport(ctx, b.TransportParams, refreshableConfig, dialer)
 	transport = wrapTransport(transport, newMetricsMiddleware(b.ServiceName, b.MetricsTagProviders, b.DisableMetrics))
@@ -129,6 +110,24 @@ func (b *httpClientBuilder) Build(ctx context.Context, params ...HTTPClientParam
 	transport = wrapTransport(transport, b.Middlewares...)
 
 	return refreshingclient.NewRefreshableHTTPClient(transport, b.Timeout), nil
+}
+
+func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refreshable.Validated[*tls.Config], error) {
+	if b.TLSConfig != nil {
+		refreshableOfStaticTLSConfig := refreshable.New(b.TLSConfig)
+		validatedStaticTLSConfig, _, err := refreshable.Validate(refreshableOfStaticTLSConfig, func(cfg *tls.Config) error {
+			// No validation needed given validation is done when setting config
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return validatedStaticTLSConfig, nil
+	}
+	tlsParams := refreshable.View(b.TransportParams, func(t refreshingclient.TransportParams) refreshingclient.TLSParams {
+		return t.TLS
+	})
+	return refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)
 }
 
 // NewClient returns a configured client ready for use.

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -126,7 +126,7 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 	}
 	fileSlices, _ := refreshable.Map(b.TransportParams, func(t refreshingclient.TransportParams) map[string]struct{} {
 		toReturn := map[string]struct{}{}
-		for _, file := range t.TLS.CAFiles {
+		for _, file := range t.TLSConfigurationParams.CAFiles {
 			toReturn[file] = struct{}{}
 		}
 		return toReturn
@@ -139,10 +139,9 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 		}
 		return refreshingclient.TLSParams{
 			CABytes:            caBytes,
-			CAFiles:            t1.TLS.CAFiles,
-			CertFile:           t1.TLS.CertFile,
-			KeyFile:            t1.TLS.KeyFile,
-			InsecureSkipVerify: t1.TLS.InsecureSkipVerify,
+			CertFile:           t1.TLSConfigurationParams.CertFile,
+			KeyFile:            t1.TLSConfigurationParams.KeyFile,
+			InsecureSkipVerify: t1.TLSConfigurationParams.InsecureSkipVerify,
 		}
 	})
 	return refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -246,12 +246,11 @@ func TestMissingCAFilesCausesError(t *testing.T) {
 		context.Background(),
 		clientConfigRefreshable,
 	)
-	assert.EqualError(t, err, "fdsafasd")
-	require.NoError(t, err)
+	assert.ErrorContains(t, err, "open fakedir/ca1.pem: no such file or directory")
 	_, err = httpclient.NewClient(
 		httpclient.WithConfig(cfg),
 	)
-	assert.EqualError(t, err, "fdsafasd")
+	assert.ErrorContains(t, err, "open fakedir/ca1.pem: no such file or directory")
 }
 
 // unwrapTransport traverses the RoundTripper chain to find the underlying *http.Transport.

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -142,7 +142,6 @@ func TestAddingCAFileIsCaptured(t *testing.T) {
 }
 
 func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
-	t.Skip("skipping test until feature complete")
 	// Create a temp directory with CA certificate files
 	tmpDir := t.TempDir()
 	caFile1 := filepath.Join(tmpDir, "ca1.pem")
@@ -182,22 +181,23 @@ func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
 	)
 	require.NoError(t, err)
 	_, err = scopedTokenClient.Delete(context.Background())
-	assert.ErrorContains(t, err, "test-service")
+	assert.Error(t, err)
 	assert.Equal(t, capturedSubjects, map[string]struct{}{
 		"Test CA": {},
 	})
 	// Append a file and see the newest CA
-	capturedSubjects = map[string]struct{}{}
+
 	appendTestCACertFile(t, caFile1, 3, "Test CA 3")
-	// Ensure the underlying refreshable can sync
-	_, err = scopedTokenClient.Delete(context.Background())
-	assert.ErrorContains(t, err, "test-service")
+	// Poll until the file refreshable picks up the change and transport rebuilds
 	assert.Eventually(t, func() bool {
+		capturedSubjects = map[string]struct{}{}
+		_, err = scopedTokenClient.Delete(context.Background())
+		assert.Error(t, err)
 		return reflect.DeepEqual(map[string]struct{}{
 			"Test CA":   {},
 			"Test CA 3": {},
 		}, capturedSubjects)
-	}, time.Second*2, time.Millisecond*100)
+	}, time.Second*5, time.Millisecond*100)
 }
 
 // unwrapTransport traverses the RoundTripper chain to find the underlying *http.Transport.
@@ -243,7 +243,7 @@ func appendTestCACertFile(t *testing.T, filePath string, serialNumber int64, org
 	certPEM := generateTestCACertPEM(t, serialNumber, orgName)
 	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0600)
 	require.NoError(t, err)
-	defer assert.NoError(t, f.Close())
+	defer func() { assert.NoError(t, f.Close()) }()
 	_, err = f.Write(certPEM)
 	require.NoError(t, err)
 }

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -229,6 +229,31 @@ func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
 	}, time.Second*5, time.Millisecond*100)
 }
 
+// TestMissingCAFilesCausesError ensures that we can't create clients that start broken
+func TestMissingCAFilesCausesError(t *testing.T) {
+	// Create a temp directory with CA certificate files
+	caFile1 := filepath.Join("fakedir/", "ca1.pem")
+	cfg := httpclient.ClientConfig{
+		URIs: []string{
+			"https://test-service",
+		},
+		Security: httpclient.SecurityConfig{
+			CAFiles: []string{caFile1},
+		},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	_, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+	)
+	assert.EqualError(t, err, "fdsafasd")
+	require.NoError(t, err)
+	_, err = httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+	)
+	assert.EqualError(t, err, "fdsafasd")
+}
+
 // unwrapTransport traverses the RoundTripper chain to find the underlying *http.Transport.
 func unwrapTransport(rt http.RoundTripper) *http.Transport {
 	for rt != nil {

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -232,13 +232,12 @@ func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
 // TestMissingCAFilesCausesError ensures that we can't create clients that start broken
 func TestMissingCAFilesCausesError(t *testing.T) {
 	// Create a temp directory with CA certificate files
-	caFile1 := filepath.Join("fakedir/", "ca1.pem")
 	cfg := httpclient.ClientConfig{
 		URIs: []string{
 			"https://test-service",
 		},
 		Security: httpclient.SecurityConfig{
-			CAFiles: []string{caFile1},
+			CAFiles: []string{filepath.Join("fakedir/", "ca1.pem")},
 		},
 	}
 	clientConfigRefreshable := refreshable.New(cfg)
@@ -251,6 +250,73 @@ func TestMissingCAFilesCausesError(t *testing.T) {
 		httpclient.WithConfig(cfg),
 	)
 	assert.ErrorContains(t, err, "open fakedir/ca1.pem: no such file or directory")
+}
+
+func TestMissingCertAndKeyFileErrors(t *testing.T) {
+	// Create a temp directory with CA certificate files
+	cfg := httpclient.ClientConfig{
+		URIs: []string{
+			"https://test-service",
+		},
+		Security: httpclient.SecurityConfig{
+			KeyFile:  filepath.Join("fakedir/", "key"),
+			CertFile: filepath.Join("fakedir/", "cert"),
+		},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	_, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+	)
+	assert.ErrorContains(t, err, "open fakedir/cert: no such file or directory")
+	_, err = httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+	)
+	assert.ErrorContains(t, err, "open fakedir/cert: no such file or directory")
+}
+
+func TestJustMissingCertDoesntError(t *testing.T) {
+	// Create a temp directory with CA certificate files
+	cfg := httpclient.ClientConfig{
+		URIs: []string{
+			"https://test-service",
+		},
+		Security: httpclient.SecurityConfig{
+			CertFile: filepath.Join("fakedir/", "cert"),
+		},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	_, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+	)
+	assert.NoError(t, err)
+	_, err = httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+	)
+	assert.NoError(t, err)
+}
+
+func TestJustMissingKeyDoesntError(t *testing.T) {
+	// Create a temp directory with CA certificate files
+	cfg := httpclient.ClientConfig{
+		URIs: []string{
+			"https://test-service",
+		},
+		Security: httpclient.SecurityConfig{
+			KeyFile: filepath.Join("fakedir/", "key"),
+		},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	_, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+	)
+	assert.NoError(t, err)
+	_, err = httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+	)
+	assert.NoError(t, err)
 }
 
 // unwrapTransport traverses the RoundTripper chain to find the underlying *http.Transport.

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -200,6 +200,63 @@ func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
 	}, time.Second*5, time.Millisecond*100)
 }
 
+func TestCAUpdatesToTheSameCAFileIsCapturedForConfigClient(t *testing.T) {
+	// Create a temp directory with CA certificate files
+	tmpDir := t.TempDir()
+	caFile1 := filepath.Join(tmpDir, "ca1.pem")
+	createTestCACertFile(t, caFile1, 1, "Test CA")
+
+	// Track unique CA subjects captured during requests
+	capturedSubjects := make(map[string]struct{})
+	tlsCapturingMiddleware := httpclient.MiddlewareFunc(
+		func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+			transport := unwrapTransport(next)
+			for _, subject := range transport.TLSClientConfig.RootCAs.Subjects() {
+				results := strings.Split(strings.TrimSpace(string(subject)), "\a")
+				last := results[len(results)-1]
+				results = strings.Split(last, "\t")
+				last = results[len(results)-1]
+				capturedSubjects[last] = struct{}{}
+			}
+			return next.RoundTrip(req)
+		},
+	)
+
+	cfg := httpclient.ClientConfig{
+		ServiceName: "baz",
+		URIs: []string{
+			"https://test-service",
+		},
+		MaxNumRetries: toPointer(0),
+		Security: httpclient.SecurityConfig{
+			CAFiles: []string{caFile1},
+		},
+	}
+	scopedTokenClient, err := httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+		httpclient.WithMiddleware(tlsCapturingMiddleware),
+	)
+	require.NoError(t, err)
+	_, err = scopedTokenClient.Delete(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, capturedSubjects, map[string]struct{}{
+		"Test CA": {},
+	})
+	// Append a file and see the newest CA
+
+	appendTestCACertFile(t, caFile1, 3, "Test CA 3")
+	// Poll until the file refreshable picks up the change and transport rebuilds
+	assert.Eventually(t, func() bool {
+		capturedSubjects = map[string]struct{}{}
+		_, err = scopedTokenClient.Delete(context.Background())
+		assert.Error(t, err)
+		return reflect.DeepEqual(map[string]struct{}{
+			"Test CA":   {},
+			"Test CA 3": {},
+		}, capturedSubjects)
+	}, time.Second*5, time.Millisecond*100)
+}
+
 // unwrapTransport traverses the RoundTripper chain to find the underlying *http.Transport.
 func unwrapTransport(rt http.RoundTripper) *http.Transport {
 	for rt != nil {

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -141,6 +141,7 @@ func TestAddingCAFileIsCaptured(t *testing.T) {
 	}, time.Second*2, time.Millisecond*100)
 }
 
+// TestCAUpdatesToTheSameCAFileIsCaptured ensures that refreshable and non-refreshable clients still respect on disk CA refreshes
 func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
 	// Create a temp directory with CA certificate files
 	tmpDir := t.TempDir()
@@ -174,81 +175,52 @@ func TestCAUpdatesToTheSameCAFileIsCaptured(t *testing.T) {
 		},
 	}
 	clientConfigRefreshable := refreshable.New(cfg)
-	scopedTokenClient, err := httpclient.NewClientFromRefreshableConfig(
+	client1, err := httpclient.NewClientFromRefreshableConfig(
 		context.Background(),
 		clientConfigRefreshable,
 		httpclient.WithMiddleware(tlsCapturingMiddleware),
 	)
 	require.NoError(t, err)
-	_, err = scopedTokenClient.Delete(context.Background())
-	assert.Error(t, err)
-	assert.Equal(t, capturedSubjects, map[string]struct{}{
-		"Test CA": {},
-	})
+	client2, err := httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+		httpclient.WithMiddleware(tlsCapturingMiddleware),
+	)
+	require.NoError(t, err)
+	// Client 1
+	assert.Eventually(t, func() bool {
+		capturedSubjects = map[string]struct{}{}
+		_, err = client1.Delete(context.Background())
+		assert.Error(t, err)
+		return reflect.DeepEqual(map[string]struct{}{
+			"Test CA": {},
+		}, capturedSubjects)
+	}, time.Second*5, time.Millisecond*100)
+	// Client 2
+	assert.Eventually(t, func() bool {
+		capturedSubjects = map[string]struct{}{}
+		_, err = client2.Delete(context.Background())
+		assert.Error(t, err)
+		return reflect.DeepEqual(map[string]struct{}{
+			"Test CA": {},
+		}, capturedSubjects)
+	}, time.Second*5, time.Millisecond*100)
 	// Append a file and see the newest CA
 
 	appendTestCACertFile(t, caFile1, 3, "Test CA 3")
-	// Poll until the file refreshable picks up the change and transport rebuilds
+	// Client 1
 	assert.Eventually(t, func() bool {
 		capturedSubjects = map[string]struct{}{}
-		_, err = scopedTokenClient.Delete(context.Background())
+		_, err = client1.Delete(context.Background())
 		assert.Error(t, err)
 		return reflect.DeepEqual(map[string]struct{}{
 			"Test CA":   {},
 			"Test CA 3": {},
 		}, capturedSubjects)
 	}, time.Second*5, time.Millisecond*100)
-}
-
-func TestCAUpdatesToTheSameCAFileIsCapturedForConfigClient(t *testing.T) {
-	// Create a temp directory with CA certificate files
-	tmpDir := t.TempDir()
-	caFile1 := filepath.Join(tmpDir, "ca1.pem")
-	createTestCACertFile(t, caFile1, 1, "Test CA")
-
-	// Track unique CA subjects captured during requests
-	capturedSubjects := make(map[string]struct{})
-	tlsCapturingMiddleware := httpclient.MiddlewareFunc(
-		func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-			transport := unwrapTransport(next)
-			for _, subject := range transport.TLSClientConfig.RootCAs.Subjects() {
-				results := strings.Split(strings.TrimSpace(string(subject)), "\a")
-				last := results[len(results)-1]
-				results = strings.Split(last, "\t")
-				last = results[len(results)-1]
-				capturedSubjects[last] = struct{}{}
-			}
-			return next.RoundTrip(req)
-		},
-	)
-
-	cfg := httpclient.ClientConfig{
-		ServiceName: "baz",
-		URIs: []string{
-			"https://test-service",
-		},
-		MaxNumRetries: toPointer(0),
-		Security: httpclient.SecurityConfig{
-			CAFiles: []string{caFile1},
-		},
-	}
-	scopedTokenClient, err := httpclient.NewClient(
-		httpclient.WithConfig(cfg),
-		httpclient.WithMiddleware(tlsCapturingMiddleware),
-	)
-	require.NoError(t, err)
-	_, err = scopedTokenClient.Delete(context.Background())
-	assert.Error(t, err)
-	assert.Equal(t, capturedSubjects, map[string]struct{}{
-		"Test CA": {},
-	})
-	// Append a file and see the newest CA
-
-	appendTestCACertFile(t, caFile1, 3, "Test CA 3")
-	// Poll until the file refreshable picks up the change and transport rebuilds
+	// Client 2
 	assert.Eventually(t, func() bool {
 		capturedSubjects = map[string]struct{}{}
-		_, err = scopedTokenClient.Delete(context.Background())
+		_, err = client2.Delete(context.Background())
 		assert.Error(t, err)
 		return reflect.DeepEqual(map[string]struct{}{
 			"Test CA":   {},

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -391,7 +391,37 @@ func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 			b.TLSConfig.InsecureSkipVerify = true
 		}
 		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
-			p.TLS.InsecureSkipVerify = true
+			p.TLSConfigurationParams.InsecureSkipVerify = true
+			return p
+		})
+		return nil
+	})
+}
+
+func WithKeyFile(keyFile string) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLSConfigurationParams.KeyFile = keyFile
+			return p
+		})
+		return nil
+	})
+}
+
+func WithCertFile(certFile string) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLSConfigurationParams.CertFile = certFile
+			return p
+		})
+		return nil
+	})
+}
+
+func WithCAFiles(CAFiles []string) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLSConfigurationParams.CAFiles = CAFiles
 			return p
 		})
 		return nil

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -398,19 +398,12 @@ func WithTLSInsecureSkipVerify() ClientOrHTTPClientParam {
 	})
 }
 
-func WithKeyFile(keyFile string) ClientOrHTTPClientParam {
+// WithKeyAndCertFile sets the client TLS certificate and key file paths.
+// The files are read when the client is created and on each request to support certificate rotation.
+func WithKeyAndCertFile(keyFile string, certFile string) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
 			p.TLSConfigurationParams.KeyFile = keyFile
-			return p
-		})
-		return nil
-	})
-}
-
-func WithCertFile(certFile string) ClientOrHTTPClientParam {
-	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
-		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
 			p.TLSConfigurationParams.CertFile = certFile
 			return p
 		})
@@ -418,6 +411,8 @@ func WithCertFile(certFile string) ClientOrHTTPClientParam {
 	})
 }
 
+// WithCAFiles sets the CA certificate file paths for the client's TLS configuration.
+// The files are read when the client is created and periodically refreshed to support certificate rotation.
 func WithCAFiles(CAFiles []string) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -386,7 +386,7 @@ func getClientTLSParams(c ClientConfig) ([]ClientParam, error) {
 	if derefPtr(c.Security.InsecureSkipVerify, false) {
 		params = append(params, WithTLSInsecureSkipVerify())
 	}
-	clientBuilderArg := &clientBuilder{}
+	clientBuilderArg := newClientBuilder()
 	for _, p := range params {
 		err := p.apply(clientBuilderArg)
 		if err != nil {

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -370,8 +370,7 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 func getClientTLSParams(c ClientConfig) []ClientParam {
 	params := []ClientParam{
 		WithCAFiles(c.Security.CAFiles),
-		WithCertFile(c.Security.CertFile),
-		WithKeyFile(c.Security.KeyFile),
+		WithKeyAndCertFile(c.Security.KeyFile, c.Security.CertFile),
 	}
 	if derefPtr(c.Security.InsecureSkipVerify, false) {
 		params = append(params, WithTLSInsecureSkipVerify())

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -363,63 +363,20 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 	if timeout != 0 {
 		params = append(params, WithHTTPTimeout(timeout))
 	}
-
-	tlsParams, err := getClientTLSParams(c)
-	if err != nil {
-		return nil, err
-	}
-	params = append(params, tlsParams...)
+	params = append(params, getClientTLSParams(c)...)
 	return params, nil
 }
 
-func getClientTLSParams(c ClientConfig) ([]ClientParam, error) {
-	var params []ClientParam
-	if len(c.Security.CAFiles) > 0 {
-		params = append(params, WithCAFiles(c.Security.CAFiles))
-	}
-	if len(c.Security.CertFile) > 0 {
-		params = append(params, WithCertFile(c.Security.CertFile))
-	}
-	if len(c.Security.KeyFile) > 0 {
-		params = append(params, WithKeyFile(c.Security.KeyFile))
+func getClientTLSParams(c ClientConfig) []ClientParam {
+	params := []ClientParam{
+		WithCAFiles(c.Security.CAFiles),
+		WithCertFile(c.Security.CertFile),
+		WithKeyFile(c.Security.KeyFile),
 	}
 	if derefPtr(c.Security.InsecureSkipVerify, false) {
 		params = append(params, WithTLSInsecureSkipVerify())
 	}
-	clientBuilderArg := newClientBuilder()
-	for _, p := range params {
-		err := p.apply(clientBuilderArg)
-		if err != nil {
-			return nil, err
-		}
-	}
-	tlsConfigurationParams := clientBuilderArg.HTTP.TransportParams.Current().TLSConfigurationParams
-	caBytes, err := getCABytes(tlsConfigurationParams.CAFiles)
-	if err != nil {
-		return nil, err
-	}
-	err = refreshingclient.ValidateTLSParams(context.TODO(), refreshingclient.TLSParams{
-		CABytes:            caBytes,
-		CertFile:           tlsConfigurationParams.CertFile,
-		KeyFile:            tlsConfigurationParams.KeyFile,
-		InsecureSkipVerify: tlsConfigurationParams.InsecureSkipVerify,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return params, nil
-}
-
-func getCABytes(files []string) ([][]byte, error) {
-	var caBytes [][]byte
-	for _, file := range files {
-		pemBytes, err := os.ReadFile(file)
-		if err != nil {
-			return nil, werror.Wrap(err, "failed to read CA file")
-		}
-		caBytes = append(caBytes, pemBytes)
-	}
-	return caBytes, nil
+	return params
 }
 
 func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig) (refreshingclient.ValidatedClientParams, error) {

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -364,18 +364,21 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 		params = append(params, WithHTTPTimeout(timeout))
 	}
 
-	// Security (TLS) Config
-	if tlsConfig, err := refreshingclient.NewTLSConfig(context.TODO(), refreshingclient.TLSParams{
-		CAFiles:            c.Security.CAFiles,
+	err := refreshingclient.ValidateTLSParams(context.TODO(), refreshingclient.TLSParams{
+		// CAFiles:            c.Security.CAFiles, TODO how to map for validation
 		CertFile:           c.Security.CertFile,
 		KeyFile:            c.Security.KeyFile,
 		InsecureSkipVerify: derefPtr(c.Security.InsecureSkipVerify, false),
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
-	} else if tlsConfig != nil {
-		params = append(params, WithTLSConfig(tlsConfig))
 	}
-
+	params = append(params, WithCAFiles(c.Security.CAFiles))
+	params = append(params, WithCertFile(c.Security.CertFile))
+	params = append(params, WithKeyFile(c.Security.KeyFile))
+	if derefPtr(c.Security.InsecureSkipVerify, false) {
+		params = append(params, WithTLSInsecureSkipVerify())
+	}
 	return params, nil
 }
 
@@ -396,7 +399,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 		HTTP2ReadIdleTimeout:  derefPtr(config.HTTP2ReadIdleTimeout, defaultHTTP2ReadIdleTimeout),
 		ProxyFromEnvironment:  derefPtr(config.ProxyFromEnvironment, true),
 		TLSHandshakeTimeout:   derefPtr(config.TLSHandshakeTimeout, defaultTLSHandshakeTimeout),
-		TLS: refreshingclient.TLSParams{
+		TLSConfigurationParams: refreshingclient.TLSConfigurationParams{
 			CAFiles:            config.Security.CAFiles,
 			CertFile:           config.Security.CertFile,
 			KeyFile:            config.Security.KeyFile,

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -364,22 +364,62 @@ func configToParams(c ClientConfig) ([]ClientParam, error) {
 		params = append(params, WithHTTPTimeout(timeout))
 	}
 
-	err := refreshingclient.ValidateTLSParams(context.TODO(), refreshingclient.TLSParams{
-		// CAFiles:            c.Security.CAFiles, TODO how to map for validation
-		CertFile:           c.Security.CertFile,
-		KeyFile:            c.Security.KeyFile,
-		InsecureSkipVerify: derefPtr(c.Security.InsecureSkipVerify, false),
+	tlsParams, err := getClientTLSParams(c)
+	if err != nil {
+		return nil, err
+	}
+	params = append(params, tlsParams...)
+	return params, nil
+}
+
+func getClientTLSParams(c ClientConfig) ([]ClientParam, error) {
+	var params []ClientParam
+	if len(c.Security.CAFiles) > 0 {
+		params = append(params, WithCAFiles(c.Security.CAFiles))
+	}
+	if len(c.Security.CertFile) > 0 {
+		params = append(params, WithCertFile(c.Security.CertFile))
+	}
+	if len(c.Security.KeyFile) > 0 {
+		params = append(params, WithKeyFile(c.Security.KeyFile))
+	}
+	if derefPtr(c.Security.InsecureSkipVerify, false) {
+		params = append(params, WithTLSInsecureSkipVerify())
+	}
+	clientBuilderArg := &clientBuilder{}
+	for _, p := range params {
+		err := p.apply(clientBuilderArg)
+		if err != nil {
+			return nil, err
+		}
+	}
+	tlsConfigurationParams := clientBuilderArg.HTTP.TransportParams.Current().TLSConfigurationParams
+	caBytes, err := getCABytes(tlsConfigurationParams.CAFiles)
+	if err != nil {
+		return nil, err
+	}
+	err = refreshingclient.ValidateTLSParams(context.TODO(), refreshingclient.TLSParams{
+		CABytes:            caBytes,
+		CertFile:           tlsConfigurationParams.CertFile,
+		KeyFile:            tlsConfigurationParams.KeyFile,
+		InsecureSkipVerify: tlsConfigurationParams.InsecureSkipVerify,
 	})
 	if err != nil {
 		return nil, err
 	}
-	params = append(params, WithCAFiles(c.Security.CAFiles))
-	params = append(params, WithCertFile(c.Security.CertFile))
-	params = append(params, WithKeyFile(c.Security.KeyFile))
-	if derefPtr(c.Security.InsecureSkipVerify, false) {
-		params = append(params, WithTLSInsecureSkipVerify())
-	}
 	return params, nil
+}
+
+func getCABytes(files []string) ([][]byte, error) {
+	var caBytes [][]byte
+	for _, file := range files {
+		pemBytes, err := os.ReadFile(file)
+		if err != nil {
+			return nil, werror.Wrap(err, "failed to read CA file")
+		}
+		caBytes = append(caBytes, pemBytes)
+	}
+	return caBytes, nil
 }
 
 func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig) (refreshingclient.ValidatedClientParams, error) {

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -27,6 +27,7 @@ import (
 // Its fields must all be compatible with reflect.DeepEqual.
 type TLSParams struct {
 	CAFiles            []string
+	CABytes            [][]byte
 	CertFile           string
 	KeyFile            string
 	InsecureSkipVerify bool
@@ -52,9 +53,7 @@ func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Refreshable
 // NewTLSConfig returns a *tls.Config built from the provided TLSParams.
 func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 	var tlsParams []tlsconfig.ClientParam
-	if len(p.CAFiles) != 0 {
-		tlsParams = append(tlsParams, tlsconfig.ClientRootCAFiles(p.CAFiles...))
-	}
+	tlsParams = append(tlsParams, getCAClientParam(p)...)
 	if p.CertFile != "" && p.KeyFile != "" {
 		tlsParams = append(tlsParams, tlsconfig.ClientKeyPairFiles(p.CertFile, p.KeyFile))
 	}
@@ -66,4 +65,22 @@ func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 		return nil, werror.WrapWithContextParams(ctx, err, "failed to build tlsConfig")
 	}
 	return tlsConfig, nil
+}
+
+func getCAClientParam(p TLSParams) []tlsconfig.ClientParam {
+	if len(p.CAFiles) == 0 && len(p.CABytes) == 0 {
+		return nil
+	}
+	var certPoolOptions []tlsconfig.CertPoolOption
+	if len(p.CAFiles) > 0 {
+		certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionFromCAFiles(p.CAFiles...))
+	}
+	if len(p.CABytes) > 0 {
+		for _, ca := range p.CABytes {
+			certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionCABytes(ca))
+		}
+	}
+	return []tlsconfig.ClientParam{
+		tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCertPoolOptions(certPoolOptions)),
+	}
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -52,7 +52,13 @@ func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Refreshable
 // NewTLSConfig returns a *tls.Config built from the provided TLSParams.
 func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 	var tlsParams []tlsconfig.ClientParam
-	tlsParams = append(tlsParams, getCAClientParam(p)...)
+	if len(p.CABytes) > 0 {
+		var certPoolOptions []tlsconfig.CertPoolOption
+		for _, ca := range p.CABytes {
+			certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionCABytes(ca))
+		}
+		tlsParams = append(tlsParams, tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCertPoolOptions(certPoolOptions)))
+	}
 	if p.CertFile != "" && p.KeyFile != "" {
 		tlsParams = append(tlsParams, tlsconfig.ClientKeyPairFiles(p.CertFile, p.KeyFile))
 	}
@@ -69,17 +75,4 @@ func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 func ValidateTLSParams(ctx context.Context, p TLSParams) error {
 	_, err := NewTLSConfig(ctx, p)
 	return err
-}
-
-func getCAClientParam(p TLSParams) []tlsconfig.ClientParam {
-	if len(p.CABytes) == 0 {
-		return nil
-	}
-	var certPoolOptions []tlsconfig.CertPoolOption
-	for _, ca := range p.CABytes {
-		certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionCABytes(ca))
-	}
-	return []tlsconfig.ClientParam{
-		tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCertPoolOptions(certPoolOptions)),
-	}
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -75,10 +75,8 @@ func getCAClientParam(p TLSParams) []tlsconfig.ClientParam {
 	if len(p.CAFiles) > 0 {
 		certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionFromCAFiles(p.CAFiles...))
 	}
-	if len(p.CABytes) > 0 {
-		for _, ca := range p.CABytes {
-			certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionCABytes(ca))
-		}
+	for _, ca := range p.CABytes {
+		certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionCABytes(ca))
 	}
 	return []tlsconfig.ClientParam{
 		tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCertPoolOptions(certPoolOptions)),

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -26,7 +26,6 @@ import (
 // TLSParams contains the parameters needed to build a *tls.Config.
 // Its fields must all be compatible with reflect.DeepEqual.
 type TLSParams struct {
-	CAFiles            []string
 	CABytes            [][]byte
 	CertFile           string
 	KeyFile            string
@@ -67,14 +66,16 @@ func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+func ValidateTLSParams(ctx context.Context, p TLSParams) error {
+	_, err := NewTLSConfig(ctx, p)
+	return err
+}
+
 func getCAClientParam(p TLSParams) []tlsconfig.ClientParam {
-	if len(p.CAFiles) == 0 && len(p.CABytes) == 0 {
+	if len(p.CABytes) == 0 {
 		return nil
 	}
 	var certPoolOptions []tlsconfig.CertPoolOption
-	if len(p.CAFiles) > 0 {
-		certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionFromCAFiles(p.CAFiles...))
-	}
 	for _, ca := range p.CABytes {
 		certPoolOptions = append(certPoolOptions, tlsconfig.CertPoolOptionCABytes(ca))
 	}

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -71,8 +71,3 @@ func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 	}
 	return tlsConfig, nil
 }
-
-func ValidateTLSParams(ctx context.Context, p TLSParams) error {
-	_, err := NewTLSConfig(ctx, p)
-	return err
-}

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -40,7 +40,14 @@ type TransportParams struct {
 	HTTP2ReadIdleTimeout  time.Duration
 	HTTP2PingTimeout      time.Duration
 
-	TLS TLSParams
+	TLSConfigurationParams TLSConfigurationParams
+}
+
+type TLSConfigurationParams struct {
+	CAFiles            []string
+	CertFile           string
+	KeyFile            string
+	InsecureSkipVerify bool
 }
 
 func NewRefreshableTransport(ctx context.Context, p refreshable.Refreshable[TransportParams], refreshableConfig refreshable.Validated[*tls.Config], dialer ContextDialer) http.RoundTripper {


### PR DESCRIPTION
- Update client with TLS file changes if the file on disk is updated 
- Include `CABytes` into `refreshingclient.TLSParams` and give the client builder the ability to include CA paths and CA bytes. Split out `TLSParams` and `TLSConfigurationParams` to better indicate which is refreshable and which is not
- We also needed to change the logic in `getClientTLSParams` to make sure we do not call `WithTLSConfig`, by doing the later we enter a mode in which all refreshability it turned off; that isn't what we want. We still want the configuration values to trigger refreshes and go through the identical client construction code. `WithTLSConfig` should only be used by clients when they need to do something truly bespoke. Because of that we needed to add 2 more configuration options to set the key and the ca paths 
- Populate `refreshingclient.TLSParams` through a `MultiFileRefreshable` that internally tracks the CA files on disk
- Enable the `TestCAUpdatesToTheSameCAFileIsCaptured` test and add 3 additional validation tests 
- Handles the first part of  https://github.com/palantir/conjure-go-runtime/issues/221 
- 2nd part of https://github.com/palantir/conjure-go-runtime/pull/861