### PR TITLE
Make NewClient use a Context tied to the lifetime of the returned Client

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
@@ -165,7 +166,15 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 // We apply "sane defaults" before applying the provided params.
 func NewClient(params ...ClientParam) (Client, error) {
 	b := newClientBuilder()
-	return newClient(context.TODO(), b, params...)
+
+	// NewClient is not provided with a context.Context, so create a new Context to use for the builder. The lifetime of
+	// the Context is tied to the returned Client: when the returned Client is no longer reachable, the Context is
+	// canceled as part of cleanup.
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := newClient(ctx, b, params...)
+	runtime.AddCleanup(&client, func(_ struct{}) { cancel() }, struct{}{})
+
+	return client, err
 }
 
 // NewClientFromRefreshableConfig returns a configured client ready for use.

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -243,11 +243,22 @@ func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (Cl
 // We apply "sane defaults" before applying the provided params.
 func NewHTTPClient(params ...HTTPClientParam) (*http.Client, error) {
 	b := newClientBuilder()
-	provider, err := b.HTTP.Build(context.TODO(), params...)
+
+	// NewHTTPClient is not provided with a context.Context, so create a new Context to use for the builder. The
+	// lifetime of the Context is tied to the returned *Client: when the returned *Client is no longer reachable, the
+	// Context is canceled as part of cleanup.
+	ctx, cancel := context.WithCancel(context.Background())
+	provider, err := b.HTTP.Build(ctx, params...)
 	if err != nil {
+		// if returning nil, cancel the context
+		cancel()
 		return nil, err
 	}
-	return provider.Current(), nil
+
+	client := provider.Current()
+	runtime.AddCleanup(client, func(_ struct{}) { cancel() }, struct{}{})
+
+	return client, nil
 }
 
 // NewHTTPClientFromRefreshableConfig returns a configured http client ready for use.


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

