### PR TITLE
Fix memory/goroutine leak in httpclient.NewClient and httpclient.NewHTTPClient

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
@@ -161,11 +162,30 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 	return refreshingclient.NewRefreshableTLSConfig(ctx, tlsParams)
 }
 
+// Deprecated: prefer [NewClientWithContext].
+//
 // NewClient returns a configured client ready for use.
-// We apply "sane defaults" before applying the provided params.
+// The builder used to build this client is provided with a Context that is associated with the lifetime of the returned
+// struct that implements Client, and may be canceled when the pointer to the struct is no longer reachable.
 func NewClient(params ...ClientParam) (Client, error) {
 	b := newClientBuilder()
-	return newClient(context.TODO(), b, params...)
+	ctx, cancelFn := context.WithCancel(context.Background())
+	client, err := newClient(ctx, b, params...)
+	if client == nil {
+		cancelFn()
+	} else {
+		runtime.AddCleanup(client, func(cancel context.CancelFunc) { cancel() }, cancelFn)
+	}
+	return client, err
+}
+
+// NewClientWithContext returns a configured client ready for use.
+// The provided ctx is used to build the client and is provided to any functions in the builder that require a Context.
+// If the provided ctx is canceled, background tasks associated with the returned Client may also be canceled and the
+// Client may no longer be valid.
+// Sane defaults are applied to the builder before applying the provided params.
+func NewClientWithContext(ctx context.Context, params ...ClientParam) (Client, error) {
+	return newClient(ctx, newClientBuilder(), params...)
 }
 
 // NewClientFromRefreshableConfig returns a configured client ready for use.
@@ -178,7 +198,7 @@ func NewClientFromRefreshableConfig(ctx context.Context, config refreshable.Refr
 	return newClient(ctx, b, params...)
 }
 
-func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (Client, error) {
+func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (*clientImpl, error) {
 	for _, p := range params {
 		if p == nil {
 			continue
@@ -230,15 +250,42 @@ func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (Cl
 	}, nil
 }
 
-// NewHTTPClient returns a configured http client ready for use.
-// We apply "sane defaults" before applying the provided params.
-func NewHTTPClient(params ...HTTPClientParam) (*http.Client, error) {
+// NewHTTPClientWithContext returns a configured *http.Client ready for use.
+// The provided ctx is used to build the client and is provided to any functions in the builder that require a Context.
+// If the provided ctx is canceled, background tasks associated with the returned *http.Client may also be canceled and
+// the *http.Client may no longer be valid.
+// Sane defaults are applied to the builder before applying the provided params.
+func NewHTTPClientWithContext(ctx context.Context, params ...HTTPClientParam) (*http.Client, error) {
 	b := newClientBuilder()
-	provider, err := b.HTTP.Build(context.TODO(), params...)
+
+	provider, err := b.HTTP.Build(ctx, params...)
 	if err != nil {
 		return nil, err
 	}
 	return provider.Current(), nil
+}
+
+// Deprecated: prefer [NewHTTPClientWithContext].
+//
+// NewHTTPClient returns a configured *http.Client ready for use.
+// The builder used to build this client is provided with a Context that is associated with the lifetime of the returned
+// *http.Client, and may be canceled when the pointer is no longer reachable.
+func NewHTTPClient(params ...HTTPClientParam) (*http.Client, error) {
+	b := newClientBuilder()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	provider, err := b.HTTP.Build(ctx, params...)
+	if err != nil {
+		cancelFn()
+		return nil, err
+	}
+	client := provider.Current()
+	if client == nil {
+		cancelFn()
+	} else {
+		runtime.AddCleanup(client, func(cancel context.CancelFunc) { cancel() }, cancelFn)
+	}
+	return client, nil
 }
 
 // NewHTTPClientFromRefreshableConfig returns a configured http client ready for use.

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -168,9 +168,9 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 // The builder used to build this client is provided with a Context that is associated with the lifetime of the returned
 // struct that implements Client, and may be canceled when the pointer to the struct is no longer reachable.
 func NewClient(params ...ClientParam) (Client, error) {
-	b := newClientBuilder()
 	ctx, cancelFn := context.WithCancel(context.Background())
-	client, err := newClient(ctx, b, params...)
+	// note: does not delegate to NewClientWithContext because runtime.AddCleanup needs the actual pointer
+	client, err := newClient(ctx, newClientBuilder(), params...)
 	if client == nil {
 		cancelFn()
 	} else {
@@ -271,21 +271,14 @@ func NewHTTPClientWithContext(ctx context.Context, params ...HTTPClientParam) (*
 // The builder used to build this client is provided with a Context that is associated with the lifetime of the returned
 // *http.Client, and may be canceled when the pointer is no longer reachable.
 func NewHTTPClient(params ...HTTPClientParam) (*http.Client, error) {
-	b := newClientBuilder()
-
 	ctx, cancelFn := context.WithCancel(context.Background())
-	provider, err := b.HTTP.Build(ctx, params...)
-	if err != nil {
-		cancelFn()
-		return nil, err
-	}
-	client := provider.Current()
+	client, err := NewHTTPClientWithContext(ctx, params...)
 	if client == nil {
 		cancelFn()
 	} else {
 		runtime.AddCleanup(client, func(cancel context.CancelFunc) { cancel() }, cancelFn)
 	}
-	return client, nil
+	return client, err
 }
 
 // NewHTTPClientFromRefreshableConfig returns a configured http client ready for use.

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -257,7 +257,6 @@ func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (*c
 // Sane defaults are applied to the builder before applying the provided params.
 func NewHTTPClientWithContext(ctx context.Context, params ...HTTPClientParam) (*http.Client, error) {
 	b := newClientBuilder()
-
 	provider, err := b.HTTP.Build(ctx, params...)
 	if err != nil {
 		return nil, err

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 	"unsafe"
@@ -480,4 +481,75 @@ func generateTestCACertPEM(t *testing.T, serialNumber int64, orgName string) []b
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
+	const numClients = 1000
+	mostClients := int(numClients * .9)
+
+	for _, tc := range []struct {
+		name   string
+		argVal bool
+	}{
+		{
+			name:   "httpclient.NewClient doesn't leak goroutines",
+			argVal: false,
+		},
+		{
+			name:   "httpclient.NewHTTPClient doesn't leak goroutines",
+			argVal: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			startNumGoroutines := runtime.NumGoroutine()
+			t.Log("Goroutines at start:", startNumGoroutines)
+
+			clients := createNewClients(t, numClients, tc.argVal)
+			afterCreateClientsNumGoroutines := runtime.NumGoroutine()
+			t.Log("Goroutines after createNewClients, before GC:", afterCreateClientsNumGoroutines)
+			// add in some slack in case goroutines other than client ones stopped since startNumGoroutines was recorded
+			assert.True(t, afterCreateClientsNumGoroutines > startNumGoroutines+mostClients)
+
+			// make clients unreferenced, run GC, and briefly sleep
+			_ = clients
+			clients = nil
+			_ = clients
+
+			runtime.GC()
+			time.Sleep(50 * time.Millisecond)
+
+			afterGCNumGoroutines := runtime.NumGoroutine()
+			t.Log("Goroutines after GC:", afterGCNumGoroutines)
+			assert.True(t, afterGCNumGoroutines < startNumGoroutines+mostClients)
+		})
+	}
+}
+
+func createNewClients(t *testing.T, nClients int, httpClient bool) []any {
+	uris := []string{"https://test-service"}
+
+	tmpDir := t.TempDir()
+	caFile := filepath.Join(tmpDir, "ca.pem")
+	createTestCACertFile(t, caFile, 1, "Test CA")
+
+	var out []any
+	for range nClients {
+		var (
+			client any
+			err    error
+		)
+		if httpClient {
+			client, err = httpclient.NewHTTPClient(
+				httpclient.WithCAFiles([]string{caFile}),
+			)
+		} else {
+			client, err = httpclient.NewClient(
+				httpclient.WithBaseURLs(uris),
+				httpclient.WithCAFiles([]string{caFile}),
+			)
+		}
+		require.NoError(t, err)
+		out = append(out, client)
+	}
+	return out
 }

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -483,6 +483,8 @@ func generateTestCACertPEM(t *testing.T, serialNumber int64, orgName string) []b
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 }
 
+// Test_NewClientDoesNotLeakGoroutines verifies that the clients returned by httpclient.NewClient and
+// httpclient.NewHTTPClient do not leak goroutines.
 func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
 	const numClients = 1000
 	mostClients := int(numClients * .9)
@@ -493,7 +495,7 @@ func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
 	}{
 		{
 			name:   "httpclient.NewClient doesn't leak goroutines",
-			argVal: false,
+			argVal: true,
 		},
 		{
 			name:   "httpclient.NewHTTPClient doesn't leak goroutines",

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -495,11 +495,11 @@ func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
 	}{
 		{
 			name:   "httpclient.NewClient doesn't leak goroutines",
-			argVal: true,
+			argVal: false,
 		},
 		{
 			name:   "httpclient.NewHTTPClient doesn't leak goroutines",
-			argVal: false,
+			argVal: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -510,7 +510,7 @@ func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
 			afterCreateClientsNumGoroutines := runtime.NumGoroutine()
 			t.Log("Goroutines after createNewClients, before GC:", afterCreateClientsNumGoroutines)
 			// add in some slack in case goroutines other than client ones stopped since startNumGoroutines was recorded
-			assert.True(t, afterCreateClientsNumGoroutines > startNumGoroutines+mostClients)
+			assert.Greater(t, afterCreateClientsNumGoroutines, startNumGoroutines+mostClients)
 
 			// make clients unreferenced, run GC, and briefly sleep
 			_ = clients
@@ -522,7 +522,7 @@ func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
 
 			afterGCNumGoroutines := runtime.NumGoroutine()
 			t.Log("Goroutines after GC:", afterGCNumGoroutines)
-			assert.True(t, afterGCNumGoroutines < startNumGoroutines+mostClients)
+			assert.LessOrEqual(t, afterGCNumGoroutines, startNumGoroutines+int(numClients*0.1))
 		})
 	}
 }


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes memory/goroutine leak that can occur when constructing a client using httpclient.NewClient and httpclient.NewHTTPClient if the client uses a file refreshable. Does this by calling the internal builder with a context that is canceled when the client is cleaned up.

Also marks the functions as deprecated and adds "WithContext" versions of these functions to allow callers to provide a context.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

