### PR TITLE
fix: Prevent subscriber leak when discarding clients built from refreshable config

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -231,11 +231,16 @@ func newClient(ctx context.Context, b *clientBuilder, params ...ClientParam) (*c
 	if !b.HTTP.DisableRecovery {
 		recovery = recoveryMiddleware{}
 	}
+	// Extract URIScorerBuilder before closing over it so the closure does not
+	// capture the entire *clientBuilder. Capturing b keeps all derived
+	// refreshable wrappers reachable from the root config's subscriber chain,
+	// preventing runtime.AddCleanup from firing and leaking subscriptions.
+	uriScorerBuilder := b.URIScorerBuilder
 	uriScorer := internal.NewRefreshableURIScoringMiddleware(b.URIs, func(uris []string) internal.URIScoringMiddleware {
-		if b.URIScorerBuilder == nil {
+		if uriScorerBuilder == nil {
 			return internal.NewBalancedURIScoringMiddleware(uris, func() int64 { return time.Now().UnixNano() })
 		}
-		return b.URIScorerBuilder(uris)
+		return uriScorerBuilder(uris)
 	})
 	return &clientImpl{
 		serviceName:            b.HTTP.ServiceName,
@@ -361,9 +366,17 @@ func newClientBuilderFromRefreshableConfig(ctx context.Context, config refreshab
 	b.HTTP.DisableMetrics, _ = refreshable.MapFromValidated(validParams, func(p refreshingclient.ValidatedClientParams) bool {
 		return p.DisableMetrics
 	})
+	// Use MapFromValidated to create an intermediate refreshable for MetricsTags
+	// instead of capturing validParams (a derivedValidated wrapper) directly in
+	// the closure. Capturing the wrapper creates a reference cycle:
+	//   config → v → timeout.inner → transport → metricsMiddleware → validParams → v
+	// which prevents runtime.AddCleanup from firing on the wrapper.
+	metricsTags, _ := refreshable.MapFromValidated(validParams, func(p refreshingclient.ValidatedClientParams) metrics.Tags {
+		return p.MetricsTags
+	})
 	b.HTTP.MetricsTagProviders = append(b.HTTP.MetricsTagProviders,
 		TagsProviderFunc(func(*http.Request, *http.Response, error) metrics.Tags {
-			return validParams.Unvalidated().MetricsTags
+			return metricsTags.Current()
 		}))
 
 	apiToken, _ := refreshable.MapFromValidated(validParams, func(p refreshingclient.ValidatedClientParams) *string {

--- a/conjure-go-client/httpclient/client_builder_subscriber_test.go
+++ b/conjure-go-client/httpclient/client_builder_subscriber_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient_test
+
+import (
+	"context"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/pkg/refreshable/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewClientFromRefreshableConfigSubscriberCleanup verifies that creating
+// and discarding clients built from a refreshable config does not leak
+// subscribers on the root config refreshable. Each call to
+// NewClientFromRefreshableConfig creates a chain of derived refreshables
+// (MapWithError → MapFromValidated fan-out → Map for transport/dialer/etc.)
+// that subscribe to the root config. When the client is garbage collected,
+// these subscriptions must be cleaned up via runtime.AddCleanup cascading
+// through the derived wrappers.
+//
+// Without proper cleanup, each discarded client leaks one subscriber on the
+// root config, leading to unbounded memory growth in production services that
+// create clients dynamically (e.g. per-service import backends).
+func TestNewClientFromRefreshableConfigSubscriberCleanup(t *testing.T) {
+	cfg := httpclient.ClientConfig{
+		ServiceName: "test-service",
+		URIs:        []string{"https://localhost:8080"},
+	}
+	config := refreshable.New(cfg)
+
+	// Warmup: create and discard one client to establish steady state.
+	_, err := httpclient.NewClientFromRefreshableConfig(context.Background(), config)
+	require.NoError(t, err)
+	forceGCAndCleanup()
+
+	baseline := updatableSubscriberCount(t, config)
+	t.Logf("Baseline subscriber count after warmup: %d", baseline)
+
+	// Create and discard 100 clients.
+	const iterations = 100
+	for range iterations {
+		_, err := httpclient.NewClientFromRefreshableConfig(context.Background(), config)
+		require.NoError(t, err)
+	}
+
+	beforeGC := updatableSubscriberCount(t, config)
+	t.Logf("Subscriber count after %d clients (before GC): %d", iterations, beforeGC)
+
+	forceGCAndCleanup()
+
+	final := updatableSubscriberCount(t, config)
+	growth := final - baseline
+	t.Logf("Final subscriber count: %d (growth from baseline: %d)", final, growth)
+
+	// Each client adds 1 subscriber to config via validatedFromRefreshable.
+	// With proper GC cleanup, all subscribers should be removed. Allow a
+	// small tolerance for in-flight GC cycles.
+	assert.Less(t, growth, 10,
+		"subscriber count grew by %d after discarding %d clients; "+
+			"the cleanup chain from derived refreshables back to the root config is not working",
+		growth, iterations)
+}
+
+// TestNewHTTPClientFromRefreshableConfigSubscriberCleanup is the same test
+// as above but exercises the NewHTTPClientFromRefreshableConfig path which
+// returns a refreshable.Refreshable[*http.Client] instead of a Client.
+func TestNewHTTPClientFromRefreshableConfigSubscriberCleanup(t *testing.T) {
+	cfg := httpclient.ClientConfig{
+		ServiceName: "test-service",
+		URIs:        []string{"https://localhost:8080"},
+	}
+	config := refreshable.New(cfg)
+
+	// Warmup.
+	_, err := httpclient.NewHTTPClientFromRefreshableConfig(context.Background(), config)
+	require.NoError(t, err)
+	forceGCAndCleanup()
+
+	baseline := updatableSubscriberCount(t, config)
+	t.Logf("Baseline subscriber count after warmup: %d", baseline)
+
+	const iterations = 100
+	for range iterations {
+		_, err := httpclient.NewHTTPClientFromRefreshableConfig(context.Background(), config)
+		require.NoError(t, err)
+	}
+
+	forceGCAndCleanup()
+
+	final := updatableSubscriberCount(t, config)
+	growth := final - baseline
+	t.Logf("Final subscriber count: %d (growth from baseline: %d)", final, growth)
+
+	assert.Less(t, growth, 10,
+		"subscriber count grew by %d after discarding %d clients",
+		growth, iterations)
+}
+
+// updatableSubscriberCount uses reflection to read the length of the internal
+// subscribers slice on a defaultRefreshable (the concrete type behind Updatable).
+func updatableSubscriberCount(t *testing.T, updatable any) int {
+	t.Helper()
+	v := reflect.ValueOf(updatable)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	subs := v.FieldByName("subscribers")
+	require.True(t, subs.IsValid(), "could not find subscribers field via reflection")
+	return subs.Len()
+}
+
+// forceGCAndCleanup runs multiple GC cycles with pauses to allow
+// runtime.AddCleanup callbacks to execute and cascade through multi-level
+// derived refreshable chains.
+func forceGCAndCleanup() {
+	for range 20 {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -492,13 +492,19 @@ func Test_NewClientDoesNotLeakGoroutines(t *testing.T) {
 			// add in some slack in case goroutines other than client ones stopped since startNumGoroutines was recorded
 			assert.Greater(t, afterCreateClientsNumGoroutines, startNumGoroutines+mostClients)
 
-			// make clients unreferenced, run GC, and briefly sleep
+			// make clients unreferenced, run GC, and briefly sleep.
+			// Multiple GC cycles are needed because runtime.AddCleanup
+			// callbacks cascade through multi-level derived refreshable
+			// chains: each level must be collected before its cleanup
+			// unsubscribes from the next level up.
 			_ = clients
 			clients = nil
 			_ = clients
 
-			runtime.GC()
-			time.Sleep(50 * time.Millisecond)
+			for range 20 {
+				runtime.GC()
+				time.Sleep(10 * time.Millisecond)
+			}
 
 			afterGCNumGoroutines := runtime.NumGoroutine()
 			t.Log("Goroutines after GC:", afterGCNumGoroutines)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/palantir/pkg/bytesbuffers v1.3.0
 	github.com/palantir/pkg/httpserver v1.2.0
 	github.com/palantir/pkg/metrics v1.10.1
-	github.com/palantir/pkg/refreshable/v2 v2.8.0
+	github.com/palantir/pkg/refreshable/v2 v2.9.0
 	github.com/palantir/pkg/retry v1.3.0
 	github.com/palantir/pkg/safejson v1.2.0
 	github.com/palantir/pkg/tlsconfig v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/palantir/pkg/metrics v1.10.1 h1:NG/TSZIOtdCKS5pXSWhG6Wk2fzZhxa3MuINpQ
 github.com/palantir/pkg/metrics v1.10.1/go.mod h1:etZRED9/ZNlDPR4SAm6tZhyQI0HmAN1ecHf+wR1HaDY=
 github.com/palantir/pkg/objmatcher v1.2.0 h1:cR0IX2NXAhR1hRFBFUwA7y/+m4CtpXUCm5tabqdvS6I=
 github.com/palantir/pkg/objmatcher v1.2.0/go.mod h1:ekDpUDezSoBcD47CUWo9xbYTGycIkiM2ODvxHCUR+lQ=
-github.com/palantir/pkg/refreshable/v2 v2.8.0 h1:5M6PdPxZZ+CqzWpTLMDHj/Kj4IlXJ/uHC3V5hvx2Jtc=
-github.com/palantir/pkg/refreshable/v2 v2.8.0/go.mod h1:0Og1iRoyMOHpjjk5wBuRhgazUbqLTo8KfdqJe1h9+0g=
+github.com/palantir/pkg/refreshable/v2 v2.9.0 h1:cpYShp5h0DNoPEM3lHg+DXN25NYR6HoG66YVaSVT8sE=
+github.com/palantir/pkg/refreshable/v2 v2.9.0/go.mod h1:0Og1iRoyMOHpjjk5wBuRhgazUbqLTo8KfdqJe1h9+0g=
 github.com/palantir/pkg/retry v1.3.0 h1:uHrY3sv4q3XefvVLyqKIK1frXE9ZxtCtNtvijAkwW4k=
 github.com/palantir/pkg/retry v1.3.0/go.mod h1:HzOR3eLw/9PiujskMpjaC6m3uU8fy53s6NszjbmpbOQ=
 github.com/palantir/pkg/rid v1.2.0 h1:sEdklNKk4hrDm0JsUyICYakbc+16GrC6pYxMFjfqXkE=

--- a/vendor/github.com/palantir/pkg/refreshable/v2/derived.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/derived.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package refreshable
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+// derivedRefreshable wraps a Refreshable and ties upstream subscription lifetime
+// to its own GC reachability and active subscriber count via cleanupState.
+//
+// Must be a separate allocation from the inner Refreshable: the inner is
+// typically captured by upstream subscription callbacks, so combining them
+// would create a reference cycle that prevents runtime.AddCleanup from firing.
+//
+// Upstream derived wrappers do NOT need to be kept alive by this wrapper.
+// When an upstream wrapper is collected, its cleanupState.gcDone is set but
+// cleanup is deferred until subCount reaches zero. The subscription callbacks
+// reference the upstream inner (not the wrapper), so updates continue to flow.
+// When the downstream eventually unsubscribes, the deferred cleanup fires and
+// correctly propagates the unsubscribe to the grandparent.
+type derivedRefreshable[T any] struct {
+	inner Refreshable[T]
+	state *cleanupState
+}
+
+func newDerivedRefreshable[T any](inner Refreshable[T], unsubs ...UnsubscribeFunc) *derivedRefreshable[T] {
+	state := &cleanupState{
+		unsubs: unsubs,
+	}
+	d := &derivedRefreshable[T]{
+		inner: inner,
+		state: state,
+	}
+	runtime.AddCleanup(d, (*cleanupState).markGCd, state)
+	return d
+}
+
+func (d *derivedRefreshable[T]) Current() T {
+	return d.inner.Current()
+}
+
+func (d *derivedRefreshable[T]) Subscribe(consumer func(T)) UnsubscribeFunc {
+	d.state.addSubscriber()
+	innerUnsub := d.inner.Subscribe(consumer)
+	state := d.state // capture state not d, so d remains GC-eligible
+	return sync.OnceFunc(func() {
+		innerUnsub()
+		state.removeSubscriber()
+	})
+}
+
+// derivedValidated wraps a Validated with the same GC cleanup semantics as
+// derivedRefreshable. See derivedRefreshable for design rationale.
+type derivedValidated[T any] struct {
+	inner Validated[T]
+	state *cleanupState
+}
+
+func newDerivedValidated[T any](inner Validated[T], unsubs ...UnsubscribeFunc) *derivedValidated[T] {
+	state := &cleanupState{
+		unsubs: unsubs,
+	}
+	d := &derivedValidated[T]{
+		inner: inner,
+		state: state,
+	}
+	runtime.AddCleanup(d, (*cleanupState).markGCd, state)
+	return d
+}
+
+func (d *derivedValidated[T]) Unvalidated() T {
+	return d.inner.Unvalidated()
+}
+
+func (d *derivedValidated[T]) Validation() (T, error) {
+	return d.inner.Validation()
+}
+
+func (d *derivedValidated[T]) SubscribeValidated(consumer func(Validated[T])) UnsubscribeFunc {
+	d.state.addSubscriber()
+	innerUnsub := d.inner.SubscribeValidated(consumer)
+	state := d.state // capture state not d, so d remains GC-eligible
+	return sync.OnceFunc(func() {
+		innerUnsub()
+		state.removeSubscriber()
+	})
+}
+
+// cleanupState coordinates between GC and active subscribers. Upstream
+// unsubscribe functions fire only when the derived wrapper is GC'd AND
+// the subscriber count reaches zero, allowing subscriptions on a derived
+// refreshable to outlive the derived reference itself.
+type cleanupState struct {
+	subCount atomic.Int32      // incremented by Subscribe, decremented by its returned unsub
+	gcDone   atomic.Bool       // set by runtime.AddCleanup callback
+	unsubs   []UnsubscribeFunc // upstream unsubscribe functions
+	once     sync.Once         // ensures cleanup runs exactly once
+}
+
+func (s *cleanupState) addSubscriber() {
+	s.subCount.Add(1)
+}
+
+func (s *cleanupState) removeSubscriber() {
+	s.subCount.Add(-1)
+	s.tryCleanup()
+}
+
+func (s *cleanupState) markGCd() {
+	s.gcDone.Store(true)
+	s.tryCleanup()
+}
+
+func (s *cleanupState) tryCleanup() {
+	if s.gcDone.Load() && s.subCount.Load() <= 0 {
+		s.once.Do(func() {
+			for _, unsub := range s.unsubs {
+				unsub()
+			}
+			// Release references captured by unsub closures so that objects
+			// reachable only through these closures (e.g. transport chains,
+			// upstream inners) become unreachable immediately rather than
+			// waiting for this cleanupState to be garbage collected.
+			s.unsubs = nil
+		})
+	}
+}

--- a/vendor/github.com/palantir/pkg/refreshable/v2/main.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/main.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build module
-// +build module
 
 // This file exists only to smooth the transition for modules. Having this file makes it such that other modules that
 // consume this module will not have import path conflicts caused by github.com/palantir/pkg.

--- a/vendor/github.com/palantir/pkg/refreshable/v2/map_values.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/map_values.go
@@ -7,67 +7,101 @@ package refreshable
 import (
 	"context"
 	"errors"
+	"sync"
 )
 
-// MapValues creates a Validated Refreshable by applying a mapper function to each entry in a map.
-// For each key-value pair in the input map, the mapper function creates a Validated[R] refreshable.
-// The output is a Validated[map[K]R] that aggregates all mapped values.
+// MapValues creates a Validated[map[K]R] by applying mapperFn to each entry of a map Refreshable.
+// When keys are added, mapperFn is called with a per-key context that is cancelled on removal.
+// When any per-key refreshable updates, the output map is rebuilt with aggregated validation errors.
 //
-// When keys are added to the input map, new refreshables are created via the mapper function.
-// When keys are removed, their corresponding refreshables are unsubscribed.
-// When any individual mapped refreshable updates, the output map is rebuilt.
-//
-// Unvalidated() returns a map containing the last valid value for each key.
-// Validation() returns the map and a joined error of all validation failures.
-//
-// This should be used instead of just calling Map on a map[K]V when you need to interject an additional refreshable that can be updated independently
+// Use this instead of Map on a map[K]V when you need per-key refreshables that update independently.
 func MapValues[K comparable, V, R any](
 	ctx context.Context,
 	refreshableMap Refreshable[map[K]V],
 	mapperFn func(context.Context, K, V) Validated[R],
 ) Validated[map[K]R] {
+	type perKey struct {
+		val    Validated[R]
+		unsub  UnsubscribeFunc
+		cancel context.CancelFunc
+	}
+
 	out := newValidRefreshable[map[K]R]()
-	mappedRefreshables := make(map[K]Validated[R])
-	unsubscribers := make(map[K]UnsubscribeFunc)
+	var mu sync.Mutex
+	keys := make(map[K]*perKey)
 
 	updateOutput := func() {
+		mu.Lock()
 		result := make(map[K]R)
 		var errs []error
-		for key, refreshable := range mappedRefreshables {
-			result[key] = refreshable.Unvalidated()
-			if _, err := refreshable.Validation(); err != nil {
+		for k, pk := range keys {
+			result[k] = pk.val.Unvalidated()
+			if _, err := pk.val.Validation(); err != nil {
 				errs = append(errs, err)
 			}
 		}
+		mu.Unlock()
 		joined := errors.Join(errs...)
 		if joined == nil {
-			out.r.Update(validRefreshableContainer[map[K]R]{unvalidated: result, validated: result, lastErr: nil})
+			out.r.Update(validRefreshableContainer[map[K]R]{unvalidated: result, validated: result})
 		} else {
-			out.r.Update(validRefreshableContainer[map[K]R]{unvalidated: result, validated: nil, lastErr: joined})
+			out.r.Update(validRefreshableContainer[map[K]R]{unvalidated: result, lastErr: joined})
 		}
 	}
 
-	refreshableMap.Subscribe(func(currentMap map[K]V) {
-		// Remove keys no longer in the map
-		for key, unsub := range unsubscribers {
-			if _, exists := currentMap[key]; !exists {
-				unsub()
-				delete(unsubscribers, key)
-				delete(mappedRefreshables, key)
+	unsub := refreshableMap.Subscribe(func(currentMap map[K]V) {
+		mu.Lock()
+		var removed []*perKey
+		for k := range keys {
+			if _, ok := currentMap[k]; !ok {
+				removed = append(removed, keys[k])
+				delete(keys, k)
 			}
 		}
-		// Add new keys
-		for key, value := range currentMap {
-			if _, exists := mappedRefreshables[key]; !exists {
-				mapped := mapperFn(ctx, key, value)
-				mappedRefreshables[key] = mapped
-				unsubscribers[key] = mapped.SubscribeValidated(func(Validated[R]) {
-					updateOutput()
-				})
+		type newEntry struct {
+			key K
+			pk  *perKey
+		}
+		var added []newEntry
+		for k, v := range currentMap {
+			if _, ok := keys[k]; !ok {
+				keyCtx, keyCancel := context.WithCancel(ctx)
+				pk := &perKey{val: mapperFn(keyCtx, k, v), cancel: keyCancel}
+				keys[k] = pk
+				added = append(added, newEntry{key: k, pk: pk})
 			}
+		}
+		mu.Unlock()
+
+		// Run outside lock: unsub/cancel may trigger callbacks that call updateOutput,
+		// and SubscribeValidated immediately invokes its callback.
+		for _, pk := range removed {
+			pk.unsub()
+			pk.cancel()
+		}
+		for _, entry := range added {
+			stop := entry.pk.val.SubscribeValidated(func(Validated[R]) { updateOutput() })
+			mu.Lock()
+			entry.pk.unsub = stop
+			mu.Unlock()
 		}
 		updateOutput()
 	})
 
-	return out
+	combinedUnsub := func() {
+		unsub()
+		mu.Lock()
+		all := make([]*perKey, 0, len(keys))
+		for _, pk := range keys {
+			all = append(all, pk)
+		}
+		clear(keys)
+		mu.Unlock()
+		for _, pk := range all {
+			pk.unsub()
+			pk.cancel()
+		}
+	}
+
+	return newDerivedValidated(out, combinedUnsub)
 }

--- a/vendor/github.com/palantir/pkg/refreshable/v2/refreshable.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/refreshable.go
@@ -70,7 +70,13 @@ func New[T any](val T) Updatable[T] {
 func Cached[T any](original Refreshable[T]) (Refreshable[T], UnsubscribeFunc) {
 	out := newZero[T]()
 	stop := original.Subscribe(out.Update)
-	return out.readOnly(), stop
+	return newDerivedRefreshable(out, stop), stop
+}
+
+// CachedAuto is like Cached with automatic GC-based cleanup of the upstream subscription.
+func CachedAuto[T any](original Refreshable[T]) Refreshable[T] {
+	out, _ := Cached(original)
+	return out
 }
 
 // View returns a Refreshable implementation that converts the original Refreshable value to a new value using mapFn.
@@ -91,6 +97,12 @@ func Map[T any, M any](original Refreshable[T], mapFn func(T) M) (Refreshable[M]
 	return Cached(View(original, mapFn))
 }
 
+// MapAuto is like Map with automatic GC-based cleanup of the upstream subscription.
+func MapAuto[T any, M any](original Refreshable[T], mapFn func(T) M) Refreshable[M] {
+	out, _ := Map(original, mapFn)
+	return out
+}
+
 // MapContext is like Map but unsubscribes when the context is cancelled.
 func MapContext[T any, M any](ctx context.Context, original Refreshable[T], mapFn func(T) M) Refreshable[M] {
 	out, stop := Map(original, mapFn)
@@ -103,43 +115,89 @@ func MapContext[T any, M any](ctx context.Context, original Refreshable[T], mapF
 
 // MapWithError is similar to Validate but allows for the function to return a mapping/mutation
 // of the input object in addition to returning an error. The returned validRefreshable will contain the mapped value.
+// The context is passed to the mapFn but is not considered in the subscription lifecycle.
 // An error is returned if the current original value fails to map.
+// The subscription and mapping continue until the UnsubscribeFunc is called or the Validated is garbage-collected.
 func MapWithError[T any, M any](ctx context.Context, original Refreshable[T], mapFn func(context.Context, T) (M, error)) (Validated[M], UnsubscribeFunc, error) {
 	v := newValidRefreshable[M]()
-	stop := subscribeValidRefreshable(ctx, v, validatedFromRefreshable(original), mapFn)
+	intermediate := validatedFromRefreshable(original)
+	stop := subscribeValidRefreshable(ctx, v, intermediate, mapFn)
 	_, err := v.Validation()
-	return v, stop, err
+	return newDerivedValidated(v, stop), stop, err
+}
+
+// MapWithErrorAuto is like MapWithError with automatic GC-based cleanup of the upstream subscription.
+func MapWithErrorAuto[T any, M any](ctx context.Context, original Refreshable[T], mapFn func(context.Context, T) (M, error)) (Validated[M], error) {
+	out, _, err := MapWithError(ctx, original, mapFn)
+	return out, err
 }
 
 // Validate returns a new Refreshable that returns the latest original value accepted by the validatingFn.
+// The context is passed to the validatingFn but is not considered in the subscription lifecycle.
 // If the upstream value results in an error, it is reported by Validation().
 // An error is returned if the current original value is invalid.
+// The subscription and mapping continue until the UnsubscribeFunc is called or the Validated is garbage-collected.
 func Validate[T any](ctx context.Context, original Refreshable[T], validatingFn func(context.Context, T) error) (Validated[T], UnsubscribeFunc, error) {
 	return MapWithError(ctx, original, identity(validatingFn))
 }
 
+// ValidateAuto is like Validate with automatic GC-based cleanup of the upstream subscription.
+func ValidateAuto[T any](ctx context.Context, original Refreshable[T], validatingFn func(context.Context, T) error) (Validated[T], error) {
+	out, _, err := Validate(ctx, original, validatingFn)
+	return out, err
+}
+
 // Merge returns a new Refreshable that combines the latest values of two Refreshables of different types using the mergeFn.
 // The returned Refreshable is updated whenever either of the original Refreshables updates.
-// The unsubscribe function removes subscriptions from both original Refreshables.
 func Merge[T1 any, T2 any, R any](original1 Refreshable[T1], original2 Refreshable[T2], mergeFn func(T1, T2) R) (Refreshable[R], UnsubscribeFunc) {
 	out := newZero[R]()
+	// Subscriber callbacks push latest values into shared state so doUpdate
+	// does not capture any Refreshable interface values. This avoids reference
+	// cycles between derivedRefreshable wrappers and upstream subscriber lists
+	// that would prevent runtime.AddCleanup from firing.
+	var mu sync.Mutex
+	val1 := original1.Current()
+	val2 := original2.Current()
 	doUpdate := func() {
-		out.Update(mergeFn(original1.Current(), original2.Current()))
+		// mu must be held by caller.
+		out.Update(mergeFn(val1, val2))
 	}
-	stop1 := original1.Subscribe(func(T1) { doUpdate() })
-	stop2 := original2.Subscribe(func(T2) { doUpdate() })
-	return out.readOnly(), func() {
+	stop1 := original1.Subscribe(func(v T1) {
+		mu.Lock()
+		defer mu.Unlock()
+		val1 = v
+		doUpdate()
+	})
+	stop2 := original2.Subscribe(func(v T2) {
+		mu.Lock()
+		defer mu.Unlock()
+		val2 = v
+		doUpdate()
+	})
+	combined := func() {
 		stop1()
 		stop2()
 	}
+	return newDerivedRefreshable(out, combined), combined
+}
+
+// MergeAuto is like Merge with automatic GC-based cleanup of the upstream subscriptions.
+func MergeAuto[T1 any, T2 any, R any](original1 Refreshable[T1], original2 Refreshable[T2], mergeFn func(T1, T2) R) Refreshable[R] {
+	out, _ := Merge(original1, original2, mergeFn)
+	return out
 }
 
 // Collect returns a new Refreshable that combines the latest values of multiple Refreshables into a slice.
 // The returned Refreshable is updated whenever any of the original Refreshables updates.
-// The unsubscribe function removes subscriptions from all original Refreshables.
 func Collect[T any](list ...Refreshable[T]) (Refreshable[[]T], UnsubscribeFunc) {
 	out, _, unsub := CollectMutable(list...)
 	return out, unsub
+}
+
+// CollectAuto is like Collect with automatic GC-based cleanup of the upstream subscriptions.
+func CollectAuto[T any](list ...Refreshable[T]) Refreshable[[]T] {
+	out, _ := Collect(list...)
+	return out
 }
 
 // AddFunc is a function that adds a new Refreshable to a collection.
@@ -151,37 +209,53 @@ type AddFunc[T any] func(Refreshable[T])
 // The unsubscribe function removes subscriptions from all Refreshables in the collection.
 func CollectMutable[T any](list ...Refreshable[T]) (Refreshable[[]T], AddFunc[T], UnsubscribeFunc) {
 	out := newZero[[]T]()
-	var mu sync.RWMutex
-	refreshables := make([]Refreshable[T], len(list))
-	copy(refreshables, list)
+	// Subscriber callbacks push latest values into a parallel slice so doUpdate
+	// does not capture any Refreshable interface values. This avoids reference
+	// cycles between derivedRefreshable wrappers and upstream subscriber lists
+	// that would prevent runtime.AddCleanup from firing.
+	var mu sync.Mutex
+	vals := make([]T, len(list))
+	for i, r := range list {
+		vals[i] = r.Current()
+	}
 	stops := make([]UnsubscribeFunc, 0, len(list))
 	doUpdate := func() {
-		mu.RLock()
-		current := make([]T, len(refreshables))
-		for i := range refreshables {
-			current[i] = refreshables[i].Current()
-		}
-		mu.RUnlock()
+		// mu must be held by caller.
+		current := make([]T, len(vals))
+		copy(current, vals)
 		out.Update(current)
 	}
-	for _, r := range refreshables {
-		stops = append(stops, r.Subscribe(func(T) { doUpdate() }))
+	for i, r := range list {
+		idx := i
+		stops = append(stops, r.Subscribe(func(v T) {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[idx] = v
+			doUpdate()
+		}))
 	}
 	add := func(r Refreshable[T]) {
 		mu.Lock()
-		refreshables = append(refreshables, r)
+		vals = append(vals, r.Current())
+		idx := len(vals) - 1
 		mu.Unlock()
-		// Subscribe outside of lock since it immediately invokes the callback
-		stop := r.Subscribe(func(T) { doUpdate() })
+		// Subscribe outside of lock since it immediately invokes the callback.
+		stop := r.Subscribe(func(v T) {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[idx] = v
+			doUpdate()
+		})
 		mu.Lock()
 		stops = append(stops, stop)
 		mu.Unlock()
 	}
-	return out.readOnly(), add, func() {
+	combined := func() {
 		mu.Lock()
 		defer mu.Unlock()
 		for _, stop := range stops {
 			stop()
 		}
 	}
+	return newDerivedRefreshable(out, combined), add, combined
 }

--- a/vendor/github.com/palantir/pkg/refreshable/v2/refreshable_default.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/refreshable_default.go
@@ -6,13 +6,14 @@ package refreshable
 
 import (
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 )
 
 type defaultRefreshable[T any] struct {
 	mux         sync.Mutex
-	current     atomic.Value
+	current     atomic.Pointer[T]
 	subscribers []*func(T)
 }
 
@@ -31,7 +32,7 @@ func (d *defaultRefreshable[T]) Update(val T) {
 	d.mux.Lock()
 	defer d.mux.Unlock()
 	old := d.current.Swap(&val)
-	if reflect.DeepEqual(*(old.(*T)), val) {
+	if reflect.DeepEqual(*old, val) {
 		return
 	}
 	for _, sub := range d.subscribers {
@@ -40,7 +41,7 @@ func (d *defaultRefreshable[T]) Update(val T) {
 }
 
 func (d *defaultRefreshable[T]) Current() T {
-	return *(d.current.Load().(*T))
+	return *d.current.Load()
 }
 
 func (d *defaultRefreshable[T]) Subscribe(consumer func(T)) UnsubscribeFunc {
@@ -66,25 +67,9 @@ func (d *defaultRefreshable[T]) unsubscribe(consumerFnPtr *func(T)) UnsubscribeF
 			}
 		}
 		if matchIdx != -1 {
-			d.subscribers = append(d.subscribers[:matchIdx], d.subscribers[matchIdx+1:]...)
+			d.subscribers = slices.Delete(d.subscribers, matchIdx, matchIdx+1)
 		}
 	}
-}
-
-func (d *defaultRefreshable[T]) readOnly() *readOnlyRefreshable[T] {
-	return (*readOnlyRefreshable[T])(d)
-}
-
-// readOnlyRefreshable aliases defaultRefreshable but hides the Update method so the type
-// does not implement Updatable.
-type readOnlyRefreshable[T any] defaultRefreshable[T]
-
-func (d *readOnlyRefreshable[T]) Current() T {
-	return (*defaultRefreshable[T])(d).Current()
-}
-
-func (d *readOnlyRefreshable[T]) Subscribe(consumer func(T)) UnsubscribeFunc {
-	return (*defaultRefreshable[T])(d).Subscribe(consumer)
 }
 
 // mapperRefreshable wraps an existing Refreshable and applies a mapping function to its values.
@@ -100,5 +85,8 @@ func (d mapperRefreshable[S, T]) Current() T {
 }
 
 func (d mapperRefreshable[S, T]) Subscribe(consumer func(T)) UnsubscribeFunc {
-	return d.base.Subscribe(func(value S) { consumer(d.mapper(value)) })
+	// Extract mapper to avoid capturing d.base in the closure, which would
+	// prevent GC cleanup of upstream derived wrappers in Map chains.
+	mapper := d.mapper
+	return d.base.Subscribe(func(value S) { consumer(mapper(value)) })
 }

--- a/vendor/github.com/palantir/pkg/refreshable/v2/refreshable_ticker.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/refreshable_ticker.go
@@ -36,11 +36,13 @@ func NewRefreshableTickerWithDuration[M any](ctx context.Context, a time.Duratio
 // NewRefreshableTicker returns a [Validated] refreshable whose current value is read using the provided readerFunc.
 // The readerFunc is only called when the [ChangeDetector] indicates the data source has changed.
 // The detector's MarkUpdated is called after each successful read.
-// The readerFunc is called once initially and then on each tick (subject to the detector) until the context is cancelled.
+// The readerFunc is called once initially and then on each tick (subject to the detector) until the context is
+// cancelled or the returned Validated is garbage collected.
 // If reading fails, the Unvalidated() value will be unchanged. The error is present in v.Validation().
 func NewRefreshableTicker[M any](ctx context.Context, updateTicker <-chan time.Time, readerFunc func(context.Context) (M, error), detector ChangeDetector) Validated[M] {
+	tickCtx, tickCancel := context.WithCancel(ctx)
 	v := newValidRefreshable[M]()
-	updateValidRefreshable(ctx, v, readerFunc)
+	updateValidRefreshable(tickCtx, v, readerFunc)
 	if _, err := v.Validation(); err == nil {
 		detector.MarkUpdated()
 	}
@@ -48,17 +50,17 @@ func NewRefreshableTicker[M any](ctx context.Context, updateTicker <-chan time.T
 		for {
 			select {
 			case <-updateTicker:
-				if !detector.ShouldUpdate(ctx) {
+				if !detector.ShouldUpdate(tickCtx) {
 					continue
 				}
-				updateValidRefreshable(ctx, v, readerFunc)
+				updateValidRefreshable(tickCtx, v, readerFunc)
 				if _, err := v.Validation(); err == nil {
 					detector.MarkUpdated()
 				}
-			case <-ctx.Done():
+			case <-tickCtx.Done():
 				return
 			}
 		}
 	}()
-	return v
+	return newDerivedValidated(v, UnsubscribeFunc(tickCancel))
 }

--- a/vendor/github.com/palantir/pkg/refreshable/v2/refreshable_validating.go
+++ b/vendor/github.com/palantir/pkg/refreshable/v2/refreshable_validating.go
@@ -96,14 +96,14 @@ func validatedFromRefreshable[M any](original Refreshable[M]) Validated[M] {
 	valid := &validRefreshable[M]{
 		r: newDefault(validRefreshableContainer[M]{}),
 	}
-	original.Subscribe(func(m M) {
+	unsub := original.Subscribe(func(m M) {
 		valid.r.Update(validRefreshableContainer[M]{
 			unvalidated: m,
 			validated:   m,
 			lastErr:     nil,
 		})
 	})
-	return valid
+	return newDerivedValidated(valid, unsub)
 }
 
 // MapFromValidated returns a new Refreshable by applying mapFn to the most recent
@@ -113,7 +113,13 @@ func MapFromValidated[T any, M any](original Validated[T], mapFn func(T) M) (Ref
 	stop := original.SubscribeValidated(func(v Validated[T]) {
 		out.Update(mapFn(v.Unvalidated()))
 	})
-	return out.readOnly(), stop
+	return newDerivedRefreshable(out, stop), stop
+}
+
+// MapFromValidatedAuto is like MapFromValidated with automatic GC-based cleanup of the upstream subscription.
+func MapFromValidatedAuto[T any, M any](original Validated[T], mapFn func(T) M) Refreshable[M] {
+	out, _ := MapFromValidated(original, mapFn)
+	return out
 }
 
 // MapFromValidatedChecked is identical to MapFromValidated but first checks if the
@@ -126,12 +132,29 @@ func MapFromValidatedChecked[T any, M any](original Validated[T], mapFn func(T) 
 	return out, stop, nil
 }
 
+// MapFromValidatedCheckedAuto is like MapFromValidatedChecked with automatic GC-based cleanup of the upstream subscription.
+func MapFromValidatedCheckedAuto[T any, M any](original Validated[T], mapFn func(T) M) (Refreshable[M], error) {
+	if _, err := original.Validation(); err != nil {
+		return nil, err
+	}
+	return MapFromValidatedAuto(original, mapFn), nil
+}
+
 // MapValidated returns a new Validated based on the current one that handles updates based on the current Validated.
+// The context is passed to the mapFn but is not considered in the subscription lifecycle.
+// An error is returned if the current original value fails to map.
+// The subscription and mapping continue until the UnsubscribeFunc is called or the Validated is garbage-collected.
 func MapValidated[T any, M any](ctx context.Context, original Validated[T], mapFn func(context.Context, T) (M, error)) (Validated[M], UnsubscribeFunc, error) {
 	v := newValidRefreshable[M]()
 	stop := subscribeValidRefreshable(ctx, v, original, mapFn)
 	_, err := v.Validation()
-	return v, stop, err
+	return newDerivedValidated(v, stop), stop, err
+}
+
+// MapValidatedAuto is like MapValidated with automatic GC-based cleanup of the upstream subscription.
+func MapValidatedAuto[T any, M any](ctx context.Context, original Validated[T], mapFn func(context.Context, T) (M, error)) (Validated[M], error) {
+	out, _, err := MapValidated(ctx, original, mapFn)
+	return out, err
 }
 
 // ValidatedAddFunc is a function that adds a new Validated to a collection.
@@ -139,10 +162,15 @@ type ValidatedAddFunc[T any] func(Validated[T])
 
 // CollectValidated returns a new Validated that combines the latest values of multiple Validated refreshables into a slice.
 // The returned Validated is updated whenever any of the original Validated refreshables updates.
-// The unsubscribe function removes subscriptions from all original Validated refreshables.
 func CollectValidated[T any](list ...Validated[T]) (Validated[[]T], UnsubscribeFunc) {
 	out, _, unsub := CollectValidatedMutable(list...)
 	return out, unsub
+}
+
+// CollectValidatedAuto is like CollectValidated with automatic GC-based cleanup of the upstream subscriptions.
+func CollectValidatedAuto[T any](list ...Validated[T]) Validated[[]T] {
+	out, _ := CollectValidated(list...)
+	return out
 }
 
 // CollectValidatedMutable returns a new Validated that combines the latest values of multiple Validated refreshables into a slice.
@@ -151,21 +179,28 @@ func CollectValidated[T any](list ...Validated[T]) (Validated[[]T], UnsubscribeF
 // The unsubscribe function removes subscriptions from all Validated refreshables in the collection.
 func CollectValidatedMutable[T any](list ...Validated[T]) (Validated[[]T], ValidatedAddFunc[T], UnsubscribeFunc) {
 	out := newValidRefreshable[[]T]()
-	var mu sync.RWMutex
-	validateds := make([]Validated[T], len(list))
-	copy(validateds, list)
+	// Subscriber callbacks push latest values into parallel slices so doUpdate
+	// does not capture any Validated interface values. This avoids reference
+	// cycles between derivedValidated wrappers and upstream subscriber lists
+	// that would prevent runtime.AddCleanup from firing.
+	var mu sync.Mutex
+	vals := make([]T, len(list))
+	valErrs := make([]error, len(list))
+	for i, r := range list {
+		vals[i] = r.Unvalidated()
+		_, valErrs[i] = r.Validation()
+	}
 	stops := make([]UnsubscribeFunc, 0, len(list))
 	doUpdate := func() {
-		mu.RLock()
-		current := make([]T, len(validateds))
+		// mu must be held by caller.
+		current := make([]T, len(vals))
+		copy(current, vals)
 		var errs []error
-		for i := range validateds {
-			current[i] = validateds[i].Unvalidated()
-			if _, err := validateds[i].Validation(); err != nil {
+		for _, err := range valErrs {
+			if err != nil {
 				errs = append(errs, err)
 			}
 		}
-		mu.RUnlock()
 		joined := errors.Join(errs...)
 		if joined == nil {
 			out.r.Update(validRefreshableContainer[[]T]{unvalidated: current, validated: current, lastErr: nil})
@@ -173,36 +208,60 @@ func CollectValidatedMutable[T any](list ...Validated[T]) (Validated[[]T], Valid
 			out.r.Update(validRefreshableContainer[[]T]{unvalidated: current, validated: nil, lastErr: joined})
 		}
 	}
-	for _, r := range validateds {
-		stops = append(stops, r.SubscribeValidated(func(Validated[T]) { doUpdate() }))
+	for i, r := range list {
+		idx := i
+		stops = append(stops, r.SubscribeValidated(func(v Validated[T]) {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[idx] = v.Unvalidated()
+			_, valErrs[idx] = v.Validation()
+			doUpdate()
+		}))
 	}
 	add := func(r Validated[T]) {
 		mu.Lock()
-		validateds = append(validateds, r)
+		_, validErr := r.Validation()
+		vals = append(vals, r.Unvalidated())
+		valErrs = append(valErrs, validErr)
+		idx := len(vals) - 1
 		mu.Unlock()
-		// Subscribe outside of lock since it immediately invokes the callback
-		stop := r.SubscribeValidated(func(Validated[T]) { doUpdate() })
+		// Subscribe outside of lock since it immediately invokes the callback.
+		stop := r.SubscribeValidated(func(v Validated[T]) {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[idx] = v.Unvalidated()
+			_, valErrs[idx] = v.Validation()
+			doUpdate()
+		})
 		mu.Lock()
 		stops = append(stops, stop)
 		mu.Unlock()
 	}
-	return out, add, func() {
+	combined := func() {
 		mu.Lock()
 		defer mu.Unlock()
 		for _, stop := range stops {
 			stop()
 		}
 	}
+	return newDerivedValidated(out, combined), add, combined
 }
 
 // MergeValidated returns a new Validated that combines the latest values of two Validated refreshables using the mergeFn.
-// The returned Validated is updated whenever either of the original Validated refreshables updates.
 func MergeValidated[T1 any, T2 any, R any](original1 Validated[T1], original2 Validated[T2], mergeFn func(T1, T2) R) (Validated[R], UnsubscribeFunc) {
 	out := newValidRefreshable[R]()
+	// Subscriber callbacks push latest values into shared state so doUpdate
+	// does not capture any Validated interface values. This avoids reference
+	// cycles between derivedValidated wrappers and upstream subscriber lists
+	// that would prevent runtime.AddCleanup from firing.
+	var mu sync.Mutex
+	val1 := original1.Unvalidated()
+	val2 := original2.Unvalidated()
+	_, err1 := original1.Validation()
+	_, err2 := original2.Validation()
 	doUpdate := func() {
-		merged := mergeFn(original1.Unvalidated(), original2.Unvalidated())
-		_, err1 := original1.Validation()
-		_, err2 := original2.Validation()
+		// mu must be held by caller.
+		merged := mergeFn(val1, val2)
 		err := getError(err1, err2)
 		if err == nil {
 			out.r.Update(validRefreshableContainer[R]{unvalidated: merged, validated: merged, lastErr: nil})
@@ -211,25 +270,58 @@ func MergeValidated[T1 any, T2 any, R any](original1 Validated[T1], original2 Va
 			out.r.Update(validRefreshableContainer[R]{unvalidated: merged, validated: zero, lastErr: err})
 		}
 	}
-	stop1 := original1.SubscribeValidated(func(Validated[T1]) { doUpdate() })
-	stop2 := original2.SubscribeValidated(func(Validated[T2]) { doUpdate() })
-	return out, func() {
+	stop1 := original1.SubscribeValidated(func(v Validated[T1]) {
+		mu.Lock()
+		defer mu.Unlock()
+		val1 = v.Unvalidated()
+		_, err1 = v.Validation()
+		doUpdate()
+	})
+	stop2 := original2.SubscribeValidated(func(v Validated[T2]) {
+		mu.Lock()
+		defer mu.Unlock()
+		val2 = v.Unvalidated()
+		_, err2 = v.Validation()
+		doUpdate()
+	})
+	combined := func() {
 		stop1()
 		stop2()
 	}
+	return newDerivedValidated(out, combined), combined
+}
+
+// MergeValidatedAuto is like MergeValidated with automatic GC-based cleanup of the upstream subscriptions.
+func MergeValidatedAuto[T1 any, T2 any, R any](original1 Validated[T1], original2 Validated[T2], mergeFn func(T1, T2) R) Validated[R] {
+	out, _ := MergeValidated(original1, original2, mergeFn)
+	return out
 }
 
 // MergeValidatedAndRefreshable returns a new Validated that combines the latest values of a Validated
 // and a plain Refreshable using the mergeFn. The Refreshable is wrapped with an always-valid Validate
 // so that only errors from the Validated source propagate. The returned Validated is updated whenever
 // either source updates.
+// The context is used internally to wrap the Refreshable as a Validated but does not affect the subscription lifecycle.
+// The subscription and mapping continue until the UnsubscribeFunc is called or the Validated is garbage-collected.
 func MergeValidatedAndRefreshable[T1 any, T2 any, R any](
 	ctx context.Context,
 	original1 Validated[T1],
 	refreshable1 Refreshable[T2],
-	mergeFn func(T1, T2) R) (Validated[R], UnsubscribeFunc) {
+	mergeFn func(T1, T2) R,
+) (Validated[R], UnsubscribeFunc) {
 	original2, _, _ := Validate(ctx, refreshable1, func(ctx context.Context, i T2) error {
 		return nil
 	})
 	return MergeValidated(original1, original2, mergeFn)
+}
+
+// MergeValidatedAndRefreshableAuto is like MergeValidatedAndRefreshable with automatic GC-based cleanup of the upstream subscriptions.
+func MergeValidatedAndRefreshableAuto[T1 any, T2 any, R any](
+	ctx context.Context,
+	original1 Validated[T1],
+	refreshable1 Refreshable[T2],
+	mergeFn func(T1, T2) R,
+) Validated[R] {
+	out, _ := MergeValidatedAndRefreshable(ctx, original1, refreshable1, mergeFn)
+	return out
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,7 +28,7 @@ github.com/palantir/pkg/httpserver
 # github.com/palantir/pkg/metrics v1.10.1
 ## explicit; go 1.25.0
 github.com/palantir/pkg/metrics
-# github.com/palantir/pkg/refreshable/v2 v2.8.0
+# github.com/palantir/pkg/refreshable/v2 v2.9.0
 ## explicit; go 1.25.0
 github.com/palantir/pkg/refreshable/v2
 # github.com/palantir/pkg/retry v1.3.0


### PR DESCRIPTION
Each call to NewClientFromRefreshableConfig creates a chain of derived refreshables that subscribe to the root config. Previously, discarding the returned client leaked these subscriptions because nothing unsubscribed them, causing unbounded memory growth in services that create clients dynamically.

Two changes fix this:

1. Bump refreshable/v2 to a version that uses runtime.AddCleanup to automatically unsubscribe derived refreshables when they become unreachable. Derived wrappers (Map, MapWithError, Collect, etc.) now return a derivedRefreshable/derivedValidated that ties upstream subscription lifetime to GC reachability.

2. Avoid capturing *clientBuilder and validParams in closures that outlive client construction. Capturing these kept the entire derived refreshable chain reachable from the root config's subscriber list, preventing runtime.AddCleanup from firing. Extract URIScorerBuilder into a local variable and create an intermediate refreshable for MetricsTags instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure-go-runtime/905)
<!-- Reviewable:end -->
