### PR TITLE
add httpclient.WithTLSCertKeyBytes param

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -76,7 +76,8 @@ type httpClientBuilder struct {
 	DialerParams    refreshable.Refreshable[refreshingclient.DialerParams]
 	TLSConfig       *tls.Config // If unset, config in TransportParams will be used.
 	TransportParams refreshable.Refreshable[refreshingclient.TransportParams]
-	TLSCABytes      refreshable.Refreshable[[][]byte] // Optional refreshable CA bytes to combine with TLSParams.
+	TLSCABytes      refreshable.Refreshable[[][]byte]          // Optional refreshable CA bytes to combine with TLSParams.
+	TLSCertKeyBytes refreshable.Refreshable[CertKeyPairBytes] // Optional refreshable cert+key bytes to combine with TLSParams.
 	Middlewares     []Middleware
 
 	DisableMetrics      refreshable.Refreshable[bool]
@@ -156,6 +157,13 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 			for _, caByteSlice := range caByteSlices {
 				tlsParams.CABytes = append(tlsParams.CABytes, caByteSlice)
 			}
+			return tlsParams
+		})
+	}
+	if b.TLSCertKeyBytes != nil {
+		tlsParams, _ = refreshable.MergeValidatedAndRefreshable(ctx, tlsParams, b.TLSCertKeyBytes, func(tlsParams refreshingclient.TLSParams, certKey CertKeyPairBytes) refreshingclient.TLSParams {
+			tlsParams.CertBytes = certKey.CertBytes
+			tlsParams.KeyBytes = certKey.KeyBytes
 			return tlsParams
 		})
 	}

--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -76,7 +76,7 @@ type httpClientBuilder struct {
 	DialerParams    refreshable.Refreshable[refreshingclient.DialerParams]
 	TLSConfig       *tls.Config // If unset, config in TransportParams will be used.
 	TransportParams refreshable.Refreshable[refreshingclient.TransportParams]
-	TLSCABytes      refreshable.Refreshable[[][]byte]          // Optional refreshable CA bytes to combine with TLSParams.
+	TLSCABytes      refreshable.Refreshable[[][]byte]         // Optional refreshable CA bytes to combine with TLSParams.
 	TLSCertKeyBytes refreshable.Refreshable[CertKeyPairBytes] // Optional refreshable cert+key bytes to combine with TLSParams.
 	Middlewares     []Middleware
 

--- a/conjure-go-client/httpclient/client_builder_test.go
+++ b/conjure-go-client/httpclient/client_builder_test.go
@@ -340,6 +340,89 @@ func TestCABytesAndCAFileCombined(t *testing.T) {
 	}, time.Second*2, time.Millisecond*100)
 }
 
+func TestCertKeyBytesRefreshable(t *testing.T) {
+	// Generate initial client cert+key PEM bytes
+	certPEM1, keyPEM1 := generateTestCertKeyPEM(t, 1, "Test Client Cert")
+	certKeyRefreshable := refreshable.New(httpclient.CertKeyPairBytes{
+		CertBytes: certPEM1,
+		KeyBytes:  keyPEM1,
+	})
+
+	// Track unique cert subjects captured during requests
+	capturedSubjects1 := make(map[string]struct{})
+	certKeyCapturingMiddleware1 := newCertKeyCapturingMiddleware(&capturedSubjects1)
+	capturedSubjects2 := make(map[string]struct{})
+	certKeyCapturingMiddleware2 := newCertKeyCapturingMiddleware(&capturedSubjects2)
+
+	cfg := httpclient.ClientConfig{
+		ServiceName:   "test-service",
+		MaxNumRetries: new(0),
+		URIs:          []string{"https://test-service"},
+	}
+	clientConfigRefreshable := refreshable.New(cfg)
+	client1, err := httpclient.NewClientFromRefreshableConfig(
+		context.Background(),
+		clientConfigRefreshable,
+		httpclient.WithMiddleware(certKeyCapturingMiddleware1),
+		httpclient.WithTLSCertKeyBytes(certKeyRefreshable),
+	)
+	require.NoError(t, err)
+	client2, err := httpclient.NewClient(
+		httpclient.WithConfig(cfg),
+		httpclient.WithMiddleware(certKeyCapturingMiddleware2),
+		httpclient.WithTLSCertKeyBytes(certKeyRefreshable),
+	)
+	require.NoError(t, err)
+
+	// Ensure the initial client cert is loaded
+	_, err = client1.Delete(context.Background())
+	assert.Error(t, err)
+	assert.True(t, containsAllKeys(capturedSubjects1, []string{"Test Client Cert"}))
+	_, err = client2.Delete(context.Background())
+	assert.Error(t, err)
+	assert.True(t, containsAllKeys(capturedSubjects2, []string{"Test Client Cert"}))
+
+	// Update cert+key bytes and verify it refreshes
+	capturedSubjects1 = make(map[string]struct{})
+	capturedSubjects2 = make(map[string]struct{})
+	certPEM2, keyPEM2 := generateTestCertKeyPEM(t, 2, "New Client Cert")
+	certKeyRefreshable.Update(httpclient.CertKeyPairBytes{
+		CertBytes: certPEM2,
+		KeyBytes:  keyPEM2,
+	})
+	// Re-Check
+	assert.Eventually(t, func() bool {
+		capturedSubjects1 = make(map[string]struct{})
+		_, err = client1.Delete(context.Background())
+		assert.Error(t, err)
+		return containsAllKeys(capturedSubjects1, []string{"New Client Cert"})
+	}, time.Second*2, time.Millisecond*100)
+	assert.Eventually(t, func() bool {
+		capturedSubjects2 = make(map[string]struct{})
+		_, err = client2.Delete(context.Background())
+		assert.Error(t, err)
+		return containsAllKeys(capturedSubjects2, []string{"New Client Cert"})
+	}, time.Second*2, time.Millisecond*100)
+}
+
+func newCertKeyCapturingMiddleware(capturedSubjects *map[string]struct{}) httpclient.MiddlewareFunc {
+	return func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+		transport := unwrapTransport(next)
+		if transport.TLSClientConfig != nil && transport.TLSClientConfig.GetClientCertificate != nil {
+			cert, err := transport.TLSClientConfig.GetClientCertificate(nil)
+			if err == nil && len(cert.Certificate) > 0 {
+				x509Cert, parseErr := x509.ParseCertificate(cert.Certificate[0])
+				if parseErr == nil {
+					for _, org := range x509Cert.Subject.Organization {
+						(*capturedSubjects)[org] = struct{}{}
+					}
+				}
+			}
+		}
+		return next.RoundTrip(req)
+	}
+}
+
 func newTLSCapturingMiddleware(capturedSubjects *map[string]struct{}) httpclient.MiddlewareFunc {
 	return func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
 		transport := unwrapTransport(next)
@@ -461,6 +544,27 @@ func generateTestCACertPEM(t *testing.T, serialNumber int64, orgName string) []b
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func generateTestCertKeyPEM(t *testing.T, serialNumber int64, orgName string) (certPEM []byte, keyPEM []byte) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(serialNumber),
+		Subject: pkix.Name{
+			Organization: []string{orgName},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
 }
 
 // Test_NewClientDoesNotLeakGoroutines verifies that the clients returned by httpclient.NewClient and

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -122,12 +122,29 @@ func WithMiddleware(h Middleware) ClientOrHTTPClientParam {
 	})
 }
 
+// CertKeyPairBytes contains PEM-encoded TLS certificate and private key bytes.
+type CertKeyPairBytes struct {
+	CertBytes []byte
+	KeyBytes  []byte
+}
+
 // WithTLSCABytes sets the root CA certificates for the HTTP client's TLS config using a refreshable
 // source of PEM-encoded bytes. The TLS configuration will be rebuilt whenever the refreshable updates.
 // This is useful when the CA certificates are available in memory rather than on disk and may change over time.
 func WithTLSCABytes(caBytes refreshable.Refreshable[[][]byte]) ClientOrHTTPClientParam {
 	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
 		b.TLSCABytes = caBytes
+		return nil
+	})
+}
+
+// WithTLSCertKeyBytes sets the client TLS certificate and private key for the HTTP client's TLS config
+// using a refreshable source of PEM-encoded bytes. The TLS configuration will be rebuilt whenever the
+// refreshable updates. This is useful when the certificate and key are available in memory rather than
+// on disk and may change over time. When set, this takes precedence over WithKeyAndCertFile.
+func WithTLSCertKeyBytes(certKeyBytes refreshable.Refreshable[CertKeyPairBytes]) ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TLSCertKeyBytes = certKeyBytes
 		return nil
 	})
 }

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -30,6 +30,8 @@ type TLSParams struct {
 	CABytes            [][]byte
 	CertFile           string
 	KeyFile            string
+	CertBytes          []byte
+	KeyBytes           []byte
 	InsecureSkipVerify bool
 }
 
@@ -66,7 +68,13 @@ func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 		}
 		tlsParams = append(tlsParams, tlsconfig.ClientRootCAs(tlsconfig.AugmentCertPoolWithCertPoolOptions(certPool, certPoolOptions)))
 	}
-	if p.CertFile != "" && p.KeyFile != "" {
+	if len(p.CertBytes) > 0 && len(p.KeyBytes) > 0 {
+		certBytes := p.CertBytes
+		keyBytes := p.KeyBytes
+		tlsParams = append(tlsParams, tlsconfig.ClientKeyPair(func() (tls.Certificate, error) {
+			return tls.X509KeyPair(certBytes, keyBytes)
+		}))
+	} else if p.CertFile != "" && p.KeyFile != "" {
 		tlsParams = append(tlsParams, tlsconfig.ClientKeyPairFiles(p.CertFile, p.KeyFile))
 	}
 	if p.InsecureSkipVerify {


### PR DESCRIPTION

There are already httpclient builder params that allow callers to provide refreshable CA bytes; this adds similar support for providing a refreshable cert+key pair.