### PR TITLE
Add opt-in DynamicCertReload for TLS client certificates

### DIFF
--- a/conjure-go-client/httpclient/client_builder.go
+++ b/conjure-go-client/httpclient/client_builder.go
@@ -149,6 +149,7 @@ func (b *httpClientBuilder) getRefreshableTLSConfig(ctx context.Context) (refres
 			CertFile:           t1.TLSConfigurationParams.CertFile,
 			KeyFile:            t1.TLSConfigurationParams.KeyFile,
 			InsecureSkipVerify: t1.TLSConfigurationParams.InsecureSkipVerify,
+			DynamicCertReload:  t1.TLSConfigurationParams.DynamicCertReload,
 		}
 	})
 	if b.TLSCABytes != nil {

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -421,6 +421,20 @@ func WithKeyAndCertFile(keyFile string, certFile string) ClientOrHTTPClientParam
 	})
 }
 
+// WithDynamicCertReload enables re-reading client TLS cert/key files on each TLS handshake.
+// By default, client certificates are loaded once at client creation time. When this option is
+// enabled, the cert and key files are re-read from disk on every TLS handshake, allowing the
+// client to pick up rotated certificates without restarting.
+func WithDynamicCertReload() ClientOrHTTPClientParam {
+	return clientOrHTTPClientParamFunc(func(b *httpClientBuilder) error {
+		b.TransportParams = refreshable.View(b.TransportParams, func(p refreshingclient.TransportParams) refreshingclient.TransportParams {
+			p.TLSConfigurationParams.DynamicCertReload = true
+			return p
+		})
+		return nil
+	})
+}
+
 // WithCAFiles sets the CA certificate file paths for the client's TLS configuration.
 // The files are read when the client is created and periodically refreshed to support certificate rotation.
 func WithCAFiles(CAFiles []string) ClientOrHTTPClientParam {

--- a/conjure-go-client/httpclient/config.go
+++ b/conjure-go-client/httpclient/config.go
@@ -137,6 +137,10 @@ type SecurityConfig struct {
 	// InsecureSkipVerify sets the InsecureSkipVerify field for the HTTP client's tls config.
 	// This option should only be used in clients that have other ways to establish trust with servers.
 	InsecureSkipVerify *bool `json:"insecure-skip-verify,omitempty" yaml:"insecure-skip-verify,omitempty"`
+
+	// DynamicCertReload enables re-reading client TLS cert/key files on each TLS handshake.
+	// When enabled, rotated certificates are picked up without restarting the process.
+	DynamicCertReload *bool `json:"dynamic-cert-reload,omitempty" yaml:"dynamic-cert-reload,omitempty"`
 }
 
 // MustClientConfig returns an error if the service name is not configured.
@@ -253,6 +257,9 @@ func MergeClientConfig(conf, defaults ClientConfig) ClientConfig {
 	}
 	if conf.Security.InsecureSkipVerify == nil {
 		conf.Security.InsecureSkipVerify = defaults.Security.InsecureSkipVerify
+	}
+	if conf.Security.DynamicCertReload == nil {
+		conf.Security.DynamicCertReload = defaults.Security.DynamicCertReload
 	}
 	return conf
 }
@@ -375,6 +382,9 @@ func getClientTLSParams(c ClientConfig) []ClientParam {
 	if derefPtr(c.Security.InsecureSkipVerify, false) {
 		params = append(params, WithTLSInsecureSkipVerify())
 	}
+	if derefPtr(c.Security.DynamicCertReload, false) {
+		params = append(params, WithDynamicCertReload())
+	}
 	return params
 }
 
@@ -400,6 +410,7 @@ func newValidatedClientParamsFromConfig(ctx context.Context, config ClientConfig
 			CertFile:           config.Security.CertFile,
 			KeyFile:            config.Security.KeyFile,
 			InsecureSkipVerify: derefPtr(config.Security.InsecureSkipVerify, false),
+			DynamicCertReload:  derefPtr(config.Security.DynamicCertReload, false),
 		},
 	}
 

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig.go
@@ -31,6 +31,7 @@ type TLSParams struct {
 	CertFile           string
 	KeyFile            string
 	InsecureSkipVerify bool
+	DynamicCertReload  bool
 }
 
 // NewRefreshableTLSConfig evaluates the provided TLSParams and returns a RefreshableTLSConfig that will update the
@@ -39,7 +40,7 @@ type TLSParams struct {
 // If the updated TLSParams are invalid, the RefreshableTLSConfig will continue to use the previous value and log the error.
 //
 // N.B. This subscription only fires when the paths are updated, not when the contents of the files are updated.
-// We could consider adding a file refreshable to watch the key and cert files.
+// When DynamicCertReload is enabled, the cert/key files are re-read on each TLS handshake via GetClientCertificate.
 func NewRefreshableTLSConfig(ctx context.Context, params refreshable.Validated[TLSParams]) (refreshable.Validated[*tls.Config], error) {
 	r, _, err := refreshable.MapValidated(ctx, params, func(ctx context.Context, p TLSParams) (*tls.Config, error) {
 		return NewTLSConfig(ctx, p)
@@ -67,7 +68,11 @@ func NewTLSConfig(ctx context.Context, p TLSParams) (*tls.Config, error) {
 		tlsParams = append(tlsParams, tlsconfig.ClientRootCAs(tlsconfig.AugmentCertPoolWithCertPoolOptions(certPool, certPoolOptions)))
 	}
 	if p.CertFile != "" && p.KeyFile != "" {
-		tlsParams = append(tlsParams, tlsconfig.ClientKeyPairFiles(p.CertFile, p.KeyFile))
+		if p.DynamicCertReload {
+			tlsParams = append(tlsParams, tlsconfig.ClientKeyPair(tlsconfig.TLSCertFromFiles(p.CertFile, p.KeyFile)))
+		} else {
+			tlsParams = append(tlsParams, tlsconfig.ClientKeyPairFiles(p.CertFile, p.KeyFile))
+		}
 	}
 	if p.InsecureSkipVerify {
 		tlsParams = append(tlsParams, tlsconfig.ClientInsecureSkipVerify())

--- a/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig_test.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/tlsconfig_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2024 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package refreshingclient
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestCertAndKey(t *testing.T) (certPEM, keyPEM []byte, certFile, keyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certFile, certPEM, 0600))
+	require.NoError(t, os.WriteFile(keyFile, keyPEM, 0600))
+	return certPEM, keyPEM, certFile, keyFile
+}
+
+func TestNewTLSConfig_DynamicCertReload(t *testing.T) {
+	_, _, certFile, keyFile := generateTestCertAndKey(t)
+
+	t.Run("static mode sets Certificates", func(t *testing.T) {
+		cfg, err := NewTLSConfig(context.Background(), TLSParams{
+			CertFile: certFile,
+			KeyFile:  keyFile,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, cfg.Certificates)
+		assert.Nil(t, cfg.GetClientCertificate)
+	})
+
+	t.Run("dynamic mode sets GetClientCertificate", func(t *testing.T) {
+		cfg, err := NewTLSConfig(context.Background(), TLSParams{
+			CertFile:          certFile,
+			KeyFile:           keyFile,
+			DynamicCertReload: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Certificates)
+		assert.NotNil(t, cfg.GetClientCertificate)
+	})
+}
+
+func TestNewTLSConfig_DynamicReload_PicksUpRotatedCert(t *testing.T) {
+	_, _, certFile, keyFile := generateTestCertAndKey(t)
+
+	cfg, err := NewTLSConfig(context.Background(), TLSParams{
+		CertFile:          certFile,
+		KeyFile:           keyFile,
+		DynamicCertReload: true,
+	})
+	require.NoError(t, err)
+
+	cert1, err := cfg.GetClientCertificate(nil)
+	require.NoError(t, err)
+	original := cert1.Certificate[0]
+
+	_, _, newCertFile, newKeyFile := generateTestCertAndKey(t)
+	newCertPEM, err := os.ReadFile(newCertFile)
+	require.NoError(t, err)
+	newKeyPEM, err := os.ReadFile(newKeyFile)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(certFile, newCertPEM, 0600))
+	require.NoError(t, os.WriteFile(keyFile, newKeyPEM, 0600))
+
+	cert2, err := cfg.GetClientCertificate(nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, original, cert2.Certificate[0])
+}
+
+func TestNewTLSConfig_StaticMode_DoesNotPickUpRotatedCert(t *testing.T) {
+	_, _, certFile, keyFile := generateTestCertAndKey(t)
+
+	cfg, err := NewTLSConfig(context.Background(), TLSParams{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	})
+	require.NoError(t, err)
+	original := cfg.Certificates[0].Certificate[0]
+
+	_, _, newCertFile, newKeyFile := generateTestCertAndKey(t)
+	newCertPEM, err := os.ReadFile(newCertFile)
+	require.NoError(t, err)
+	newKeyPEM, err := os.ReadFile(newKeyFile)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(certFile, newCertPEM, 0600))
+	require.NoError(t, os.WriteFile(keyFile, newKeyPEM, 0600))
+
+	assert.Equal(t, original, cfg.Certificates[0].Certificate[0])
+}

--- a/conjure-go-client/httpclient/internal/refreshingclient/transport.go
+++ b/conjure-go-client/httpclient/internal/refreshingclient/transport.go
@@ -48,6 +48,7 @@ type TLSConfigurationParams struct {
 	CertFile           string
 	KeyFile            string
 	InsecureSkipVerify bool
+	DynamicCertReload  bool
 }
 
 func NewRefreshableTransport(ctx context.Context, p refreshable.Refreshable[TransportParams], refreshableConfig refreshable.Validated[*tls.Config], dialer ContextDialer) http.RoundTripper {


### PR DESCRIPTION
## Before this PR

`conjure-go-runtime` loads TLS client certs once at client creation via `ClientKeyPairFiles()`, which sets `tls.Config.Certificates` (static). When client certificates are rotated on disk, the HTTP client never re-reads them and connections fail until the process restarts.

The underlying `palantir/pkg/tlsconfig` library already supports dynamic cert loading via [`ClientKeyPair()`](https://pkg.go.dev/github.com/palantir/pkg/tlsconfig@v1.5.0#ClientKeyPair), which sets `tls.Config.GetClientCertificate` (a callback re-invoked per TLS handshake) but `conjure-go-runtime` never uses it.

## After this PR

Adds an opt-in `DynamicCertReload` flag that switches from `ClientKeyPairFiles()` to `ClientKeyPair(TLSCertFromFiles(...))`, so rotated certs are picked up without restarting.

==COMMIT_MSG==
Add opt-in DynamicCertReload for TLS client certificates
==COMMIT_MSG==

### Testing

New unit tests in `tlsconfig_test.go`:
1. `TestNewTLSConfig_DynamicCertReload` - static sets `Certificates`, dynamic sets `GetClientCertificate`
2. `TestNewTLSConfig_DynamicReload_PicksUpRotatedCert` - overwrites cert files, callback returns new cert
3. `TestNewTLSConfig_StaticMode_DoesNotPickUpRotatedCert` - overwrites cert files, `Certificates` still has old cert