### PR TITLE
Add support for the "For-User-Agent" header when tracing

### DIFF
--- a/conjure-go-client/httpclient/context.go
+++ b/conjure-go-client/httpclient/context.go
@@ -23,6 +23,8 @@ type ctxKey string
 const (
 	// context-key for the RPC method name associated with the HTTP request call
 	rpcMethodName ctxKey = "rpcMethodName"
+	// context-key for the "For-User-Agent" header value
+	forUserAgentContextKey ctxKey = "forUserAgent"
 )
 
 // ContextWithRPCMethodName returns a copy of ctx with the rpcMethodName key set.
@@ -33,6 +35,23 @@ func ContextWithRPCMethodName(ctx context.Context, name string) context.Context 
 
 func getRPCMethodName(ctx context.Context) string {
 	e := ctx.Value(rpcMethodName)
+	if e == nil {
+		return ""
+	}
+	return e.(string)
+}
+
+// ContextWithForUserAgent returns a copy of ctx with the forUserAgent key set to the provided value (unless the
+// provided value is the empty string, in which case it returns the provided context).
+func ContextWithForUserAgent(ctx context.Context, forUserAgent string) context.Context {
+	if forUserAgent == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, forUserAgentContextKey, forUserAgent)
+}
+
+func getForUserAgent(ctx context.Context) string {
+	e := ctx.Value(forUserAgentContextKey)
 	if e == nil {
 		return ""
 	}

--- a/conjure-go-client/httpclient/request_builder.go
+++ b/conjure-go-client/httpclient/request_builder.go
@@ -33,7 +33,10 @@ type requestBuilder struct {
 	requestTimeout         *time.Duration
 }
 
-const traceIDHeaderKey = "X-B3-TraceId"
+const (
+	traceIDHeaderKey      = "X-B3-TraceId"
+	forUserAgentHeaderKey = "For-User-Agent"
+)
 
 type RequestParam interface {
 	apply(*requestBuilder) error

--- a/conjure-go-client/httpclient/trace.go
+++ b/conjure-go-client/httpclient/trace.go
@@ -65,6 +65,11 @@ func (t traceMiddleware) RoundTrip(req *http.Request, next http.RoundTripper) (*
 				req.Header.Set(traceIDHeaderKey, string(traceID))
 			}
 		}
+
+		// is the forUserAgent header value is not set on the request and is set in the context, use the context value
+		if forUserAgent := getForUserAgent(ctx); forUserAgent != "" && req.Header.Get(forUserAgentHeaderKey) == "" {
+			req.Header.Set(forUserAgentHeaderKey, forUserAgent)
+		}
 	}
 
 	return next.RoundTrip(req)

--- a/conjure-go-client/httpclient/trace.go
+++ b/conjure-go-client/httpclient/trace.go
@@ -66,7 +66,7 @@ func (t traceMiddleware) RoundTrip(req *http.Request, next http.RoundTripper) (*
 			}
 		}
 
-		// is the forUserAgent header value is not set on the request and is set in the context, use the context value
+		// if the forUserAgent header value is not set on the request and is set in the context, use the context value
 		if forUserAgent := getForUserAgent(ctx); forUserAgent != "" && req.Header.Get(forUserAgentHeaderKey) == "" {
 			req.Header.Set(forUserAgentHeaderKey, forUserAgent)
 		}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds support for propagating the "For-User-Agent" HTTP header value as part of tracing context logic.

Adds the `httpclient.ContextWithForUserAgent` function that registers the value of the "For-User-Agent" HTTP header key to be stored in a context.Context.

If the tracing middleware is enabled on a `conjure-go-runtime` `httpclient`, then if a `For-User-Agent` value is set on the context using the function above, that value is set on the header of the request (unless the request header already has a non-empty value set for this key, in which case it is not overridden).
==COMMIT_MSG==

Analogous to the following: https://github.com/palantir/tracing-java/pull/790/changes#diff-2c42f568e4773c384eb5383415926c9e5ceb829834823421cd8e1c3618cb76acR33

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

