### PR TITLE
improvement: metrics: Disambiguate some 'other' responses with more specific tags `tls_verify_error`, `dns_error`, and `connection_error`

### DIFF
--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -246,9 +246,9 @@ func isTimeoutError(rootErr error) bool {
 
 // isTLSVerifyError reports whether respErr was caused by a failure to verify the
 // server's TLS certificate (untrusted CA, hostname mismatch, expired cert, etc.).
-func isTLSVerifyError(respErr error) bool {
+func isTLSVerifyError(rootErr error) bool {
 	var cve *tls.CertificateVerificationError
-	return errors.As(respErr, &cve)
+	return errors.As(rootErr, &cve)
 }
 
 // isDNSError reports whether the host could not be resolved. Checked before

--- a/conjure-go-client/httpclient/metrics.go
+++ b/conjure-go-client/httpclient/metrics.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptrace"
+	"syscall"
 	"time"
 
 	"github.com/palantir/pkg/metrics"
@@ -50,13 +51,16 @@ var (
 	MetricTagConnectionNew    = metrics.MustNewTag("reused", "false")
 	MetricTagConnectionReused = metrics.MustNewTag("reused", "true")
 
-	metricTagFamily1xx     = metrics.MustNewTag(metricTagFamily, "1xx")
-	metricTagFamily2xx     = metrics.MustNewTag(metricTagFamily, "2xx")
-	metricTagFamily3xx     = metrics.MustNewTag(metricTagFamily, "3xx")
-	metricTagFamily4xx     = metrics.MustNewTag(metricTagFamily, "4xx")
-	metricTagFamily5xx     = metrics.MustNewTag(metricTagFamily, "5xx")
-	metricTagFamilyOther   = metrics.MustNewTag(metricTagFamily, "other")
-	metricTagFamilyTimeout = metrics.MustNewTag(metricTagFamily, "timeout")
+	metricTagFamily1xx        = metrics.MustNewTag(metricTagFamily, "1xx")
+	metricTagFamily2xx        = metrics.MustNewTag(metricTagFamily, "2xx")
+	metricTagFamily3xx        = metrics.MustNewTag(metricTagFamily, "3xx")
+	metricTagFamily4xx        = metrics.MustNewTag(metricTagFamily, "4xx")
+	metricTagFamily5xx        = metrics.MustNewTag(metricTagFamily, "5xx")
+	metricTagFamilyOther      = metrics.MustNewTag(metricTagFamily, "other")
+	metricTagFamilyTimeout    = metrics.MustNewTag(metricTagFamily, "timeout")
+	metricTagFamilyTLSVerify  = metrics.MustNewTag(metricTagFamily, "tls_verify_error")
+	metricTagFamilyDNS        = metrics.MustNewTag(metricTagFamily, "dns_error")
+	metricTagFamilyConnection = metrics.MustNewTag(metricTagFamily, "connection_error")
 )
 
 // A TagsProvider returns metrics tags based on an http round trip.
@@ -133,9 +137,16 @@ func (h *metricsMiddleware) RoundTrip(req *http.Request, next http.RoundTripper)
 }
 
 func tagStatusFamily(_ *http.Request, resp *http.Response, respErr error) metrics.Tags {
+	rootErr := werror.RootCause(respErr)
 	switch {
-	case isTimeoutError(respErr):
+	case isDNSError(rootErr):
+		return metrics.Tags{metricTagFamilyDNS}
+	case isTimeoutError(rootErr):
 		return metrics.Tags{metricTagFamilyTimeout}
+	case isTLSVerifyError(rootErr):
+		return metrics.Tags{metricTagFamilyTLSVerify}
+	case isConnectionError(rootErr):
+		return metrics.Tags{metricTagFamilyConnection}
 	case resp == nil, resp.StatusCode < 100, resp.StatusCode > 599:
 		return metrics.Tags{metricTagFamilyOther}
 	case resp.StatusCode < 200:
@@ -216,16 +227,11 @@ func tlsVersionString(version uint16) string {
 	return ""
 }
 
-func isTimeoutError(respErr error) bool {
-	if respErr == nil {
-		return false
-	}
-	rootErr := werror.RootCause(respErr)
+func isTimeoutError(rootErr error) bool {
 	if rootErr == nil {
 		return false
 	}
-
-	if nerr, ok := rootErr.(net.Error); ok && nerr.Timeout() {
+	if nerr, ok := errors.AsType[net.Error](rootErr); ok && nerr.Timeout() {
 		return true
 	}
 	if errors.Is(rootErr, context.Canceled) || errors.Is(rootErr, context.DeadlineExceeded) {
@@ -236,4 +242,28 @@ func isTimeoutError(respErr error) bool {
 		return true
 	}
 	return false
+}
+
+// isTLSVerifyError reports whether respErr was caused by a failure to verify the
+// server's TLS certificate (untrusted CA, hostname mismatch, expired cert, etc.).
+func isTLSVerifyError(respErr error) bool {
+	var cve *tls.CertificateVerificationError
+	return errors.As(respErr, &cve)
+}
+
+// isDNSError reports whether the host could not be resolved. Checked before
+// isTimeoutError: a resolver timeout is a *net.DNSError whose Timeout() is true, so
+// without this ordering it would be counted as a generic timeout instead of DNS.
+func isDNSError(rootErr error) bool {
+	var dnsErr *net.DNSError
+	return errors.As(rootErr, &dnsErr)
+}
+
+func isConnectionError(rootErr error) bool {
+	return errors.Is(rootErr, syscall.ECONNREFUSED) ||
+		errors.Is(rootErr, syscall.ECONNRESET) ||
+		errors.Is(rootErr, syscall.ECONNABORTED) ||
+		errors.Is(rootErr, syscall.EHOSTUNREACH) ||
+		errors.Is(rootErr, syscall.ENETUNREACH) ||
+		errors.Is(rootErr, syscall.EPIPE)
 }

--- a/conjure-go-client/httpclient/metrics_internal_test.go
+++ b/conjure-go-client/httpclient/metrics_internal_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/palantir/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTagStatusFamily_ErrorClasses checks transport-error classification, in
+// particular the family precedence when an error matches more than one predicate
+// (e.g. a DNS timeout matches both isDNSError and isTimeoutError). Errors are
+// constructed rather than produced by real network calls so cases stay deterministic.
+func TestTagStatusFamily_ErrorClasses(t *testing.T) {
+	// wrap models how net/http surfaces transport errors to the caller.
+	wrap := func(err error) error { return &url.Error{Op: "Get", URL: "https://example.com", Err: err} }
+
+	for _, tc := range []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "dns not found",
+			err:      wrap(&net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{Err: "no such host", Name: "missing.invalid", IsNotFound: true}}),
+			expected: "dns_error",
+		},
+		{
+			name:     "dns timeout classified as dns, not timeout",
+			err:      wrap(&net.OpError{Op: "dial", Net: "tcp", Err: &net.DNSError{Err: "i/o timeout", Name: "slow.invalid", IsTimeout: true}}),
+			expected: "dns_error",
+		},
+		{
+			name:     "tls verification failure",
+			err:      wrap(&tls.CertificateVerificationError{Err: x509.UnknownAuthorityError{}}),
+			expected: "tls_verify_error",
+		},
+		{
+			name:     "connection refused",
+			err:      wrap(&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}),
+			expected: "connection_error",
+		},
+		{
+			name:     "connection reset",
+			err:      wrap(&net.OpError{Op: "read", Net: "tcp", Err: os.NewSyscallError("read", syscall.ECONNRESET)}),
+			expected: "connection_error",
+		},
+		{
+			name:     "host unreachable",
+			err:      wrap(&net.OpError{Op: "dial", Net: "tcp", Err: os.NewSyscallError("connect", syscall.EHOSTUNREACH)}),
+			expected: "connection_error",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tags := tagStatusFamily(nil, nil, tc.err)
+			expected := metrics.Tags{metrics.MustNewTag(metricTagFamily, tc.expected)}
+			assert.Equal(t, expected.ToMap(), tags.ToMap())
+		})
+	}
+}

--- a/conjure-go-client/httpclient/metrics_test.go
+++ b/conjure-go-client/httpclient/metrics_test.go
@@ -17,6 +17,7 @@ package httpclient_test
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -93,7 +94,8 @@ func TestRoundTripperWithMetrics(t *testing.T) {
 	testStatusCode := map[int]string{
 		200: "2xx",
 		500: "5xx",
-		0:   "other",
+		// statusCode 0: no server is stood up, so the request hits a closed port (see below).
+		0: "connection_error",
 	}
 
 	rpcNamesAndExpectedTags := map[string]string{
@@ -116,7 +118,12 @@ func TestRoundTripperWithMetrics(t *testing.T) {
 			defer server.Close()
 			serverURLstr = server.URL
 		} else {
-			serverURLstr = "http://not-a-real-host:12345"
+			// Bind then immediately close a loopback listener so the request
+			// deterministically fails with "connection refused".
+			ln, lerr := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, lerr)
+			serverURLstr = "http://" + ln.Addr().String()
+			require.NoError(t, ln.Close())
 		}
 
 		// create client
@@ -289,6 +296,81 @@ func TestMetricsMiddleware_ContextCanceled(t *testing.T) {
 			metrics.MustNewTag("service-name", "test-service"): {},
 		}
 		assert.Equal(t, expectedTags, tags.ToSet(), "expected timeout tags for %v", err)
+	})
+	assert.True(t, found, "did not find client.response metric")
+}
+
+func TestMetricsMiddleware_TLSVerifyError(t *testing.T) {
+	// NewTLSServer uses a self-signed cert that the client does not trust, so
+	// certificate verification fails during the handshake.
+	srv := httptest.NewTLSServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	rootRegistry := metrics.NewRootMetricsRegistry()
+	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
+
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{srv.URL}),
+		httpclient.WithServiceName("test-service"),
+		httpclient.WithMetrics(),
+		httpclient.WithMaxRetries(0))
+	require.NoError(t, err)
+
+	_, err = client.Get(ctx, httpclient.WithRPCMethodName("test-endpoint"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tls: failed to verify certificate")
+
+	found := false
+	rootRegistry.Each(func(name string, tags metrics.Tags, value metrics.MetricVal) {
+		if name != "client.response" {
+			return
+		}
+		found = true
+		expectedTags := map[metrics.Tag]struct{}{
+			metrics.MustNewTag("family", "tls_verify_error"):   {},
+			metrics.MustNewTag("method", "get"):                {},
+			metrics.MustNewTag("method-name", "test-endpoint"): {},
+			metrics.MustNewTag("service-name", "test-service"): {},
+		}
+		assert.Equal(t, expectedTags, tags.ToSet(), "expected tls_verify_error tags for %v", err)
+	})
+	assert.True(t, found, "did not find client.response metric")
+}
+
+func TestMetricsMiddleware_ConnectionError(t *testing.T) {
+	// Bind a loopback listener then immediately close it so the port refuses connections.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	rootRegistry := metrics.NewRootMetricsRegistry()
+	ctx := metrics.WithRegistry(context.Background(), rootRegistry)
+
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{"http://" + addr}),
+		httpclient.WithServiceName("test-service"),
+		httpclient.WithMetrics(),
+		httpclient.WithMaxRetries(0))
+	require.NoError(t, err)
+
+	_, err = client.Get(ctx, httpclient.WithRPCMethodName("test-endpoint"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection refused")
+
+	found := false
+	rootRegistry.Each(func(name string, tags metrics.Tags, value metrics.MetricVal) {
+		if name != "client.response" {
+			return
+		}
+		found = true
+		expectedTags := map[metrics.Tag]struct{}{
+			metrics.MustNewTag("family", "connection_error"):   {},
+			metrics.MustNewTag("method", "get"):                {},
+			metrics.MustNewTag("method-name", "test-endpoint"): {},
+			metrics.MustNewTag("service-name", "test-service"): {},
+		}
+		assert.Equal(t, expectedTags, tags.ToSet(), "expected connection_error tags for %v", err)
 	})
 	assert.True(t, found, "did not find client.response metric")
 }


### PR DESCRIPTION
Today, errors that are not non-2xx responses or timeouts are categorized as `other`. This PR adds tag `tls_verify_error` to split out errors caused by `*tls.CertificateVerificationError`