### PR TITLE
Improvement: Fall back to a generic error on typed decode failures

### DIFF
--- a/conjure-go-contract/errors/error_type_registry.go
+++ b/conjure-go-contract/errors/error_type_registry.go
@@ -74,18 +74,18 @@ func (d *ReflectTypeConjureErrorDecoder) RegisterErrorType(name string, typ refl
 }
 
 func (d *ReflectTypeConjureErrorDecoder) DecodeConjureError(errorName string, body []byte) (Error, error) {
-	typ, ok := d.registry[errorName]
-	if !ok {
-		// Unrecognized error name, fall back to genericError
-		typ = reflect.TypeFor[genericError]()
+	if typ, ok := d.registry[errorName]; ok {
+		instance := reflect.New(typ).Interface()
+		if err := codecs.JSON.Unmarshal(body, &instance); err == nil {
+			// RegisterErrorType guarantees *typ implements Error, so this assertion always holds.
+			return instance.(Error), nil
+		}
+		// The registered type failed to decode the body. Rather than discard the conjure error, fall through to a genericError,
+		// which decodes parameters into a map[string]any and preserves the error name, code, instance ID, and raw parameters.
 	}
-	instance := reflect.New(typ).Interface()
-	if err := codecs.JSON.Unmarshal(body, &instance); err != nil {
-		return nil, werror.Wrap(err, "failed to unmarshal body using registered type", werror.SafeParam("type", typ.String()))
-	}
-	cerr, ok := instance.(Error)
-	if !ok {
-		return nil, werror.Error("unmarshaled type does not implement errors.Error interface", werror.SafeParam("type", typ.String()))
+	var cerr genericError
+	if err := codecs.JSON.Unmarshal(body, &cerr); err != nil {
+		return nil, werror.Wrap(err, "failed to unmarshal body as generic conjure error")
 	}
 	return cerr, nil
 }

--- a/conjure-go-contract/errors/error_type_registry_test.go
+++ b/conjure-go-contract/errors/error_type_registry_test.go
@@ -18,7 +18,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/codecs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegisterErrorType_types(t *testing.T) {
@@ -90,6 +92,74 @@ func TestMustRegisterErrorTypes(t *testing.T) {
 					MustRegisterErrorTypes(&error1{})
 			})
 	})
+}
+
+func TestDecodeConjureError_typedFallback(t *testing.T) {
+	const (
+		jsonBody   = `{"errorCode":"CONFLICT","errorName":"Test:TablesConflict","errorInstanceId":"ada42104-7688-4720-8e4e-72deae1cec87","parameters":{"tables":["basic"]}}`
+		legacyBody = `{"errorCode":"CONFLICT","errorName":"Test:TablesConflict","errorInstanceId":"ada42104-7688-4720-8e4e-72deae1cec87","parameters":{"tables":"[basic]"}}`
+	)
+	decoder := NewReflectTypeConjureErrorDecoder().MustRegisterErrorTypes(new(tablesParamError))
+
+	t.Run("JSON params decode into the typed error", func(t *testing.T) {
+		cerr, err := decoder.DecodeConjureError("Test:TablesConflict", []byte(jsonBody))
+		require.NoError(t, err)
+		tablesParamErr, ok := cerr.(*tablesParamError)
+		require.True(t, ok)
+		assert.Equal(t, []string{"basic"}, tablesParamErr.Tables)
+		assert.Equal(t, "Test:TablesConflict", tablesParamErr.Name())
+		assert.Equal(t, Conflict, tablesParamErr.Code())
+		assert.Equal(t, "ada42104-7688-4720-8e4e-72deae1cec87", cerr.InstanceID().String())
+	})
+
+	t.Run("string params fall back to a generic error", func(t *testing.T) {
+		cerr, err := decoder.DecodeConjureError("Test:TablesConflict", []byte(legacyBody))
+		require.NoError(t, err)
+		_, ok := cerr.(*tablesParamError)
+		assert.False(t, ok)
+		assert.Equal(t, "Test:TablesConflict", cerr.Name())
+		assert.Equal(t, Conflict, cerr.Code())
+		assert.Equal(t, "ada42104-7688-4720-8e4e-72deae1cec87", cerr.InstanceID().String())
+		assert.Equal(t, "[basic]", cerr.UnsafeParams()["tables"])
+	})
+
+	t.Run("unknown error name falls back to a generic error", func(t *testing.T) {
+		cerr, err := decoder.DecodeConjureError("Test:Unregistered", []byte(jsonBody))
+		require.NoError(t, err)
+		_, ok := cerr.(*tablesParamError)
+		assert.False(t, ok)
+		assert.Equal(t, "Test:TablesConflict", cerr.Name())
+		assert.Equal(t, Conflict, cerr.Code())
+		assert.Equal(t, "ada42104-7688-4720-8e4e-72deae1cec87", cerr.InstanceID().String())
+	})
+}
+
+// tablesParamError mimics a conjure-generated typed error whose parameters include a
+// non-scalar field. Its UnmarshalJSON unmarshals the parameters into a typed struct and
+// therefore fails when a parameter arrives in the legacy string form
+// (e.g. "tables":"[basic]") rather than as a JSON array ("tables":["basic"]).
+type tablesParamError struct {
+	genericError
+	Tables []string
+}
+
+func (e *tablesParamError) Name() string {
+	return "Test:TablesConflict"
+}
+
+func (e *tablesParamError) UnmarshalJSON(data []byte) error {
+	var se SerializableError
+	if err := codecs.JSON.Unmarshal(data, &se); err != nil {
+		return err
+	}
+	var params struct {
+		Tables []string `json:"tables"`
+	}
+	if err := codecs.JSON.Unmarshal(se.Parameters, &params); err != nil {
+		return err
+	}
+	e.Tables = params.Tables
+	return e.genericError.UnmarshalJSON(data)
 }
 
 type error1 struct {

--- a/conjure-go-contract/errors/unmarshal_test.go
+++ b/conjure-go-contract/errors/unmarshal_test.go
@@ -132,12 +132,12 @@ func TestUnmarshalError(t *testing.T) {
 		{
 			name:      "other json",
 			inRaw:     `{"foo":"bar"}`,
-			expectErr: "failed to unmarshal body using registered type: errors: error name does not match regexp `^(([A-Z][a-z0-9]+)+):(([A-Z][a-z0-9]+)+)$`",
+			expectErr: "failed to unmarshal body as generic conjure error: errors: error name does not match regexp `^(([A-Z][a-z0-9]+)+):(([A-Z][a-z0-9]+)+)$`",
 		},
 		{
 			name:      "incomplete error json",
 			inRaw:     `{"errorName":"Default:Internal"}`,
-			expectErr: "failed to unmarshal body using registered type: errors: invalid combination of default error name and error code",
+			expectErr: "failed to unmarshal body as generic conjure error: errors: invalid combination of default error name and error code",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Before this PR
When a server's response body used an error name that was registered but whose parameters didn't match the generated type's wire form (e.g. a list param of the form "[basic]" instead of ["basic"]), the `UnmarshalJSON` failed and the entire conjure error was discarded. The returned error only included the message, status code safe param, and the raw JSON as a unsafe param. This meant that `errors.GetConjureError(err)` returned nil and all name/code based handling silently failed even though the error is a well typed conjure error.

 This was observed on `TransactionConflict` errors from an internal product where the error params were stringified resulting in a failure to decode into the typed conjure error. This is related to https://github.com/palantir/conjure-go-runtime/pull/935

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fall back to a generic error on typed decode failures
==COMMIT_MSG==

The generic error fallback now covers both unrecognized error names (as before) and registered but non-decodable bodies. 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

