### PR TITLE
Feature: Add support for conjure error parameter formats

### DIFF
--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal"
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/palantir/pkg/bytesbuffers"
 	"github.com/palantir/pkg/refreshable/v2"
 	werror "github.com/palantir/witchcraft-go-error"
@@ -173,6 +174,12 @@ func WithAuthTokenProvider(provideToken TokenProvider) ClientOrHTTPClientParam {
 // WithUserAgent sets the User-Agent header.
 func WithUserAgent(userAgent string) ClientOrHTTPClientParam {
 	return WithSetHeader("User-Agent", userAgent)
+}
+
+// WithConjureErrorParameterFormat sets the "Accept-Conjure-Error-Parameter-Format" header on
+// every request so that conjure servers serialize error parameters in the requested format.
+func WithConjureErrorParameterFormat(format errors.ConjureErrorParameterFormat) ClientOrHTTPClientParam {
+	return WithSetHeader(errors.AcceptConjureErrorParameterFormatHeader, string(format))
 }
 
 // WithOverrideRequestHost overrides the request Host from the default URL.Host

--- a/conjure-go-client/httpclient/client_params_test.go
+++ b/conjure-go-client/httpclient/client_params_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient/internal/refreshingclient"
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-contract/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -194,6 +195,13 @@ func TestMiddlewareOrdering(t *testing.T) {
 			ClientParams: []ClientParam{WithAddHeader("X-Test", "value1"), WithAddHeader("X-Test", "value2")},
 			ExpectHeaders: http.Header{
 				"X-Test": []string{"value1", "value2"},
+			},
+		},
+		{
+			Name:         "WithConjureErrorParameterFormat middleware",
+			ClientParams: []ClientParam{WithConjureErrorParameterFormat(errors.ConjureErrorParameterFormatJSON)},
+			ExpectHeaders: http.Header{
+				"Accept-Conjure-Error-Parameter-Format": []string{"JSON"},
 			},
 		},
 		{

--- a/conjure-go-client/httpclient/request_params.go
+++ b/conjure-go-client/httpclient/request_params.go
@@ -72,6 +72,12 @@ func WithHeader(key, value string) RequestParam {
 	})
 }
 
+// WithConjureErrorParameterFormatHeader sets the "Accept-Conjure-Error-Parameter-Format"
+// header on a request so that conjure servers serialize error parameters in the requested format.
+func WithConjureErrorParameterFormatHeader(format errors.ConjureErrorParameterFormat) RequestParam {
+	return WithHeader(errors.AcceptConjureErrorParameterFormatHeader, string(format))
+}
+
 // WithQueryValues sets a header on a request.
 func WithQueryValues(query url.Values) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {

--- a/conjure-go-contract/errors/error_parameter_format.go
+++ b/conjure-go-contract/errors/error_parameter_format.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+const (
+	// AcceptConjureErrorParameterFormatHeader is the request header a client sends to negotiate
+	// the serialization format of Conjure error parameters. When the value is recognized by
+	// the server, the server serializes error parameters in that format instead of the legacy form.
+	//
+	// The header is a best-effort hint: servers that do not understand it ignore it and continue
+	// to send the legacy form, so error decoding must remain tolerant of both forms.
+	AcceptConjureErrorParameterFormatHeader = "Accept-Conjure-Error-Parameter-Format"
+)
+
+// ConjureErrorParameterFormat is the value of the Accept-Conjure-Error-Parameter-Format header.
+type ConjureErrorParameterFormat string
+
+const (
+	// ConjureErrorParameterFormatJSON requests that the server serialize Conjure error parameters
+	// as native JSON values keyed by their declared Conjure type, rather than the legacy string form.
+	ConjureErrorParameterFormatJSON ConjureErrorParameterFormat = "JSON"
+)


### PR DESCRIPTION
## Before this PR
Error parameter formats did not exist for Go.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add support for conjure error parameter formats
==COMMIT_MSG==

Conjure Java servers (>=8.52.0) serialize error parameters as native JSON instead of stringified params when the request contains the `Accept-Conjure-Error-Parameter-Format: JSON` header. Go expects the JSON form in the generated / typed error decoders so without this header, non-scaler params (list, map, etc) do not decode into their typed form. 

This change adds the types to set the header with a specified format but does not wire it in anywhere. conjure-go will allow users to opt-in to specifying this header which will add the request param into the generated code.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

