### PR TITLE
Fix: Auth middleware no longer leak credentials across host redirects

### DIFF
--- a/conjure-go-client/httpclient/authn.go
+++ b/conjure-go-client/httpclient/authn.go
@@ -17,10 +17,12 @@ package httpclient
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/palantir/pkg/refreshable/v2"
+	"golang.org/x/net/idna"
 )
 
 // TokenProvider accepts a context and returns either:
@@ -44,7 +46,7 @@ func (h *authTokenMiddleware) RoundTrip(req *http.Request, next http.RoundTrippe
 		return nil, err
 	}
 	if token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		setAuthorizationHeader(req, "Bearer "+token)
 	}
 	return next.RoundTrip(req)
 }
@@ -79,13 +81,98 @@ type BasicAuthOptionalProvider func(context.Context) (*BasicAuth, error)
 func newBasicAuthMiddlewareFromRefreshable(auth refreshable.Refreshable[*BasicAuth]) Middleware {
 	return MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
 		if basicAuth := auth.Current(); basicAuth != nil {
-			setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
+			setBasicAuth(req, basicAuth.User, basicAuth.Password)
 		}
 		return next.RoundTrip(req)
 	})
 }
 
-func setBasicAuth(h http.Header, username, password string) {
+func setBasicAuth(req *http.Request, username, password string) {
+	setAuthorizationHeader(req, basicAuthValue(username, password))
+}
+
+func basicAuthValue(username, password string) string {
 	basicAuthBytes := []byte(username + ":" + password)
-	h.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString(basicAuthBytes))
+	return "Basic " + base64.StdEncoding.EncodeToString(basicAuthBytes)
+}
+
+// setAuthorizationHeader sets the Authorization header on req to value, unless following
+// redirects has taken req to a host that is not the same as (or a subdomain of) the
+// original request host.
+func setAuthorizationHeader(req *http.Request, value string) {
+	if !authHeaderAllowedOnRedirect(req) {
+		return
+	}
+	req.Header.Set("Authorization", value)
+}
+
+// authHeaderAllowedOnRedirect reports whether Authorization credentials may be attached to req.
+//
+// Source: https://github.com/golang/go/blob/go1.26.4/src/net/http/client.go#L688-L692
+func authHeaderAllowedOnRedirect(req *http.Request) bool {
+	if req.Response == nil {
+		// Initial request, not a redirect, credentials are always allowed.
+		return true
+	}
+	origin := originRequest(req)
+	if origin.URL == nil {
+		return true
+	}
+	originHost := idnaASCIIFromURL(origin.URL)
+	// Require every redirect to remain on the same host, or a subdomain of, the original host.
+	for r := req; r != origin; {
+		if r.URL == nil || !isDomainOrSubdomain(idnaASCIIFromURL(r.URL), originHost) {
+			return false
+		}
+		if r.Response == nil || r.Response.Request == nil {
+			break
+		}
+		r = r.Response.Request
+	}
+	return true
+}
+
+// originRequest walks the redirect chain back to the original request (i.e. the first request that
+// was not produced by following a redirect).
+func originRequest(req *http.Request) *http.Request {
+	r := req
+	for r.Response != nil && r.Response.Request != nil {
+		r = r.Response.Request
+	}
+	return r
+}
+
+// idnaASCIIFromURL returns the host of u in its IDNA ASCII form.
+//
+// Source: https://github.com/golang/go/blob/go1.26.4/src/net/http/transport.go#L3024-L3030
+func idnaASCIIFromURL(u *url.URL) string {
+	addr := u.Hostname()
+	if v, err := idna.Lookup.ToASCII(addr); err == nil {
+		addr = v
+	}
+	return addr
+}
+
+// isDomainOrSubdomain reports whether sub is a subdomain (or exact match) of the parent domain.
+// It is copied verbatim from net/http's unexported isDomainOrSubdomain to match the standard library's
+// redirect header-stripping semantics exactly.
+//
+// Source: https://github.com/golang/go/blob/go1.26.4/src/net/http/client.go#L1028-L1045
+func isDomainOrSubdomain(sub, parent string) bool {
+	if sub == parent {
+		return true
+	}
+	// If sub contains a :, it's probably an IPv6 address (and is definitely not a hostname).
+	// Don't check the suffix in this case, to avoid matching the contents of a IPv6 zone.
+	// For example, "::1%.www.example.com" is not a subdomain of "www.example.com".
+	if strings.ContainsAny(sub, ":%") {
+		return false
+	}
+	// If sub is "foo.example.com" and parent is "example.com",
+	// that means sub must end in "."+parent.
+	// Do it without allocating.
+	if !strings.HasSuffix(sub, parent) {
+		return false
+	}
+	return sub[len(sub)-len(parent)-1] == '.'
 }

--- a/conjure-go-client/httpclient/authn_internal_test.go
+++ b/conjure-go-client/httpclient/authn_internal_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Verifies the redirect host comparison across multiple hops.
+func TestAuthHeaderAllowedOnRedirect(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		chain []string
+		allow bool
+	}{
+		{
+			name:  "initial request",
+			chain: []string{"https://a.com/"},
+			allow: true,
+		},
+		{
+			name:  "same host redirect",
+			chain: []string{"https://a.com/", "https://a.com/other"},
+			allow: true,
+		},
+		{
+			name:  "subdomain redirect",
+			chain: []string{"https://a.com/", "https://sub.a.com/"},
+			allow: true,
+		},
+		{
+			name:  "cross host redirect",
+			chain: []string{"https://a.com/", "https://b.com/"},
+			allow: false,
+		},
+		{
+			name:  "cross host then subdomain of intermediate",
+			chain: []string{"https://a.com/", "https://b.com/", "https://sub.b.com/"},
+			allow: false,
+		},
+		{
+			name:  "subdomain then original",
+			chain: []string{"https://a.com/", "https://sub.a.com/", "https://a.com/"},
+			allow: true,
+		},
+		{
+			name:  "cross host then return to original",
+			chain: []string{"https://a.com/", "https://b.com/", "https://a.com/"},
+			allow: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.allow, authHeaderAllowedOnRedirect(redirectChain(t, tc.chain)))
+		})
+	}
+}
+
+func redirectChain(t *testing.T, urls []string) *http.Request {
+	var prev *http.Request
+
+	for _, singleURL := range urls {
+		u, err := url.Parse(singleURL)
+		require.NoError(t, err)
+		req := &http.Request{
+			URL:    u,
+			Header: make(http.Header),
+		}
+		if prev != nil {
+			req.Response = &http.Response{
+				Request: prev,
+			}
+		}
+		prev = req
+	}
+	return prev
+}

--- a/conjure-go-client/httpclient/authn_test.go
+++ b/conjure-go-client/httpclient/authn_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -293,4 +294,100 @@ func TestAuthHeaders(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Verifies that the auth middleware does not re-attach the Authorization header
+// when the stdlib follows a cross-host redirect.
+func TestAuthHeaderNotLeakedOnCrossHostRedirect(t *testing.T) {
+	const (
+		token    = "token"
+		username = "user"
+		password = "pass"
+	)
+	for _, tc := range []struct {
+		name   string
+		param  httpclient.ClientOrHTTPClientParam
+		expect string
+	}{
+		{
+			name:   "WithAuthToken",
+			param:  httpclient.WithAuthToken(token),
+			expect: "Bearer " + token,
+		},
+		{
+			name:   "WithBasicAuth",
+			param:  httpclient.WithBasicAuth(username, password),
+			expect: "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var redirectCalled bool
+			var redirectAuthValue string
+			redirectHost := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				redirectCalled = true
+				redirectAuthValue = req.Header.Get("Authorization")
+				rw.WriteHeader(http.StatusOK)
+			}))
+			defer redirectHost.Close()
+
+			// redirect from 127.0.0.1 to "localhost" so the target differs but is still reachable
+			redirectURL := strings.Replace(redirectHost.URL, "127.0.0.1", "localhost", 1)
+			require.NotEqual(t, redirectHost.URL, redirectURL, "expected httptest server to bind 127.0.0.1")
+
+			var originAuthValue string
+			origin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				originAuthValue = req.Header.Get("Authorization")
+				http.Redirect(rw, req, redirectURL, http.StatusFound)
+			}))
+			defer origin.Close()
+
+			client, err := httpclient.NewClient(
+				httpclient.WithBaseURLs([]string{origin.URL}),
+				httpclient.WithHTTPTimeout(time.Minute),
+				tc.param,
+			)
+			require.NoError(t, err)
+
+			resp, err := client.Get(context.Background())
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			// Only the origin should see the Authorization header
+			assert.Equal(t, tc.expect, originAuthValue)
+			assert.True(t, redirectCalled)
+			assert.Empty(t, redirectAuthValue)
+		})
+	}
+}
+
+// Verifies that following a same-host redirect still attaches the Authorization header.
+func TestAuthHeaderPreservedOnSameHostRedirect(t *testing.T) {
+	const token = "token"
+
+	var redirectCalled bool
+	var authValue string
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/redirect" {
+			redirectCalled = true
+			authValue = req.Header.Get("Authorization")
+			rw.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(rw, req, "/redirect", http.StatusFound)
+	}))
+	defer server.Close()
+
+	client, err := httpclient.NewClient(
+		httpclient.WithBaseURLs([]string{server.URL}),
+		httpclient.WithHTTPTimeout(time.Minute),
+		httpclient.WithAuthToken(token),
+	)
+	require.NoError(t, err)
+
+	resp, err := client.Get(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.True(t, redirectCalled)
+	assert.Equal(t, "Bearer "+token, authValue)
 }

--- a/conjure-go-client/httpclient/client_params.go
+++ b/conjure-go-client/httpclient/client_params.go
@@ -623,7 +623,7 @@ func WithErrorDecoder(errorDecoder ErrorDecoder) ClientParam {
 // password.
 func WithBasicAuth(user, password string) ClientOrHTTPClientParam {
 	return WithInnerMiddleware(MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-		setBasicAuth(req.Header, user, password)
+		setBasicAuth(req, user, password)
 		return next.RoundTrip(req)
 	}))
 }
@@ -636,7 +636,7 @@ func WithBasicAuthProvider(provider BasicAuthProvider) ClientOrHTTPClientParam {
 		if err != nil {
 			return nil, err
 		}
-		setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
+		setBasicAuth(req, basicAuth.User, basicAuth.Password)
 		return next.RoundTrip(req)
 	}))
 }
@@ -652,7 +652,7 @@ func WithBasicAuthOptionalProvider(provider BasicAuthOptionalProvider) ClientOrH
 			return nil, err
 		}
 		if basicAuth != nil {
-			setBasicAuth(req.Header, basicAuth.User, basicAuth.Password)
+			setBasicAuth(req, basicAuth.User, basicAuth.Password)
 		}
 		return next.RoundTrip(req)
 	}))

--- a/conjure-go-client/httpclient/request_params.go
+++ b/conjure-go-client/httpclient/request_params.go
@@ -215,7 +215,7 @@ func WithRequestErrorDecoder(errorDecoder ErrorDecoder) RequestParam {
 // username and password for this request only and takes precedence over any client-scoped authorization.
 func WithRequestBasicAuth(username, password string) RequestParam {
 	return requestParamFunc(func(b *requestBuilder) error {
-		setBasicAuth(b.headers, username, password)
+		b.headers.Set("Authorization", basicAuthValue(username, password))
 		return nil
 	})
 }


### PR DESCRIPTION
## Before this PR
`WithAuthToken` and `WithBasicAuth` add RoundTripper middleware that sets `Authorization` credentials on every request passing through the transport. The Go stdlib follows cross-host redirects, stripping any sensitive headers. However, since the redirect uses the same transport, the middlewares are re-invoked and add back the `Authorization` credentials, effectively undoing what the stdlib removed - this has the potential to be compromised.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Auth middleware no longer leaks credentials across host redirects
==COMMIT_MSG==

The middlewares will now remove the `Authorization` header when a request is redirected to a host that is not the same as (or a subdomain of) the host that issued the redirect. Same host and sub-domain redirects continue to forward credentials exactly as before.

One caveat to note, the stdlib is stateful in how it triggers whether to strip sensitive headers since it's the one that owns the core loop. We have to walk back up the request in order to verify whether to strip or not. Arguably the same outcome but worth noting.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
