### PR TITLE
Fix: Balanced URI scorer now correctly tracks in-flight requests per URI

### DIFF
--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -35,7 +35,7 @@ type URIScoringMiddleware interface {
 }
 
 type balancedScorer struct {
-	uriInfos map[string]uriInfo
+	uriInfos map[string]*uriInfo
 }
 
 type uriInfo struct {
@@ -51,9 +51,9 @@ type uriInfo struct {
 // This implementation is based on Dialogue's BalancedScoreTracker:
 // https://github.com/palantir/dialogue/blob/develop/dialogue-core/src/main/java/com/palantir/dialogue/core/BalancedScoreTracker.java
 func NewBalancedURIScoringMiddleware(uris []string, nanoClock func() int64) URIScoringMiddleware {
-	uriInfos := make(map[string]uriInfo, len(uris))
+	uriInfos := make(map[string]*uriInfo, len(uris))
 	for _, uri := range uris {
-		uriInfos[uri] = uriInfo{
+		uriInfos[uri] = &uriInfo{
 			recentFailures: NewCourseExponentialDecayReservoir(nanoClock, failureMemory),
 		}
 	}

--- a/conjure-go-client/httpclient/internal/balanced_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer_test.go
@@ -17,9 +17,11 @@ package internal
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBalancedScorerRandomizesWithNoneInflight(t *testing.T) {
@@ -55,4 +57,74 @@ func TestBalancedScoring(t *testing.T) {
 	}
 	scoredUris := scorer.GetURIsInOrderOfIncreasingScore()
 	assert.Equal(t, []string{server200.URL, server429.URL, server503.URL}, scoredUris)
+}
+
+func TestBalancedScoringTracksInflightRequests(t *testing.T) {
+	const uri = "https://example.com"
+	scorer := NewBalancedURIScoringMiddleware([]string{uri}, func() int64 { return 0 }).(*balancedScorer)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	var once sync.Once
+	transport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		once.Do(func() {
+			close(started)
+		})
+		<-release
+		return &http.Response{
+			StatusCode: http.StatusOK,
+		}, nil
+	})
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	require.NoError(t, err)
+	go func() {
+		defer close(done)
+		_, _ = scorer.RoundTrip(req, transport)
+	}()
+	<-started
+
+	assert.Equal(t, int32(1), scorer.uriInfos[uri].computeScore())
+	close(release)
+	<-done
+	assert.Equal(t, int32(0), scorer.uriInfos[uri].computeScore())
+}
+
+// TestBalancedScoring_InflightRequestsAffectsScore asserts that an in-flight request against uriA
+// causes uriA to rank worse than an idle uriB. It should never rank equal to or ahead of an idle host.
+func TestBalancedScoring_InflightRequestsAffectsScore(t *testing.T) {
+	uriA := "https://a.example.com"
+	uriB := "https://b.example.com"
+	scorer := NewBalancedURIScoringMiddleware([]string{uriA, uriB}, func() int64 { return 0 })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	var once sync.Once
+	slowTransport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return &http.Response{
+			StatusCode: http.StatusOK,
+		}, nil
+	})
+
+	reqA, _ := http.NewRequest(http.MethodGet, uriA, nil)
+	go func() {
+		defer close(done)
+		_, _ = scorer.RoundTrip(reqA, slowTransport)
+	}()
+	<-started // wait until the request to uriA is actually in flight
+
+	order := scorer.GetURIsInOrderOfIncreasingScore()
+	assert.Equal(t, uriB, order[0], "expected idle uriB should rank ahead of the in-flight uriA")
+
+	close(release)
+	<-done
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/conjure-go-client/httpclient/internal/balanced_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer_test.go
@@ -102,7 +102,9 @@ func TestBalancedScoring_InflightRequestsAffectsScore(t *testing.T) {
 	done := make(chan struct{})
 	var once sync.Once
 	slowTransport := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-		once.Do(func() { close(started) })
+		once.Do(func() {
+			close(started)
+		})
 		<-release
 		return &http.Response{
 			StatusCode: http.StatusOK,


### PR DESCRIPTION
## Before this PR
`balancedScorer` stores per-URI state in a `map[string]uriInfo` (e.g. by value) and when `RoundTrip` reads an entry and incremented it's `inflight` counter the increment only mutated the copy of the value and not the actual value stored in the map. `computeScore()` always read the real unmutated entry so the in-flight component of the URIs score has always been zero. 2 URIs with identical failure history are treated as equally good candidates today regardless of how many requests are currently in-flight for each of them, which effectively disables a large portion of what the scorer was intended to do.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Balanced URI scorer now correctly tracks in-flight requests per URI
==COMMIT_MSG==

Host selection will now start respecting in-flight request counts in addition to recent failures.

The test `TestBalancedScoringTracksInflightRequests` asserts the actual value differences from an in-flight request for a single URI and the test `TestBalancedScoring_InflightRequestsAffectsScore` is a blackbox test which fails on develop and passes after this change. 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

