### PR TITLE
Fix: Fix balanced scoring for base URIs with paths

### DIFF
--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -171,7 +171,10 @@ func (c *clientImpl) doOnce(
 	transport := clientCopy.Transport // start with the client's transport configured with default middleware
 
 	// must precede the error decoders to read the status code of the raw response.
-	transport = wrapTransport(transport, c.uriScorer.CurrentURIScoringMiddleware())
+	uriScorer := c.uriScorer.CurrentURIScoringMiddleware()
+	transport = wrapTransport(transport, MiddlewareFunc(func(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+		return uriScorer.RoundTripForURI(baseURI, req, next)
+	}))
 	// request decoder must precede the client decoder
 	// must precede the body middleware to read the response body
 	transport = wrapTransport(transport, b.errorDecoderMiddleware, c.errorDecoderMiddleware)

--- a/conjure-go-client/httpclient/client_internal_test.go
+++ b/conjure-go-client/httpclient/client_internal_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientBalancedScoringAttributesBasePath(t *testing.T) {
+	healthyServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer healthyServer.Close()
+
+	requestPath := make(chan string, 1)
+	failingServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		requestPath <- req.URL.Path
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer failingServer.Close()
+
+	healthyURI := healthyServer.URL + "/healthy/base"
+	failingURI := failingServer.URL + "/failing/base"
+	httpClient, err := NewClient(WithBaseURLs([]string{healthyURI, failingURI}), WithNoProxy())
+	require.NoError(t, err)
+
+	client := httpClient.(*clientImpl)
+	_, _, err = client.doOnce(
+		t.Context(),
+		failingURI,
+		false,
+		WithRequestMethod(http.MethodGet),
+		WithPath("/rpc"),
+	)
+	require.Error(t, err)
+	assert.Equal(t, "/failing/base/rpc", <-requestPath)
+	assert.Equal(t,
+		[]string{healthyURI, failingURI},
+		client.uriScorer.CurrentURIScoringMiddleware().GetURIsInOrderOfIncreasingScore(),
+	)
+}

--- a/conjure-go-client/httpclient/internal/balanced_scorer.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
-	"net/url"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -31,7 +30,8 @@ const (
 
 type URIScoringMiddleware interface {
 	GetURIsInOrderOfIncreasingScore() []string
-	RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error)
+	// RoundTripForURI scores the request against baseURI, the configured URI selected for an attempt.
+	RoundTripForURI(baseURI string, req *http.Request, next http.RoundTripper) (*http.Response, error)
 }
 
 type balancedScorer struct {
@@ -77,8 +77,7 @@ func (u *balancedScorer) GetURIsInOrderOfIncreasingScore() []string {
 	return uris
 }
 
-func (u *balancedScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
-	baseURI := getBaseURI(req.URL)
+func (u *balancedScorer) RoundTripForURI(baseURI string, req *http.Request, next http.RoundTripper) (*http.Response, error) {
 	info, foundInfo := u.uriInfos[baseURI]
 	if foundInfo {
 		atomic.AddInt32(&info.inflight, 1)
@@ -104,16 +103,6 @@ func (u *balancedScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*
 
 func (i *uriInfo) computeScore() int32 {
 	return atomic.LoadInt32(&i.inflight) + int32(math.Round(i.recentFailures.Get()))
-}
-
-func getBaseURI(u *url.URL) string {
-	uCopy := url.URL{
-		Scheme: u.Scheme,
-		Opaque: u.Opaque,
-		User:   u.User,
-		Host:   u.Host,
-	}
-	return uCopy.String()
 }
 
 func isGlobalQosStatus(statusCode int) bool {

--- a/conjure-go-client/httpclient/internal/balanced_scorer_test.go
+++ b/conjure-go-client/httpclient/internal/balanced_scorer_test.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -51,7 +52,7 @@ func TestBalancedScoring(t *testing.T) {
 		for range 10 {
 			req, err := http.NewRequest("GET", server.URL, nil)
 			assert.NoError(t, err)
-			_, err = scorer.RoundTrip(req, server.Client().Transport)
+			_, err = scorer.RoundTripForURI(server.URL, req, server.Client().Transport)
 			assert.NoError(t, err)
 		}
 	}
@@ -59,8 +60,73 @@ func TestBalancedScoring(t *testing.T) {
 	assert.Equal(t, []string{server200.URL, server429.URL, server503.URL}, scoredUris)
 }
 
+func TestBalancedScoringAttributesBasePath(t *testing.T) {
+	const (
+		baseURI      = "https://example.test/server"
+		otherBaseURI = "https://example.test/other"
+	)
+	scorer := NewBalancedURIScoringMiddleware([]string{baseURI, otherBaseURI}, func() int64 { return 0 }).(*balancedScorer)
+	req, err := http.NewRequest(http.MethodGet, baseURI+"/data/store/transactions", nil)
+	require.NoError(t, err)
+
+	_, err = scorer.RoundTripForURI(baseURI, req, roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+		}, nil
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, int32(failureWeight), scorer.uriInfos[baseURI].computeScore())
+	assert.Zero(t, scorer.uriInfos[otherBaseURI].computeScore())
+}
+
+func TestBalancedScoringAttributesFailuresForURIForms(t *testing.T) {
+	transportErr := errors.New("transport failed")
+	for _, tc := range []struct {
+		name       string
+		uri        string
+		requestURL string
+		response   *http.Response
+		err        error
+	}{
+		{
+			name:       "pathless URI",
+			uri:        "https://example.test",
+			requestURL: "https://example.test/rpc",
+			response:   &http.Response{StatusCode: http.StatusServiceUnavailable},
+		},
+		{
+			name:       "trailing slash",
+			uri:        "https://example.test/",
+			requestURL: "https://example.test/rpc",
+			response:   &http.Response{StatusCode: http.StatusServiceUnavailable},
+		},
+		{
+			name:       "multiple path components with transport error",
+			uri:        "https://example.test/one/two",
+			requestURL: "https://example.test/one/two/rpc",
+			err:        transportErr,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scorer := NewBalancedURIScoringMiddleware([]string{tc.uri}, func() int64 { return 0 }).(*balancedScorer)
+			req, err := http.NewRequest(http.MethodGet, tc.requestURL, nil)
+			require.NoError(t, err)
+
+			_, err = scorer.RoundTripForURI(tc.uri, req, roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return tc.response, tc.err
+			}))
+			if tc.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.err)
+			}
+			assert.Equal(t, int32(failureWeight), scorer.uriInfos[tc.uri].computeScore())
+		})
+	}
+}
+
 func TestBalancedScoringTracksInflightRequests(t *testing.T) {
-	const uri = "https://example.com"
+	const uri = "https://example.com/base"
 	scorer := NewBalancedURIScoringMiddleware([]string{uri}, func() int64 { return 0 }).(*balancedScorer)
 
 	started := make(chan struct{})
@@ -76,11 +142,11 @@ func TestBalancedScoringTracksInflightRequests(t *testing.T) {
 			StatusCode: http.StatusOK,
 		}, nil
 	})
-	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	req, err := http.NewRequest(http.MethodGet, uri+"/rpc", nil)
 	require.NoError(t, err)
 	go func() {
 		defer close(done)
-		_, _ = scorer.RoundTrip(req, transport)
+		_, _ = scorer.RoundTripForURI(uri, req, transport)
 	}()
 	<-started
 
@@ -114,7 +180,7 @@ func TestBalancedScoring_InflightRequestsAffectsScore(t *testing.T) {
 	reqA, _ := http.NewRequest(http.MethodGet, uriA, nil)
 	go func() {
 		defer close(done)
-		_, _ = scorer.RoundTrip(reqA, slowTransport)
+		_, _ = scorer.RoundTripForURI(uriA, reqA, slowTransport)
 	}()
 	<-started // wait until the request to uriA is actually in flight
 

--- a/conjure-go-client/httpclient/internal/random_scorer.go
+++ b/conjure-go-client/httpclient/internal/random_scorer.go
@@ -33,7 +33,7 @@ func (n *randomScorer) GetURIsInOrderOfIncreasingScore() []string {
 	return uris
 }
 
-func (n *randomScorer) RoundTrip(req *http.Request, next http.RoundTripper) (*http.Response, error) {
+func (n *randomScorer) RoundTripForURI(baseURI string, req *http.Request, next http.RoundTripper) (*http.Response, error) {
 	return next.RoundTrip(req)
 }
 


### PR DESCRIPTION
## Before this PR
Balanced URI scoring derived the URI from the request URL, but this discards the path. Configured baseURIs containing paths did not match the scorer map entries so failures and in-flight requests were never recorded. Typically users configure their `install.server.context-path` in the `witchcraft-go-server` install config which inherently means the baseURIs contain paths and thus the scoring behavior seems broken for the majority of projects.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix balanced scoring for base URIs with paths
==COMMIT_MSG==

Now the selected baseURI is passed directly to the scorer (same value used as it's map keys) and path based URIs should now recieve load and failure scores while remaining distinct from other paths on the same base.

There are no public API changes here, but the `URIScoringMiddleware` no longer implements the `Middleware` interface and instead we provide a closure to pass the selected baseURI through for scoring.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

