### PR TITLE
Feature: Add StickySession support to pin requests to a single URI

### DIFF
--- a/conjure-go-client/httpclient/client.go
+++ b/conjure-go-client/httpclient/client.go
@@ -82,31 +82,45 @@ func (c *clientImpl) Delete(ctx context.Context, params ...RequestParam) (*http.
 }
 
 func (c *clientImpl) Do(ctx context.Context, params ...RequestParam) (*http.Response, error) {
-	uris := c.uriScorer.CurrentURIScoringMiddleware().GetURIsInOrderOfIncreasingScore()
+	uris, attempts := c.currentURIsAndMaxAttempts()
 	if len(uris) == 0 {
 		return nil, werror.WrapWithContextParams(ctx, ErrEmptyURIs, "", werror.SafeParam("serviceName", c.serviceName.Current()))
 	}
+	resp, _, err := c.doWithURIs(ctx, uris, attempts, params...)
+	return resp, err
+}
 
+func (c *clientImpl) currentURIsAndMaxAttempts() ([]string, int) {
+	uris := c.uriScorer.CurrentURIScoringMiddleware().GetURIsInOrderOfIncreasingScore()
 	attempts := 2 * len(uris)
 	if c.maxAttempts != nil {
 		if confMaxAttempts := c.maxAttempts.Current(); confMaxAttempts != nil {
 			attempts = *confMaxAttempts
 		}
 	}
+	return uris, attempts
+}
 
-	retrier := internal.NewRequestRetrier(uris, c.backoffOptions.Current().Start(ctx), attempts)
+// doWithURIs executes a request against the given URIs, retrying according to retrier policy up to maxAttempts times.
+// In addition to the response and error, it returns the URI that served a successful (2xx) response, or "" if the request did not succeed.
+func (c *clientImpl) doWithURIs(ctx context.Context, uris []string, maxAttempts int, params ...RequestParam) (*http.Response, string, error) {
+	retrier := internal.NewRequestRetrier(uris, c.backoffOptions.Current().Start(ctx), maxAttempts)
 	uri, isRelocated := retrier.GetNextURI(nil, nil)
 	for {
-		resp, retryable, err := c.doOnce(ctx, uri, isRelocated, params...)
+		attemptResp, retryable, attemptErr := c.doOnce(ctx, uri, isRelocated, params...)
 		if !retryable {
-			return resp, err
+			var succeededURI string
+			if attemptErr == nil && attemptResp != nil && attemptResp.StatusCode >= http.StatusOK && attemptResp.StatusCode < http.StatusMultipleChoices {
+				succeededURI = uri
+			}
+			return attemptResp, succeededURI, attemptErr
 		}
-		uri, isRelocated = retrier.GetNextURI(resp, err)
+		uri, isRelocated = retrier.GetNextURI(attemptResp, attemptErr)
 		if uri == "" {
-			return resp, err
+			return attemptResp, "", attemptErr
 		}
-		if err != nil {
-			svc1log.FromContext(ctx).Debug("Retrying request", svc1log.Stacktrace(err))
+		if attemptErr != nil {
+			svc1log.FromContext(ctx).Debug("Retrying request", svc1log.Stacktrace(attemptErr))
 		}
 	}
 }

--- a/conjure-go-client/httpclient/sticky_session.go
+++ b/conjure-go-client/httpclient/sticky_session.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"sync"
+
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+var (
+	// ErrStickySessionUnsupported is returned by NewStickySession when a Client does not support sticky sessions.
+	ErrStickySessionUnsupported = werror.Error("httpclient: client does not support sticky sessions")
+
+	// ErrStickyPinInvalidated is returned by a sticky session's methods once its pinned URI is no longer part of the current URI set.
+	// A sticky session never repins itself to a different URI. Once invalidated it fails every subsequent call, so callers should establish a
+	// new sticky session to continue.
+	ErrStickyPinInvalidated = werror.Error("httpclient: sticky session's pinned URI is no longer part of the client's URI set")
+)
+
+type stickySessionProvider interface {
+	newStickySession() (Client, error)
+}
+
+// NewStickySession returns a Client that pins every request it sends to a single URI for its entire
+// lifetime.
+//
+// The pin is established from the outcome of the session's first request. The first request is sent
+// through the Clients normal load-balanced, multi-attempt path, exactly like a non-sticky call, so it
+// benefits from the usual cross-host failover. If it succeeds (a 2xx response), the URI that served
+// it becomes the pin. Every call after that makes exactly one attempt against the pinned URI and it is
+// never retried and never fails over to a different URI.
+//
+// On each call after a pin is established, if the pinned URI was one of the client's configured URIs, it is
+// checked against the client's current URI set. If it is no longer present, the call fails immediately with
+// ErrStickyPinInvalidated rather than silently repinning.
+func NewStickySession(c Client) (Client, error) {
+	provider, ok := c.(stickySessionProvider)
+	if !ok {
+		return nil, ErrStickySessionUnsupported
+	}
+	return provider.newStickySession()
+}
+
+func (c *clientImpl) newStickySession() (Client, error) {
+	return &stickyClient{
+		parent: c,
+	}, nil
+}
+
+var _ Client = (*stickyClient)(nil)
+
+// stickyClient is the Client returned by NewStickySession.
+type stickyClient struct {
+	parent *clientImpl
+
+	mu        sync.Mutex
+	pinnedURI string // "" until a pin is established
+
+	// pinnedURIIsListed records whether pinnedURI was one of the client's configured URIs at the
+	// moment it was captured, as opposed to a URI reached only via a 307/308 redirect.
+	pinnedURIIsListed bool
+}
+
+func (s *stickyClient) Do(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	if p, ok := s.currentPin(); ok {
+		return s.doWithPin(ctx, p, params...)
+	}
+	return s.doAndMaybePin(ctx, params...)
+}
+
+type pin struct {
+	uri      string
+	isListed bool
+}
+
+func (s *stickyClient) currentPin() (pin, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return pin{
+		uri:      s.pinnedURI,
+		isListed: s.pinnedURIIsListed,
+	}, s.pinnedURI != ""
+}
+
+// doAndMaybePin sends the request through the parent's normal load-balanced path, since no pin exists
+// yet, and if it succeeds, establishes the pin as the URI that served the response. If another
+// concurrent call has already established a pin by the time this one succeeds, that earlier pin wins.
+func (s *stickyClient) doAndMaybePin(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	uris, attempts := s.parent.currentURIsAndMaxAttempts()
+	if len(uris) == 0 {
+		return nil, werror.WrapWithContextParams(ctx, ErrEmptyURIs, "", werror.SafeParam("serviceName", s.parent.serviceName.Current()))
+	}
+	resp, succeededURI, err := s.parent.doWithURIs(ctx, uris, attempts, params...)
+	if succeededURI != "" {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.pinnedURI == "" {
+			s.pinnedURI = succeededURI
+			s.pinnedURIIsListed = slices.Contains(uris, succeededURI)
+		}
+	}
+	return resp, err
+}
+
+// doWithPin makes exactly one attempt against the pinned URI. It never retries and never fails over
+// to a different URI, even on error.
+func (s *stickyClient) doWithPin(ctx context.Context, p pin, params ...RequestParam) (*http.Response, error) {
+	if p.isListed && !s.pinIsCurrent(p.uri) {
+		return nil, werror.WrapWithContextParams(ctx, ErrStickyPinInvalidated, "invalid URI for request",
+			werror.SafeParam("serviceName", s.parent.serviceName.Current()))
+	}
+	resp, _, err := s.parent.doWithURIs(ctx, []string{p.uri}, 1, params...)
+	return resp, err
+}
+
+func (s *stickyClient) pinIsCurrent(pinnedURI string) bool {
+	uris := s.parent.uriScorer.CurrentURIScoringMiddleware().GetURIsInOrderOfIncreasingScore()
+	return slices.Contains(uris, pinnedURI)
+}
+
+func (s *stickyClient) Get(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	return s.Do(ctx, append(params, WithRequestMethod(http.MethodGet))...)
+}
+
+func (s *stickyClient) Head(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	return s.Do(ctx, append(params, WithRequestMethod(http.MethodHead))...)
+}
+
+func (s *stickyClient) Post(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	return s.Do(ctx, append(params, WithRequestMethod(http.MethodPost))...)
+}
+
+func (s *stickyClient) Put(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	return s.Do(ctx, append(params, WithRequestMethod(http.MethodPut))...)
+}
+
+func (s *stickyClient) Delete(ctx context.Context, params ...RequestParam) (*http.Response, error) {
+	return s.Do(ctx, append(params, WithRequestMethod(http.MethodDelete))...)
+}

--- a/conjure-go-client/httpclient/sticky_session.go
+++ b/conjure-go-client/httpclient/sticky_session.go
@@ -38,10 +38,10 @@ type stickySessionProvider interface {
 }
 
 // NewStickySession returns a Client that pins every request it sends to a single URI for its entire
-// lifetime.
+// lifetime. Returns an ErrStickySessionUnsupported error if the provided Client does not support sticky sessions.
 //
 // The pin is established from the outcome of the session's first request. The first request is sent
-// through the Clients normal load-balanced, multi-attempt path, exactly like a non-sticky call, so it
+// through the Client's normal load-balanced, multi-attempt path, exactly like a non-sticky call, so it
 // benefits from the usual cross-host failover. If it succeeds (a 2xx response), the URI that served
 // it becomes the pin. Every call after that makes exactly one attempt against the pinned URI and it is
 // never retried and never fails over to a different URI.

--- a/conjure-go-client/httpclient/sticky_session_test.go
+++ b/conjure-go-client/httpclient/sticky_session_test.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
+	"github.com/palantir/pkg/refreshable/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStickySession_FirstRequestGetsFailover verifies that the first request on a sticky session
+// before any pin exists, gets the client's normal cross-host failover.
+func TestStickySession_FirstRequestGetsFailover(t *testing.T) {
+	var (
+		ctx      = t.Context()
+		badHits  atomic.Int32
+		goodHits atomic.Int32
+	)
+	bad := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		badHits.Add(1)
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer bad.Close()
+	good := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		goodHits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer good.Close()
+
+	client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{bad.URL, good.URL}))
+	require.NoError(t, err)
+	sticky, err := httpclient.NewStickySession(client)
+	require.NoError(t, err)
+
+	// bad/good requests are randomized on the first attempt, but a request to bad should always fail over to good.
+	_, err = sticky.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	badHitsAfterFirstCall := badHits.Load()
+	assert.LessOrEqual(t, badHitsAfterFirstCall, int32(1))
+	assert.Equal(t, int32(1), goodHits.Load())
+
+	// Once pinned, every subsequent call must land on the good server
+	for range 5 {
+		_, err = sticky.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
+		require.NoError(t, err)
+	}
+	assert.Equal(t, badHitsAfterFirstCall, badHits.Load())
+	assert.Equal(t, int32(6), goodHits.Load())
+}
+
+// TestStickySession_NoRetryOncePinned verifies that once a sticky session has a pin, a failing
+// request makes exactly one attempt with no retries.
+func TestStickySession_NoRetryOncePinned(t *testing.T) {
+	var hits atomic.Int32
+	pinned := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer pinned.Close()
+
+	client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{pinned.URL}))
+	require.NoError(t, err)
+	sticky, err := httpclient.NewStickySession(client)
+	require.NoError(t, err)
+
+	// First call succeeds, establishing the pin.
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), hits.Load())
+
+	// Now the pinned host starts failing.
+	pinned.Config.Handler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	})
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	assert.Error(t, err)
+	assert.Equal(t, int32(2), hits.Load())
+}
+
+// TestStickySession_PinnedURIRemovedFailsFast verifies that once a pinned URI is no longer part of
+// the client's current refreshable URI set, the session fails fast rather than silently repinning.
+func TestStickySession_PinnedURIRemovedFailsFast(t *testing.T) {
+	var hits atomic.Int32
+	s1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer s1.Close()
+	s2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer s2.Close()
+
+	uris := refreshable.New([]string{s1.URL})
+	client, err := httpclient.NewClientFromRefreshableConfig(
+		t.Context(),
+		refreshable.New(httpclient.ClientConfig{}),
+		httpclient.WithRefreshableBaseURLs(uris))
+	require.NoError(t, err)
+	sticky, err := httpclient.NewStickySession(client)
+	require.NoError(t, err)
+
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), hits.Load())
+
+	// Remove the pinned URI (s1) from the URI list.
+	uris.Update([]string{s2.URL})
+
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	assert.ErrorIs(t, err, httpclient.ErrStickyPinInvalidated)
+	assert.Equal(t, int32(1), hits.Load())
+}
+
+// TestStickySession_ConcurrentCallsConvergeOnSameHost verifies that once a sticky session is pinned,
+// many concurrent goroutines calling Do all land on the same host.
+func TestStickySession_ConcurrentCallsConvergeOnSameHost(t *testing.T) {
+	var (
+		ctx    = t.Context()
+		s1Hits atomic.Int32
+		s2Hits atomic.Int32
+	)
+	s1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		s1Hits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer s1.Close()
+	s2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		s2Hits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer s2.Close()
+
+	client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{s1.URL, s2.URL}))
+	require.NoError(t, err)
+	sticky, err := httpclient.NewStickySession(client)
+	require.NoError(t, err)
+
+	// Establish the pin with a single call before starting concurrent callers
+	_, err = sticky.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_, doErr := sticky.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
+			assert.NoError(t, doErr)
+		}()
+	}
+	wg.Wait()
+
+	total := s1Hits.Load() + s2Hits.Load()
+	assert.Equal(t, int32(n+1), total)
+	assert.True(t, s1Hits.Load() == 0 || s2Hits.Load() == 0, "all concurrent calls must land on the single pinned host")
+}
+
+// TestStickySession_SharedHealthState verifies that a sticky session maintains shared health scoring.
+// A failure observed through one session should always affect the ranking of a later one, since they share the same URI scorer.
+func TestStickySession_SharedHealthState(t *testing.T) {
+	var (
+		ctx              = t.Context()
+		firstRequestDone atomic.Bool
+		aHits, bHits     atomic.Int32
+		aFailed, bFailed atomic.Bool
+	)
+	fail := func(failed *atomic.Bool, rw http.ResponseWriter) {
+		if !firstRequestDone.Swap(true) {
+			failed.Store(true)
+			rw.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+	}
+	serverA := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		aHits.Add(1)
+		fail(&aFailed, rw)
+	}))
+	defer serverA.Close()
+	serverB := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		bHits.Add(1)
+		fail(&bFailed, rw)
+	}))
+	defer serverB.Close()
+
+	client, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{serverA.URL, serverB.URL}))
+	require.NoError(t, err)
+
+	// Whichever server the scorer sends this first request to fails and the client must fail over to the other server and succeed.
+	_, err = client.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	require.True(t, aFailed.Load() != bFailed.Load(), "exactly one server must have received the forced first failure")
+
+	badHits := &aHits
+	if bFailed.Load() {
+		badHits = &bHits
+	}
+	hitsBeforeSticky := badHits.Load()
+
+	// A fresh sticky session from the same client and the same scorer should avoid whichever server just failed.
+	sticky, err := httpclient.NewStickySession(client)
+	require.NoError(t, err)
+	_, err = sticky.Do(ctx, httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	assert.Equal(t, hitsBeforeSticky, badHits.Load(), "sticky session's first request should have avoided the host that just failed")
+}
+
+// TestStickySession_UnsupportedClientReturnsError verifies that NewStickySession fails when called
+// on a Client that isn't the concrete CGR defined [httpclient.Client].
+func TestStickySession_UnsupportedClientReturnsError(t *testing.T) {
+	s1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer s1.Close()
+	cli, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{s1.URL}))
+	require.NoError(t, err)
+
+	type passthroughClient struct {
+		httpclient.Client
+	}
+
+	decorator := &passthroughClient{Client: cli}
+	sticky, err := httpclient.NewStickySession(decorator)
+	assert.Nil(t, sticky)
+	assert.ErrorIs(t, err, httpclient.ErrStickySessionUnsupported)
+}
+
+// TestStickySession_RedirectNotFollowedOncePinned verifies that once a sticky session is pinned, a
+// 307/308 response from the pinned host is surfaced as a failure rather than followed.
+func TestStickySession_RedirectNotFollowedOncePinned(t *testing.T) {
+	var (
+		pinnedHits atomic.Int32
+		otherHits  atomic.Int32
+	)
+	other := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		otherHits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer other.Close()
+	pinned := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		pinnedHits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer pinned.Close()
+
+	cli, err := httpclient.NewClient(httpclient.WithBaseURLs([]string{pinned.URL}))
+	require.NoError(t, err)
+	sticky, err := httpclient.NewStickySession(cli)
+	require.NoError(t, err)
+
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), pinnedHits.Load())
+
+	// Now the pinned host starts issuing a redirect to other but because the session is pinned, this must never be followed.
+	pinned.Config.Handler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		pinnedHits.Add(1)
+		rw.Header().Set("Location", other.URL)
+		rw.WriteHeader(http.StatusPermanentRedirect)
+	})
+
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	assert.Error(t, err)
+	assert.Equal(t, int32(2), pinnedHits.Load())
+	assert.Equal(t, int32(0), otherHits.Load(), "redirect must never be followed once a session is pinned")
+}
+
+// TestStickySession_InFlightRequestFinishesAfterURIRemoval verifies that removing a session's pinned
+// URI from a refreshable URI list mid-flight does not disturb a request already in progress against it.
+func TestStickySession_InFlightRequestFinishesAfterURIRemoval(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var pinnedHits, newHits atomic.Int32
+
+	pinned := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		pinnedHits.Add(1)
+		close(requestStarted)
+		<-releaseRequest
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer pinned.Close()
+	replacement := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		newHits.Add(1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer replacement.Close()
+
+	uris := refreshable.New([]string{pinned.URL})
+	cli, err := httpclient.NewClientFromRefreshableConfig(t.Context(), refreshable.New(httpclient.ClientConfig{}),
+		httpclient.WithRefreshableBaseURLs(uris))
+	require.NoError(t, err)
+	sticky, err := httpclient.NewStickySession(cli)
+	require.NoError(t, err)
+
+	callErr := make(chan error, 1)
+	go func() {
+		_, doErr := sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+		callErr <- doErr
+	}()
+	<-requestStarted
+
+	// Remove the pinned URI while the request above is still in flight against it.
+	uris.Update([]string{replacement.URL})
+	close(releaseRequest)
+	require.NoError(t, <-callErr, "an in-flight request must be allowed to finish even if its URI is removed mid-flight")
+
+	// The next call observes the removal and fails fast, never touching the replacement
+	_, err = sticky.Do(t.Context(), httpclient.WithRequestMethod(http.MethodGet))
+	assert.ErrorIs(t, err, httpclient.ErrStickyPinInvalidated)
+	assert.Equal(t, int32(1), pinnedHits.Load())
+	assert.Equal(t, int32(0), newHits.Load())
+}


### PR DESCRIPTION
## Before this PR
CGR did not have a native way to pin requests to a single URI. Some transactional services require that all requests land on a single host for the duration of a transaction and this was not possible in CGR today without losing cross host scoring. Today every `Do` call scores the request response meaning multiple requests could land on different URIs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add StickySession support to pin requests to a single URI
==COMMIT_MSG==

The `NewStickySession` constructor returns a native `httpclient.Client` that is capable of pinning itself to a single URI for it's lifetime. The pin is established from the outcome of the first request which is still sent through the load-balanced flow that CGR uses for non-sticky clients. The difference now is that after a successful request, that host will remain pinned. Retries are explicitly disabled so only 1 attempt is ever made to the pinned URI. This includes transient blips that would self resolve, but callers are now expected to handle the retry mechanism a layer up.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

