### PR TITLE
Fix: Validate retryOther Location origin against configured URIs

### DIFF
--- a/conjure-go-client/httpclient/client_test.go
+++ b/conjure-go-client/httpclient/client_test.go
@@ -73,6 +73,10 @@ func TestCanUseRelocationURI(t *testing.T) {
 		case "/newPath":
 			rw.WriteHeader(200)
 			assert.NoError(t, codecs.JSON.Encode(rw, respBody))
+		default:
+			// Configured URIs are tried in a shuffled order, so this node may be tried
+			// first. Send the client on to the node which serves /oldPath.
+			rw.WriteHeader(503)
 		}
 	}))
 	defer relocationServer.Close()
@@ -88,7 +92,9 @@ func TestCanUseRelocationURI(t *testing.T) {
 
 	client, err := httpclient.NewClient(
 		httpclient.WithBytesBufferPool(bytesbuffers.NewSizedPool(1, 10)),
-		httpclient.WithBaseURLs([]string{server.URL}),
+		// Both nodes are configured, since a Location is only used when it names one of
+		// the client's configured origins.
+		httpclient.WithBaseURLs([]string{server.URL, relocationServer.URL}),
 	)
 	assert.NoError(t, err)
 

--- a/conjure-go-client/httpclient/failover_test.go
+++ b/conjure-go-client/httpclient/failover_test.go
@@ -142,21 +142,51 @@ func TestBackoffSingleURL(t *testing.T) {
 }
 
 func TestFailoverOtherURL(t *testing.T) {
-	didHitS1, didHitS2 := false, false
+	relocatedHits := 0
 
+	// s1 serves the relocated path, and sends the client elsewhere for anything else so
+	// that the request converges whichever configured URI is tried first.
+	s1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/relocated" {
+			relocatedHits++
+			rw.WriteHeader(http.StatusOK)
+			return
+		}
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	s2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header()["Location"] = []string{s1.URL + "/relocated"}
+		rw.WriteHeader(http.StatusPermanentRedirect)
+	}))
+
+	// s1 is configured alongside s2, so a Location naming it is used.
+	cli, err := NewClient(WithBaseURLs([]string{s2.URL, s1.URL}))
+	require.NoError(t, err)
+
+	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
+	assert.NoError(t, err)
+	assert.Positive(t, relocatedHits, "expected the client to follow the Location to the configured node")
+}
+
+func TestFailoverOtherURLNotConfigured(t *testing.T) {
+	didHitS1 := false
+	s2Hits, s3Hits := 0, 0
+
+	// s1 is deliberately absent from the client's configured URIs.
 	s1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		didHitS1 = true
 		rw.WriteHeader(http.StatusOK)
 	}))
 
 	s2 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		didHitS2 = true
+		s2Hits++
 		rw.Header()["Location"] = []string{s1.URL}
 		rw.WriteHeader(http.StatusPermanentRedirect)
 	}))
 
 	s3 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		didHitS2 = true
+		s3Hits++
 		rw.Header()["Location"] = []string{s1.URL}
 		rw.WriteHeader(http.StatusPermanentRedirect)
 	}))
@@ -164,10 +194,12 @@ func TestFailoverOtherURL(t *testing.T) {
 	cli, err := NewClient(WithBaseURLs([]string{s2.URL, s3.URL}))
 	require.NoError(t, err)
 
+	// The Location names a node outside the configured URIs, so it is not used. The client
+	// retries its configured nodes instead and exhausts its attempts there.
 	_, err = cli.Do(context.Background(), WithRequestMethod("GET"))
-	assert.NoError(t, err)
-	assert.True(t, didHitS2)
-	assert.True(t, didHitS1)
+	assert.Error(t, err)
+	assert.False(t, didHitS1, "should not send the request to a URI outside the configured set")
+	assert.Greater(t, s2Hits+s3Hits, 1, "expected the configured nodes to be retried")
 }
 
 func TestFailoverDistribution(t *testing.T) {

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -34,6 +34,7 @@ type RequestRetrier struct {
 	currentURI    string
 	retrier       retry.Retrier
 	uris          []string
+	hosts         map[string]struct{}
 	offset        int
 	relocatedURIs map[string]struct{}
 	failedURIs    map[string]struct{}
@@ -49,12 +50,41 @@ func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *R
 		currentURI:    uris[offset],
 		retrier:       retrier,
 		uris:          uris,
+		hosts:         configuredHosts(uris),
 		offset:        offset,
 		relocatedURIs: map[string]struct{}{},
 		failedURIs:    map[string]struct{}{},
 		maxAttempts:   maxAttempts,
 		attemptCount:  0,
 	}
+}
+
+// configuredHosts returns the set of hosts named by uris. URIs which do not parse, or which
+// name no host, are omitted. If no URI yields a host the result is empty, in which case
+// Location values are used without being checked against it.
+func configuredHosts(uris []string) map[string]struct{} {
+	hosts := make(map[string]struct{}, len(uris))
+	for _, uri := range uris {
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			continue
+		}
+		if host := parsed.Hostname(); host != "" {
+			hosts[host] = struct{}{}
+		}
+	}
+	return hosts
+}
+
+// isConfiguredHost reports whether otherURI names one of the hosts from the configured URIs.
+// A retryOther response directs the client to another node of the same service, so a Location
+// naming some other host does not describe a node this client is configured to use.
+func (r *RequestRetrier) isConfiguredHost(otherURI *url.URL) bool {
+	if len(r.hosts) == 0 {
+		return true
+	}
+	_, ok := r.hosts[otherURI.Hostname()]
+	return ok
 }
 
 func (r *RequestRetrier) attemptsRemaining() bool {
@@ -110,7 +140,9 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() b
 		return r.nextURIOrBackoff
 	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr, errCode); shouldTryOther {
 		// 307 or 308: go to next node, or particular node if provided.
-		if otherURI != nil {
+		// A Location naming a host outside the configured URIs is ignored and handled as
+		// though no Location had been provided.
+		if otherURI != nil && r.isConfiguredHost(otherURI) {
 			return func() bool {
 				r.setURIAndResetBackoff(otherURI)
 				return true

--- a/conjure-go-client/httpclient/internal/request_retrier.go
+++ b/conjure-go-client/httpclient/internal/request_retrier.go
@@ -34,7 +34,7 @@ type RequestRetrier struct {
 	currentURI    string
 	retrier       retry.Retrier
 	uris          []string
-	hosts         map[string]struct{}
+	origins       map[origin]struct{}
 	offset        int
 	relocatedURIs map[string]struct{}
 	failedURIs    map[string]struct{}
@@ -50,7 +50,7 @@ func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *R
 		currentURI:    uris[offset],
 		retrier:       retrier,
 		uris:          uris,
-		hosts:         configuredHosts(uris),
+		origins:       configuredOrigins(uris),
 		offset:        offset,
 		relocatedURIs: map[string]struct{}{},
 		failedURIs:    map[string]struct{}{},
@@ -59,31 +59,73 @@ func NewRequestRetrier(uris []string, retrier retry.Retrier, maxAttempts int) *R
 	}
 }
 
-// configuredHosts returns the set of hosts named by uris. URIs which do not parse, or which
-// name no host, are omitted. If no URI yields a host the result is empty, in which case
-// Location values are used without being checked against it.
-func configuredHosts(uris []string) map[string]struct{} {
-	hosts := make(map[string]struct{}, len(uris))
+// origin identifies a node by the parts of a URI which determine where a request is sent.
+// The path plays no part in identifying the node.
+type origin struct {
+	scheme string
+	host   string
+	port   string
+}
+
+// originOf derives the origin of uri. ok is false when uri names no host, or names no port
+// and no default port is known for its scheme, in which case uri can not be compared against
+// the configured origins.
+func originOf(uri *url.URL) (o origin, ok bool) {
+	host := uri.Hostname()
+	if host == "" {
+		return origin{}, false
+	}
+	scheme := strings.ToLower(uri.Scheme)
+	port := uri.Port()
+	if port == "" {
+		port = defaultPortForScheme(scheme)
+	}
+	if port == "" {
+		return origin{}, false
+	}
+	return origin{scheme: scheme, host: host, port: port}, true
+}
+
+// defaultPortForScheme returns the port a URI of the given scheme uses when it names none,
+// or the empty string when no default is known.
+func defaultPortForScheme(scheme string) string {
+	switch scheme {
+	case "http", meshSchemePrefix + "http":
+		return "80"
+	case "https", meshSchemePrefix + "https":
+		return "443"
+	default:
+		return ""
+	}
+}
+
+// configuredOrigins returns the set of origins named by uris. URIs which do not parse, or
+// which have no derivable origin, are omitted.
+func configuredOrigins(uris []string) map[origin]struct{} {
+	origins := make(map[origin]struct{}, len(uris))
 	for _, uri := range uris {
 		parsed, err := url.Parse(uri)
 		if err != nil {
 			continue
 		}
-		if host := parsed.Hostname(); host != "" {
-			hosts[host] = struct{}{}
+		if o, ok := originOf(parsed); ok {
+			origins[o] = struct{}{}
 		}
 	}
-	return hosts
+	return origins
 }
 
-// isConfiguredHost reports whether otherURI names one of the hosts from the configured URIs.
-// A retryOther response directs the client to another node of the same service, so a Location
-// naming some other host does not describe a node this client is configured to use.
-func (r *RequestRetrier) isConfiguredHost(otherURI *url.URL) bool {
-	if len(r.hosts) == 0 {
-		return true
+// isConfiguredOrigin reports whether otherURI names one of the origins from the configured
+// URIs. A retryOther response directs the client to another node of the same service, so a
+// Location outside those origins does not describe a node this client is configured to use.
+// A Location with no derivable origin is not used, nor is any Location when the configured
+// URIs yield no origins to compare against.
+func (r *RequestRetrier) isConfiguredOrigin(otherURI *url.URL) bool {
+	o, ok := originOf(otherURI)
+	if !ok {
+		return false
 	}
-	_, ok := r.hosts[otherURI.Hostname()]
+	_, ok = r.origins[o]
 	return ok
 }
 
@@ -140,9 +182,9 @@ func (r *RequestRetrier) getRetryFn(resp *http.Response, respErr error) func() b
 		return r.nextURIOrBackoff
 	} else if shouldTryOther, otherURI := isRetryOtherResponse(resp, respErr, errCode); shouldTryOther {
 		// 307 or 308: go to next node, or particular node if provided.
-		// A Location naming a host outside the configured URIs is ignored and handled as
-		// though no Location had been provided.
-		if otherURI != nil && r.isConfiguredHost(otherURI) {
+		// A Location outside the configured origins is ignored and handled as though no
+		// Location had been provided.
+		if otherURI != nil && r.isConfiguredOrigin(otherURI) {
 			return func() bool {
 				r.setURIAndResetBackoff(otherURI)
 				return true

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -103,9 +103,9 @@ func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 		Header:     http.Header{"Location": []string{"http://example.com"}},
 	}
 
-	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 2)
+	r := NewRequestRetrier([]string{"http://example.com"}, retry.Start(context.Background()), 2)
 	uri, isRelocated := r.GetNextURI(nil, nil)
-	require.Equal(t, uri, "a")
+	require.Equal(t, uri, "http://example.com")
 	require.False(t, isRelocated)
 
 	uri, isRelocated = r.GetNextURI(respWithLocationHeader, nil)
@@ -114,7 +114,7 @@ func TestRequestRetrier_UsesLocationHeader(t *testing.T) {
 }
 
 func TestRequestRetrier_UsesLocationFromErr(t *testing.T) {
-	r := NewRequestRetrier([]string{"http://example-1.com"}, retry.Start(context.Background()), 2)
+	r := NewRequestRetrier([]string{"http://example-1.com", "http://example-2.com"}, retry.Start(context.Background()), 2)
 	respErr := werror.ErrorWithContextParams(context.Background(), "307",
 		werror.SafeParam("statusCode", 307),
 		werror.SafeParam("location", "http://example-2.com"))
@@ -125,6 +125,40 @@ func TestRequestRetrier_UsesLocationFromErr(t *testing.T) {
 
 	uri, isRelocated = r.GetNextURI(nil, respErr)
 	require.Equal(t, uri, "http://example-2.com")
+	require.True(t, isRelocated)
+}
+
+func TestRequestRetrier_DoesNotRelocateToUnconfiguredHost(t *testing.T) {
+	r := NewRequestRetrier([]string{"http://example-1.com", "http://example-2.com"}, retry.Start(context.Background()), 3)
+
+	uri, isRelocated := r.GetNextURI(nil, nil)
+	require.Equal(t, uri, "http://example-1.com")
+	require.False(t, isRelocated)
+
+	respErr := werror.ErrorWithContextParams(context.Background(), "308",
+		werror.SafeParam("statusCode", StatusCodeRetryOther),
+		werror.SafeParam("location", "http://example-3.com/api/resource"))
+
+	// A location naming a host outside the configured URIs is treated the same as a
+	// retryOther response with no location at all: fall through to the next configured URI.
+	uri, isRelocated = r.GetNextURI(nil, respErr)
+	require.Equal(t, uri, "http://example-2.com")
+	require.False(t, isRelocated)
+}
+
+func TestRequestRetrier_SkipsLocationValidationWhenNoConfiguredHostsParse(t *testing.T) {
+	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 3)
+
+	uri, isRelocated := r.GetNextURI(nil, nil)
+	require.Equal(t, uri, "a")
+	require.False(t, isRelocated)
+
+	respWithLocationHeader := &http.Response{
+		StatusCode: StatusCodeRetryOther,
+		Header:     http.Header{"Location": []string{"http://example.com"}},
+	}
+	uri, isRelocated = r.GetNextURI(respWithLocationHeader, nil)
+	require.Equal(t, uri, "http://example.com")
 	require.True(t, isRelocated)
 }
 

--- a/conjure-go-client/httpclient/internal/request_retrier_test.go
+++ b/conjure-go-client/httpclient/internal/request_retrier_test.go
@@ -146,7 +146,57 @@ func TestRequestRetrier_DoesNotRelocateToUnconfiguredHost(t *testing.T) {
 	require.False(t, isRelocated)
 }
 
-func TestRequestRetrier_SkipsLocationValidationWhenNoConfiguredHostsParse(t *testing.T) {
+func TestRequestRetrier_DoesNotRelocateToUnconfiguredPort(t *testing.T) {
+	r := NewRequestRetrier([]string{"http://127.0.0.1:8080"}, retry.Start(context.Background()), 3)
+
+	uri, isRelocated := r.GetNextURI(nil, nil)
+	require.Equal(t, uri, "http://127.0.0.1:8080")
+	require.False(t, isRelocated)
+
+	respWithLocationHeader := &http.Response{
+		StatusCode: StatusCodeRetryOther,
+		Header:     http.Header{"Location": []string{"http://127.0.0.1:9090"}},
+	}
+	uri, isRelocated = r.GetNextURI(respWithLocationHeader, nil)
+	require.Equal(t, uri, "http://127.0.0.1:8080")
+	require.False(t, isRelocated)
+}
+
+func TestRequestRetrier_DoesNotRelocateToUnconfiguredScheme(t *testing.T) {
+	r := NewRequestRetrier([]string{"https://example.com"}, retry.Start(context.Background()), 3)
+
+	uri, isRelocated := r.GetNextURI(nil, nil)
+	require.Equal(t, uri, "https://example.com")
+	require.False(t, isRelocated)
+
+	respWithLocationHeader := &http.Response{
+		StatusCode: StatusCodeRetryOther,
+		Header:     http.Header{"Location": []string{"http://example.com"}},
+	}
+	uri, isRelocated = r.GetNextURI(respWithLocationHeader, nil)
+	require.Equal(t, uri, "https://example.com")
+	require.False(t, isRelocated)
+}
+
+func TestRequestRetrier_RelocatesWhenOnlyThePathDiffers(t *testing.T) {
+	// An omitted port is equivalent to the default for the scheme, and the path plays no
+	// part in identifying the node.
+	r := NewRequestRetrier([]string{"https://example.com:443"}, retry.Start(context.Background()), 3)
+
+	uri, isRelocated := r.GetNextURI(nil, nil)
+	require.Equal(t, uri, "https://example.com:443")
+	require.False(t, isRelocated)
+
+	respWithLocationHeader := &http.Response{
+		StatusCode: StatusCodeRetryOther,
+		Header:     http.Header{"Location": []string{"https://example.com/api/resource"}},
+	}
+	uri, isRelocated = r.GetNextURI(respWithLocationHeader, nil)
+	require.Equal(t, uri, "https://example.com/api/resource")
+	require.True(t, isRelocated)
+}
+
+func TestRequestRetrier_DoesNotRelocateWhenNoConfiguredOriginParses(t *testing.T) {
 	r := NewRequestRetrier([]string{"a"}, retry.Start(context.Background()), 3)
 
 	uri, isRelocated := r.GetNextURI(nil, nil)
@@ -158,8 +208,8 @@ func TestRequestRetrier_SkipsLocationValidationWhenNoConfiguredHostsParse(t *tes
 		Header:     http.Header{"Location": []string{"http://example.com"}},
 	}
 	uri, isRelocated = r.GetNextURI(respWithLocationHeader, nil)
-	require.Equal(t, uri, "http://example.com")
-	require.True(t, isRelocated)
+	require.Equal(t, uri, "a")
+	require.False(t, isRelocated)
 }
 
 func TestRequestRetrier_GetNextURI(t *testing.T) {

--- a/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
+++ b/conjure-go-client/httpclient/response_error_decoder_middleware_test.go
@@ -70,13 +70,22 @@ func TestErrorDecoderMiddlewares(t *testing.T) {
 			},
 		},
 		{
-			name: "307 with location",
+			name: "307 with location on another host",
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Location", "https://google.com")
+				w.Header().Set("Location", "https://example.com")
 				w.WriteHeader(307)
 			},
 			verify: func(t *testing.T, u *url.URL, err error) {
-				assert.NoError(t, err)
+				// The location names a host which is not one of the client's configured
+				// URIs, so the request is not relocated to it. The location is still
+				// reported on the returned error.
+				assert.EqualError(t, err, "httpclient request failed: 307 Temporary Redirect")
+				code, ok := httpclient.StatusCodeFromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, 307, code)
+				location, ok := httpclient.LocationFromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, "https://example.com", location)
 			},
 		},
 		{


### PR DESCRIPTION
## Before this PR
A retryOther response (307 or 308) tells the client to retry against another node
of the same service, with the target given in the `Location` header.
`RequestRetrier` adopted that value as the next request URI without checking it, so
a `Location` naming any host, port or scheme moved the request off the URIs the
client was configured with.

Dialogue already treats this as worth checking: `RetryOtherValidatingChannel`
parses the host out of the `Location` and reports it when it is not one of the
configured hosts. Dialogue also builds one channel per configured URI, so it cannot
route to a node outside that set. The Go client has no equivalent check and does
set `currentURI` to the supplied value.

## After this PR
==COMMIT_MSG==
`RequestRetrier` only adopts a retryOther `Location` whose origin (scheme, host and
port) is among the client's configured URIs. Any other `Location` is handled as
though none had been provided, so the client retries the next configured node.
==COMMIT_MSG==

The origins of the configured URIs are recorded when the retrier is created, with an
omitted port defaulted from the scheme. When a `Location` fails the check the retrier
falls through to `nextURIOrBackoff`, which is the existing, already-tested path for a
retryOther response that carries no `Location` at all.

The check is fail-closed: a `Location` whose origin cannot be derived, and any
`Location` at all when the configured URIs yield no origins, are not used.

## Possible downsides?
This is a behavior change for any deployment relying on retryOther moving a request
to a node outside the client's configured URIs. Per the QoS contract retryOther names
"the given node of this service", so that node should already be in
`ClientConfiguration#uris`; a deployment doing otherwise would need to add it.

Tests which asserted the previous behavior are updated:

- `TestFailoverOtherURL` and `TestCanUseRelocationURI` both relocated to a URI outside
  the configured set. They now configure the node they relocate to, and the new
  `TestFailoverOtherURLNotConfigured` covers a `Location` naming a node which is not
  configured.
- `TestRequestRetrier_UsesLocationFromErr` now configures the URI it relocates to.
- `TestErrorDecoderMiddlewares/307 with location` asserted that a `Location` of
  `https://google.com` was followed successfully, which also made a live request to
  google.com on every test run. It now uses `example.com` and asserts the request is
  not relocated, removing the network dependency.
